### PR TITLE
Content query: Don't crash if child-parent relationship not configured

### DIFF
--- a/src/ds/content/content_model.cpp
+++ b/src/ds/content/content_model.cpp
@@ -610,7 +610,7 @@ void ContentModelRef::printTree(const bool verbose, const std::string& indent) {
 
 			for(auto it : mData->mProperties) {
 				if(!it.second.getResource().empty()) {
-					DS_LOG_INFO(indent << "          resource:" << it.second.getResource().getAbsoluteFilePath());
+					DS_LOG_INFO(indent << "          resource:" << it.first << " value:" << it.second.getResource().getAbsoluteFilePath());
 				} else {
 					DS_LOG_INFO(indent << "          prop:" << it.first << " value:" << it.second.getValue());
 				}

--- a/src/ds/content/content_query.cpp
+++ b/src/ds/content/content_query.cpp
@@ -162,6 +162,11 @@ void ContentQuery::assembleModels(ds::model::ContentModelRef tablesParent) {
 						// Nothing to do here!
 						continue;
 					}
+				} else {
+					DS_LOG_WARNING("ContentQuery::assembleModels() child table model has no parent-child relationship configuration.\n"
+						<< "  Must use one of: [child_local_id, parent_foreign_id, child_local_map].\n"
+						<< "  Table name: "  << it.getName() );
+					continue;
 				}
 
 				for (auto row : it.getChildren()) {


### PR DESCRIPTION
    * Also improve printTree output to show names of resource properties