### PR TITLE
Make Line Sprite extendable so we can overwrite its shaders

### DIFF
--- a/projects/essentials/src/ds/ui/sprite/line.cpp
+++ b/projects/essentials/src/ds/ui/sprite/line.cpp
@@ -170,13 +170,7 @@ LineSprite::LineSprite(ds::ui::SpriteEngine& eng, const std::vector<ci::vec2>& p
   , mLineWidth(1.0f)
   , mMiterLimit(0.5f)
   , mSmoothSpline(false) {
-	// Load shaders
-	try {
-		mShader = ci::gl::GlslProg::create(lineVert, lineFrag, lineGeom);
-	} catch (const std::exception& e) {
-		DS_LOG_ERROR("Could not compile shader for LineSprite! Error: " << e.what());
-		return;
-	}
+
 
 	mBlobType = BLOB_TYPE;
 	setTransparent(false);
@@ -290,9 +284,25 @@ void LineSprite::buildVbo() {
 	mVboMesh->bufferIndices(indices.size() * sizeof(uint16_t), indices.data());
 }
 
+void LineSprite::loadShaders() {
+	try {
+		mShader = ci::gl::GlslProg::create(lineVert, lineFrag, lineGeom);
+	}
+	catch (const std::exception& e) {
+		DS_LOG_ERROR("Could not compile shader for LineSprite! Error: " << e.what());
+		return;
+	}
+}
+
 void LineSprite::buildRenderBatch() {
 	if (!mNeedsBatchUpdate) return;
 	mNeedsBatchUpdate = false;
+
+	// Load shaders
+	if (!mShader) {
+		loadShaders();
+	}
+
 
 	if ((mSmoothSpline && mPoints.size() > 2) || (!mSmoothSpline && mPoints.size() > 1)) {
 		buildVbo();

--- a/projects/essentials/src/ds/ui/sprite/line.h
+++ b/projects/essentials/src/ds/ui/sprite/line.h
@@ -23,7 +23,7 @@ namespace ui {
 	- Sprites can be animated using the SpriteAnimatable functions to gracefully change size, position, opacity, scale,
  color, and rotation.
 	- Sprites can clip their children along their bounds using setClipping(true)	 */
-class LineSprite final : public ds::ui::Sprite {
+class LineSprite : public ds::ui::Sprite {
   public:
 	LineSprite(ds::ui::SpriteEngine& eng, const std::vector<ci::vec2>& points = std::vector<ci::vec2>());
 
@@ -76,8 +76,11 @@ class LineSprite final : public ds::ui::Sprite {
 	virtual void readAttributeFrom(const char attributeId, ds::DataBuffer&);
 	virtual void buildRenderBatch();
 	virtual void onBuildRenderBatch();
+	virtual void loadShaders();
 
 	virtual bool getInnerHit(const ci::vec3& pos) const;
+
+	ci::gl::GlslProgRef mShader;
 
   private:
 	void buildVbo();
@@ -89,8 +92,6 @@ class LineSprite final : public ds::ui::Sprite {
 
 	ci::gl::BatchRef	  mBatch;
 	std::vector<ci::vec2> mPoints;
-
-	ci::gl::GlslProgRef mShader;
 	ci::gl::VboMeshRef  mVboMesh;
 };
 


### PR DESCRIPTION
# Contribution

I ran into a use case where I wanted to overwrite the line sprite's shaders to add a gradient color effect. While collaborating with Luke, we thought the best approach was to abstract the shader creation to its own virtual method, then extend the class and overwrite that method with the new shaders. There should be no difference with how the line sprite works otherwise.

I also tested this on the Boise State World Museum app, and the lines look good!