### PR TITLE
Fix floating-point letterspacing configuration for Text sprites

### DIFF
--- a/src/ds/ui/sprite/text.cpp
+++ b/src/ds/ui/sprite/text.cpp
@@ -649,7 +649,7 @@ bool Text::measurePangoText() {
 				}
 
 				// Set letter spacing: 0.0f=normal; 1.0f = 1pt extra spacing;
-				pango_attr_list_insert(attrs, pango_attr_letter_spacing_new((int)(mLetterSpacing) * PANGO_SCALE));
+				pango_attr_list_insert(attrs, pango_attr_letter_spacing_new((int)(mLetterSpacing * PANGO_SCALE)));
 
 				// Enable ligatures, kerning, and auto-conversion of simple fractions to a single character representation
 				//pango_attr_list_insert(attrs, pango_attr_font_features_new("liga=1, -kern, afrc on, frac on"));


### PR DESCRIPTION
    * Without this fix, the Text sprite letter-spacing setting only works with integer values