### PR TITLE
Sets default for resetup on display change to true and fixes logic gap

### DIFF
--- a/example/full_starter/settings/engine.xml
+++ b/example/full_starter/settings/engine.xml
@@ -21,7 +21,7 @@
 	<setting name="idle_time" value="300" type="double" comment="Seconds before idle happens. 300 = 5 minutes." default="300" min_value="0" max_value="1000"/>
 	<setting name="system:never_sleep" value="true" type="bool" comment="Prevent the system from sleeping or powering off the screen" default="true"/>
 	<setting name="apphost:exit_on_quit" value="true" type="bool" comment="Exit apphost when quitting the app" default="true" />
-	<setting name="resetup_server_on_display_change" value="false" type="bool" comment="Resetup the server when the display changes" default="false" />
+	<setting name="resetup_server_on_display_change" value="true" type="bool" comment="Resetup the server when the display changes" default="false" />
 	<setting name="RENDER SETTINGS" value="" type="section_header"/>
 	<setting name="frame_rate" value="60" type="int" comment="Attempt to run the app at this rate" default="60" min_value="1" max_value="1000"/>
 	<setting name="vertical_sync" value="true" type="bool" comment="Attempts to align frame rate with the refresh rate of the monitor. Note that this could be overriden by the graphic card" default="true"/>

--- a/src/ds/app/app.cpp
+++ b/src/ds/app/app.cpp
@@ -298,9 +298,13 @@ void App::update() {
 
 	DS_LOG_VERBOSE(9, "App::Update fps=" << getAverageFps());
 
-	if (mEngine.getEngineSettings().getBool("resetup_server_on_display_change", 0, false) && !mSetupOnDisplayChange) {
+	auto shouldResetup = mEngine.getEngineSettings().getBool("resetup_server_on_display_change", 0, true);
+	if (shouldResetup && !mSetupOnDisplayChange) {
 		mSetupOnDisplayChange = true;
 		resetupServerOnDisplayChange();
+	}
+	else if (!shouldResetup && mSetupOnDisplayChange) {
+		mSetupOnDisplayChange = false;
 	}
 
 	if (mEngine.getHideMouse() && !mMouseHidden) {

--- a/src/ds/app/engine/engine_settings.cpp
+++ b/src/ds/app/engine/engine_settings.cpp
@@ -187,7 +187,7 @@ void EngineSettings::setDefaults(){
 	getSetting("idle_time", 0, ds::cfg::SETTING_TYPE_DOUBLE, "Seconds before idle happens. 300 = 5 minutes.", "300", "0", "1000");
 	getSetting("system:never_sleep", 0, ds::cfg::SETTING_TYPE_BOOL, "Prevent the system from sleeping or powering off the screen", "true");
 	getSetting("apphost:exit_on_quit", 0, ds::cfg::SETTING_TYPE_BOOL, "Exit apphost when quitting the app", "true");
-	getSetting("resetup_server_on_display_change", 0, ds::cfg::SETTING_TYPE_BOOL, "Resetup the server when the display changes", "false");
+	getSetting("resetup_server_on_display_change", 0, ds::cfg::SETTING_TYPE_BOOL, "Resetup the server when the display changes", "true");
 
 	getSetting("RENDER SETTINGS", 0, ds::cfg::SETTING_TYPE_SECTION_HEADER, "");
 	getSetting("frame_rate", 0, ds::cfg::SETTING_TYPE_INT, "Attempt to run the app at this rate", "60", "1", "1000");


### PR DESCRIPTION
# Contributions

* I identified a logic gap for this variable where the flag would not revert to false if the variable in the engine.xml file was updated
* Changed the default for this variable to true

# TEST

* Load up the new full starter (now has the `resetup_server_on_display_change` variable set to true by default)
* With the app loaded, set the above variable to false
* disconnect your monitor and reconnect it. Observe that the app does not resetup.