### PR TITLE
adds new method to LineSprite and registers it for netsync

### DIFF
--- a/projects/essentials/src/ds/ui/sprite/line.h
+++ b/projects/essentials/src/ds/ui/sprite/line.h
@@ -61,6 +61,8 @@ class LineSprite final : public ds::ui::Sprite {
 	void setMiterLimit(const float miterLimit);
 	/// \brief Get current miter limit
 	float getMiterLimit() { return mMiterLimit; }
+	/// \brief Get the point at a certain percentage on the line.
+	ci::vec2 getPointAtPercentage(float percentage);
 
 	virtual void drawLocalClient();
 
@@ -85,6 +87,7 @@ class LineSprite final : public ds::ui::Sprite {
 	float mMiterLimit;
 	float mLineWidth;
 	float mLineStart, mLineEnd;
+	float mLineLength;
 
 	ci::gl::BatchRef	  mBatch;
 	std::vector<ci::vec2> mPoints;


### PR DESCRIPTION
# Contributions

* Adds registration of the LineSprite at the top of its own file for netsync purposes. Before, you had to register the LineSprite in your projects for it to sync. Now, you don't have to worry about it.
* Adds a new method to the LineSprite, `getPointAtPercentage`. This was useful for me when doing the snake line easter egg, as I have to be able to get a point on the line at a certain percentage to know whether the line has collided with the dots it consumes.

# Test

* To test the netsyncing, I cloned a new DSCinder app and added a quick config for clientserver & client. I also added some code that creates a LineSprite and continually animates it. I was able to reproduce the issue without the fix, and verified that the issue is gone with the fix in place. You can find that [test repo bundled here](https://downstream.box.com/s/0dcju6p41w7sc9rciu1ggxn7xgnmrpzy).
* To test the new method, you can pull down a branch I pushed up on the google project just to test this (called [line_sprite_test](https://github.com/Downstream/google_315_moss_map/tree/line_sprite_test)). Initiate Line mode: roads and wait for the first line set to finish animating. You'll then see the snake line appear. You'll know that the method works if the cherries disappear when the snake line touches them.