### PR TITLE
Add ability to push to UserData with 'model' property and pull with 'on_click_event' (or 'on_tap_event')

### DIFF
--- a/doc/basics/Dynamic Interfaces.md
+++ b/doc/basics/Dynamic Interfaces.md
@@ -652,6 +652,18 @@ addChildPtr(mySlide);
 		/>
 </layout>
 ```
+Connecting the model and events
+---------------------------
+An event's data parameter can be set from the model by using the userData cache. To do so, begin the property to set in the model with an **underscore**. This will set the value in the userData cache of the sprite. Later when an event fires you get the value from the userData cache. 
+
+```XML
+<layout_button name="button"
+    model="_type:this->sensor_type"
+    on_click_event="{SelectSensorEvent; user_data:_type}"
+/>
+```
+
+in this example this->sensor_type is being stored in the layout_button's userData cache with the key '_type' and when the on_click_event is fired, it will look up that value in the cache and send a SelectSensorEvent with the value stored in the cache in it's Data property.
 
 `text_model` & `text_model_format`
 ----------------------------------

--- a/doc/basics/Dynamic Interfaces.md
+++ b/doc/basics/Dynamic Interfaces.md
@@ -146,10 +146,14 @@ Using the **on_tap_event** and **on_click_event** sprite parameters, you can tri
 * **Custom event parameters:** You can apply certain parameters to each event dispatched from a layout xml: Data, Id, and UserSize. Pass these properties to the event like so:
 
         RequestCustomEvent; data:myCustomStringData; id:1234; user_size:400, 300, 1;
+	data can also be set from the sprite's userData cache by using the user_data parameter and a key to a string in the userData collection:
+
+         RequestCustomEvent; user_data:keyInUserData; id:1234; user_size:400, 300, 1;
+	This can be combined with the model property's ability to set model data in the userData cache. See the ContentModel and SmartLayout section for details.
 
 * **Multiple events:** Send multiple events from the same button press by wrapping each event in brackets and separating them by commas. Do not use spaces between events. Example:
 
-        on_tap_event="{RequestCloseAllEvent},{RequestMediaOpenEvent; data:%APP%/data/temp/test.pdf; user_size:900},{RequestLayoutEvent}"
+        on_tap_event="{RequestCloseAllEvent},{RequestMediaOpenEvent; data:%APP%/data/temp/test.pdf; user_size:900},{RequestLayoutEvent; user_data:data_key}"
 
 * **Handling events:** The app will need to handle the events like normal using an event client and handling the app event. The parameters described above are automatically applied to the Event by the xml importer and you can access them through the event:
 
@@ -601,7 +605,10 @@ If you're using ds::model::ContentModelRef for your data model and queries (see 
 
 * **model**: String, colon-separated sprite parameters, semi-colon and space separated for multiple settings.
 
-**Syntax**: {sprite property}:{content model reference}->{content model property}.
+**Syntax**:  
+{sprite property}:{content model reference}->{content model property}.  
+or
+{_userData key}:{content model reference}->{content model property}. 
 
 **Example**: 
 
@@ -612,7 +619,9 @@ If you're using ds::model::ContentModelRef for your data model and queries (see 
 	/>
 ```
 
-When setting a ContentModelRef, you first specify the **sprite property**. Nearly any sprite property in the above works. Setting the model uses the same code path as the initial parsing. You can set the position, color, font, animation, tap events, text, image source, etc. The advantage of this solution is the ability to put more ui control in the database, allowing for easier re-skinning and tweaking. 
+When setting a ContentModelRef, you first specify the **sprite property**. Nearly any sprite property in the above works. Setting the model uses the same code path as the initial parsing. You can set the position, color, font, animation, tap events, text, image source, etc. The advantage of this solution is the ability to put more ui control in the database, allowing for easier re-skinning and tweaking.  
+
+You can also set a key in the userData cache by beginning the key name with and underscore. The underscore is part of the key so if you retrieve it elsewhere be sure to include it. this is intended to be used with on_click_event and on_tap_event, but it may have other uses.
 
 The second part of the syntax is the **content model reference**. Typically you'll use the "this" value, which indicates the current ContentModelRef for this SmartLayout. You can also access any level of children that can be accessed through mContentModel.getChildByName(""), such as "slide.theme" or "sqlite.settings".
 

