### PR TITLE
Resetups server on display change

### DIFF
--- a/example/full_starter/settings/engine.xml
+++ b/example/full_starter/settings/engine.xml
@@ -21,6 +21,7 @@
 	<setting name="idle_time" value="300" type="double" comment="Seconds before idle happens. 300 = 5 minutes." default="300" min_value="0" max_value="1000"/>
 	<setting name="system:never_sleep" value="true" type="bool" comment="Prevent the system from sleeping or powering off the screen" default="true"/>
 	<setting name="apphost:exit_on_quit" value="true" type="bool" comment="Exit apphost when quitting the app" default="true" />
+	<setting name="resetup_server_on_display_change" value="false" type="bool" comment="Resetup the server when the display changes" default="false" />
 	<setting name="RENDER SETTINGS" value="" type="section_header"/>
 	<setting name="frame_rate" value="60" type="int" comment="Attempt to run the app at this rate" default="60" min_value="1" max_value="1000"/>
 	<setting name="vertical_sync" value="true" type="bool" comment="Attempts to align frame rate with the refresh rate of the monitor. Note that this could be overriden by the graphic card" default="true"/>

--- a/src/ds/app/app.h
+++ b/src/ds/app/app.h
@@ -107,7 +107,6 @@ public:
 	virtual void				prepareSettings( ci::app::AppBase::Settings* );
 	void						loadAppSettings();
 	virtual void				setup();
-	void						resetTheWindow();
 	void						resetupServer();
 	void						preServerSetup();
 
@@ -152,6 +151,7 @@ private:
 	static const std::string&   envAppDataPath();
 	void						setupKeyPresses();
 	void						resetupServerOnDisplayChange();
+	void						resetTheWindow();
 	bool						mSetupOnDisplayChange;
 	ds::keys::KeyManager		mKeyManager;
 	ds::ui::TouchDebug			mTouchDebug;

--- a/src/ds/app/app.h
+++ b/src/ds/app/app.h
@@ -107,6 +107,7 @@ public:
 	virtual void				prepareSettings( ci::app::AppBase::Settings* );
 	void						loadAppSettings();
 	virtual void				setup();
+	void						resetTheWindow();
 	void						resetupServer();
 	void						preServerSetup();
 
@@ -150,6 +151,8 @@ private:
 	/// if it's what you want
 	static const std::string&   envAppDataPath();
 	void						setupKeyPresses();
+	void						resetupServerOnDisplayChange();
+	bool						mSetupOnDisplayChange;
 	ds::keys::KeyManager		mKeyManager;
 	ds::ui::TouchDebug			mTouchDebug;
 	bool						mAppKeysEnabled;

--- a/src/ds/app/engine/engine_settings.cpp
+++ b/src/ds/app/engine/engine_settings.cpp
@@ -187,6 +187,7 @@ void EngineSettings::setDefaults(){
 	getSetting("idle_time", 0, ds::cfg::SETTING_TYPE_DOUBLE, "Seconds before idle happens. 300 = 5 minutes.", "300", "0", "1000");
 	getSetting("system:never_sleep", 0, ds::cfg::SETTING_TYPE_BOOL, "Prevent the system from sleeping or powering off the screen", "true");
 	getSetting("apphost:exit_on_quit", 0, ds::cfg::SETTING_TYPE_BOOL, "Exit apphost when quitting the app", "true");
+	getSetting("resetup_server_on_display_change", 0, ds::cfg::SETTING_TYPE_BOOL, "Resetup the server when the display changes", "false");
 
 	getSetting("RENDER SETTINGS", 0, ds::cfg::SETTING_TYPE_SECTION_HEADER, "");
 	getSetting("frame_rate", 0, ds::cfg::SETTING_TYPE_INT, "Attempt to run the app at this rate", "60", "1", "1000");


### PR DESCRIPTION
# Contribution

Previously, if a DS Cinder app was set to fullscreen (by pressing "f", for instance), and the display was disconnected and reconnected, the app would lose its fullscreen status, requiring the user to press "f" again.

This PR adds a setting in the engine file called `"resetup_server_on_display_change"`. If true, the app will resetup the server when it detects a display change, maintaining the fullscreen status of the app even through disconnects.

NOTE: I set the default for this engine variable to false to be prudent, I guess. I could see a case for leaving it on true, so let me know if you want to change that.

# TEST

* Copy the full_starter project from the repo (I've already add the new engine variable to engine.xml)
* Change the world dimensions to something smaller than your screen (to verify the fullscreen works)
* Checkout this branch on ds_cinder
* Run the app in debug mode -- observe the app starts smaller than your screen
* Press "f" and observe the app goes fullscreen
* disconnect & reconnect your monitor
* Observe the app is still fullscreen
* For further verification, check the app log and look for the message `Display setup changed, resetting server`
* For bonus points, verify this doesn't happen when the variable is false