### PR TITLE
Added media viewer setting for autoloading Prev & Next Pdf pages

### DIFF
--- a/projects/viewers/src/ds/ui/media/media_player.cpp
+++ b/projects/viewers/src/ds/ui/media/media_player.cpp
@@ -252,7 +252,7 @@ void MediaPlayer::initialize(){
 		contentHeight = mStreamPlayer->getHeight();
 
 	} else if(mediaType == ds::Resource::PDF_TYPE){
-		mPDFPlayer = new PDFPlayer(mEngine, mEmbedInterface);
+		mPDFPlayer = new PDFPlayer(mEngine, mEmbedInterface, mMediaViewerSettings.mPdfCacheNextPrev);
 		addChildPtr(mPDFPlayer);
 
 		mPDFPlayer->setShowInterfaceAtStart(mMediaViewerSettings.mShowInterfaceAtStart);

--- a/projects/viewers/src/ds/ui/media/media_viewer_settings.h
+++ b/projects/viewers/src/ds/ui/media/media_viewer_settings.h
@@ -24,6 +24,7 @@ struct MediaViewerSettings {
 		, mWebAllowKeyboard(true)
 		, mWebAllowTouchToggle(true)
 		, mCacheImages(false)
+		, mPdfCacheNextPrev(true)
 		, mVideoPanning(0.0f)
 		, mVideoAutoSync(true)
 		, mVideoAutoPlayFirstFrame(true)
@@ -55,6 +56,11 @@ struct MediaViewerSettings {
 
 	/// whether to cache the primary and thumb images. Default = false
 	bool						mCacheImages;
+
+	//--------------------PDF Settings ---------------------------------------------//
+
+	/// whether to auto cache the next/previous pdf page. default = true
+	bool						mPdfCacheNextPrev;
 
 	//--------------------Video Settings -------------------------------------------//
 

--- a/projects/viewers/src/ds/ui/media/player/pdf_player.cpp
+++ b/projects/viewers/src/ds/ui/media/player/pdf_player.cpp
@@ -15,7 +15,7 @@
 namespace ds {
 namespace ui {
 
-PDFPlayer::PDFPlayer(ds::ui::SpriteEngine& eng, bool embedInterface)
+PDFPlayer::PDFPlayer(ds::ui::SpriteEngine& eng, bool embedInterface, bool cachePrevNext)
 	: ds::ui::Sprite(eng)
 	, mPDF(nullptr)
 	, mPdfInterface(nullptr)
@@ -24,6 +24,7 @@ PDFPlayer::PDFPlayer(ds::ui::SpriteEngine& eng, bool embedInterface)
 	, mPDFThumbHolder(nullptr)
 	, mEmbedInterface(embedInterface)
 	, mShowInterfaceAtStart(true)
+	, mAutoCachePrevNext(cachePrevNext)
 	, mCurrentPage(-1)
 	, mNextReady(false)
 	, mPrevReady(false)
@@ -92,7 +93,7 @@ void PDFPlayer::setResource(const ds::Resource mediaResource){
 	// This loads 2 additional PDF sprites, one for the next page, and one for the previous page
 	// The scale of the PDF stays at 0.5 (because of the thumb holder), so the quality is less than the proper PDF
 	// When the page gets changed, and the next or previous PDFs are loaded, they're shown until the primary PDF finishes rendering
-	if(mPDFThumbHolder && mPDF->getPageCount() > 1){
+	if(mPDFThumbHolder && mPDF->getPageCount() > 1 && mAutoCachePrevNext){
 		mPDFNext = new ds::ui::Pdf(mEngine);
 
 		//Next and prev pdf starts loading after the first proper page has finished, for speed

--- a/projects/viewers/src/ds/ui/media/player/pdf_player.h
+++ b/projects/viewers/src/ds/ui/media/player/pdf_player.h
@@ -19,7 +19,7 @@ class PDFInterface;
 */
 class PDFPlayer : public ds::ui::Sprite  {
 public:
-	PDFPlayer(ds::ui::SpriteEngine& eng, bool embedInterface = true);
+	PDFPlayer(ds::ui::SpriteEngine& eng, bool embedInterface = true, bool cachePrevNext = true);
 
 	void								setMedia(const std::string mediaPath);
 	void								setResource(const ds::Resource mediaResource);
@@ -58,6 +58,7 @@ protected:
 	PDFInterface*								mPdfInterface;
 	bool										mEmbedInterface;
 	bool										mShowInterfaceAtStart;
+	bool										mAutoCachePrevNext;
 	std::function<void(void)>					mGoodStatusCallback;
 	std::function<void(const std::string&)>		mErrorMsgCallback;
 


### PR DESCRIPTION
Adds option to disable the automatic caching/loading of previous and next pdf pages. Useful for preventing issues when viewing PDF's in client server mode.