--- a/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
+++ b/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
@@ -1090,11 +1090,8 @@ void XmlImporter::dispatchSingleEvent(const std::string& value, ds::ui::Sprite* 
 					eventy->mUserId = ds::string_to_int(paramValue);
 				} else if (paramType == "user_size") {
 					eventy->mUserSize = parseVector(paramValue);
-				}
-			}
-			else {
-				if (tokens[i] == "click_data") {
-					auto click_data = bs->getUserData().getString("_click_data", 0, "");
+				} else if (paramType == "user_data") {
+					auto click_data = bs->getUserData().getString(paramValue, 0, "");
 					if (!click_data.empty()) {
 						eventy->mUserStringData = click_data;
 					}

--- a/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
+++ b/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
@@ -1092,6 +1092,14 @@ void XmlImporter::dispatchSingleEvent(const std::string& value, ds::ui::Sprite* 
 					eventy->mUserSize = parseVector(paramValue);
 				}
 			}
+			else {
+				if (tokens[i] == "click_data") {
+					auto click_data = bs->getUserData().getString("_click_data", 0, "");
+					if (!click_data.empty()) {
+						eventy->mUserStringData = click_data;
+					}
+				}
+			}
 		}
 		eventy->mSpriteOriginator = bs;
 		eventy->mEventOrigin	  = globalPos;

--- a/projects/essentials/src/ds/ui/layout/smart_layout.cpp
+++ b/projects/essentials/src/ds/ui/layout/smart_layout.cpp
@@ -254,10 +254,10 @@ void SmartLayout::applyModelToSprite(ds::ui::Sprite* child, const std::string& c
 					} else {
 						child->hide();
 					}
-				} else if (sprPropToSet == "click_data") {
+				} else if (sprPropToSet.find("%",0)==0) {
 					auto click_data = theNode.getPropertyString(theProp);
 					if (!click_data.empty()) {
-						child->getUserData().setString("_click_data", click_data);
+						child->getUserData().setString(sprPropToSet, click_data);
 					}
 				} else {
 					actualValue = theNode.getPropertyString(theProp);

--- a/projects/essentials/src/ds/ui/layout/smart_layout.cpp
+++ b/projects/essentials/src/ds/ui/layout/smart_layout.cpp
@@ -254,7 +254,7 @@ void SmartLayout::applyModelToSprite(ds::ui::Sprite* child, const std::string& c
 					} else {
 						child->hide();
 					}
-				} else if (sprPropToSet.find("%",0)==0) {
+				} else if (sprPropToSet.find("_",0)==0) {
 					auto click_data = theNode.getPropertyString(theProp);
 					if (!click_data.empty()) {
 						child->getUserData().setString(sprPropToSet, click_data);

--- a/projects/essentials/src/ds/ui/layout/smart_layout.cpp
+++ b/projects/essentials/src/ds/ui/layout/smart_layout.cpp
@@ -254,6 +254,11 @@ void SmartLayout::applyModelToSprite(ds::ui::Sprite* child, const std::string& c
 					} else {
 						child->hide();
 					}
+				} else if (sprPropToSet == "click_data") {
+					auto click_data = theNode.getPropertyString(theProp);
+					if (!click_data.empty()) {
+						child->getUserData().setString("_click_data", click_data);
+					}
 				} else {
 					actualValue = theNode.getPropertyString(theProp);
 


### PR DESCRIPTION
This update allows the on_click_event and on_tap_event to access the data model via the sprites ds::UserData object. 

The 'model' property of a sprite will now drop a value into the UserData object when it detects an underscore before the property name:

`model="_type:this->sensor_type"`

will insert the value of the model property 'sensor_type' into the UserData object with the key '_type'

Correspondingly, the user_data parameter given to an event value will retrieve a value from the UserData object using the given key and put it in the mUserStringData property of the event:

{SelectSensorEvent; user_data:_type} 

Note that the key value given doesn't have to start with an underscore, so it can get strings out of the UserData object that were put there by other means.

