### PR TITLE
Refactor line distance calculation to handle tween values when animating

### DIFF
--- a/projects/essentials/src/ds/ui/sprite/line.cpp
+++ b/projects/essentials/src/ds/ui/sprite/line.cpp
@@ -250,11 +250,20 @@ void LineSprite::buildVbo() {
 
 	// first, add an adjacency vertex at the beginning
 	vertices.push_back(ci::vec4(2.0f * ci::vec3(localPoints[0], 0) - ci::vec3(localPoints[1], 0), 0));
+	// find the total length of the line for vec4 calculations
+	float totalLength = 0.f;
+	for (size_t i = 1; i < localPoints.size(); i++) {
+		totalLength += glm::distance(localPoints[i-1], localPoints[i]);
+	}
 	// next, add all 2D points as 3D vertices
-	float index = 0.0f;
-	for (const auto& p : localPoints) {
-		vertices.push_back(ci::vec4(p, 0, index / (float)localPoints.size()));
-		index += 1.0f;
+	float currentLength = 0.f;
+	bool first = true;
+	ci::vec2 prevP;
+	for (size_t i = 0; i < localPoints.size(); i++) {
+		const ci::vec2& p = localPoints[i];
+		if (i != 0) currentLength += glm::distance(p, prevP);
+		prevP = p;
+		vertices.push_back(ci::vec4(p, 0, currentLength / totalLength));
 	}
 
 	// next, add an adjacency vertex at the end

--- a/projects/essentials/src/ds/ui/sprite/line.cpp
+++ b/projects/essentials/src/ds/ui/sprite/line.cpp
@@ -257,7 +257,6 @@ void LineSprite::buildVbo() {
 	}
 	// next, add all 2D points as 3D vertices
 	float currentLength = 0.f;
-	bool first = true;
 	ci::vec2 prevP;
 	for (size_t i = 0; i < localPoints.size(); i++) {
 		const ci::vec2& p = localPoints[i];


### PR DESCRIPTION
# Contribution

Before, the line would calculate its distance as a function of its number of points. Since there's no guarantee that those points will be evenly distanced from each other, that meant animating the line by setting the end percentage would draw the line at variable speeds, making it speed up and slow down even with linear timing. This change makes the line consider it's total distance instead, making animations tween as expected.

The downside is that it adds an extra loop and distance calculations, which may affect performance. But I believe it's worth it to enable sensible tweening for line-drawing effects.

# Test

I've tested this PR with the boise state world museum repository, the only other project that uses the line sprite directly (as far as Luke or I could find), and it works!