### PR TITLE
Fixes for sprite::setFinalRenderToTexture()

### DIFF
--- a/src/ds/ui/sprite/sprite.cpp
+++ b/src/ds/ui/sprite/sprite.cpp
@@ -280,6 +280,7 @@ void Sprite::drawClient(const ci::mat4 &trans, const DrawParams &drawParams) {
 		//Need to manual flip image.  The flip() function of the ci::Texture element doesn't work with shaders.
 		ci::gl::scale(1.0f, -1.0f, 1.0f);							// invert Y axis so increasing Y goes down.
 		ci::gl::translate(0.0f, (float)-getHeight(), 0.0f);			// shift origin up to upper-left corner.
+		ci::gl::clear(ci::ColorA(0.f, 0.f, 0.f, 0.f), true);
 	}
 
 	mSpriteShader.loadShaders();	


### PR DESCRIPTION
I found a couple of issues in sprite::setFinalRenderToTexture while working on my warping sprite.

* The FBO's were never being cleared, which was leading to display artifacts.
* When rendering multiple sprites in the same tree to FBOs, the old drawing code did not correctly switch back to the original FBO. (e.g. Parent renders to an FBO, and a child renders to another FBO. Once the child has rendered, the parents FBO is not reactivated for drawing)

I believe the attached commits fix both of the above issues, but I think it needs wider testing before merging to master. Any apps you can think of that make use of rendering sprites to FBOs through setFinalRenderToTexture are good candidates for testing.