### PR TITLE
Replace setting variables and expressions after variable map is created

### DIFF
--- a/src/ds/cfg/settings.cpp
+++ b/src/ds/cfg/settings.cpp
@@ -487,5 +487,16 @@ void Settings::printAllSettings(){
 	
 }
 
+void Settings::replaceSettingVariablesAndExpressions() {
+	for (auto& it : mSettings) {
+		auto& theVec = it.second;
+		for (auto& theSetting : theVec) {
+			std::string value = ds::cfg::SettingsVariables::replaceVariables(theSetting.mRawValue);
+			value = ds::cfg::SettingsVariables::parseAllExpressions(value);
+			theSetting.mRawValue = value;
+		}
+	}
+}
+
 } // namespace cfg
 } // namespace ds

--- a/src/ds/cfg/settings.h
+++ b/src/ds/cfg/settings.h
@@ -215,6 +215,8 @@ public:
 	/// This vector may change at any time, so careful here
 	std::vector<Setting>&				getReadSortedSettings();
 
+	/// Goes through each setting to replace variables and parse expressions
+	void								replaceSettingVariablesAndExpressions();
 
 	class SettingsEditedEvent : public ds::RegisteredEvent<SettingsEditedEvent> {
 	public:

--- a/src/ds/cfg/settings_variables.cpp
+++ b/src/ds/cfg/settings_variables.cpp
@@ -27,6 +27,7 @@ public:
 			e.getAppSettings().forEachSetting([](const ds::cfg::Settings::Setting& theSetting) {
 				ds::cfg::SettingsVariables::addVariable(theSetting.mName, theSetting.mRawValue);
 			});
+			e.getAppSettings().replaceSettingVariablesAndExpressions();
 		});
 	}
 	void doNothing() {}


### PR DESCRIPTION
Previously. calling a setting in app via mEngine.getAppSettings() would not work correctly if the value contained an expression.

I'm not sure if this the best place to go through and replace variables and expressions, but I currently have it going through all the setting values after the variable map has been created in SettingVariables.