### PR TITLE
[B] Correct contentProperty comparison for resources

### DIFF
--- a/src/ds/content/content_model.cpp
+++ b/src/ds/content/content_model.cpp
@@ -124,7 +124,12 @@ void ContentProperty::setResource(const ds::Resource& resource) {
 }
 
 bool ContentProperty::operator==(const ContentProperty& b) const {
-	return mName == b.mName && mValue == b.mValue && mResource == b.mResource;
+	// If both resource shared pointers == null, match
+	// If neither are null, do a full resource compare
+	bool resourcesComparable = (mResource.get() != nullptr && b.mResource.get() != nullptr);
+	bool sameResource = (mResource.get() == b.mResource.get()) || (resourcesComparable && (*mResource == *b.mResource));
+
+	return mName == b.mName && mValue == b.mValue && sameResource;
 }
 
 bool ContentProperty::getBool() const {


### PR DESCRIPTION
Previously it was only comparing the pointer values for resources, and not doing a full equality compare on their contents.