### PR TITLE
EngineServer: resolve an issue where servers and clients weren't talking

### DIFF
--- a/src/ds/app/engine/engine_client.cpp
+++ b/src/ds/app/engine/engine_client.cpp
@@ -116,7 +116,7 @@ void EngineClient::update() {
 	bool foundBlob = false;
 	int waitCount = 0;
 	while(!foundBlob) {
-		if(mReceiver.receiveBlob()) {
+		if(mReceiver.receiveBlob(true)) {
 			foundBlob = true;
 		}
 		waitCount++;

--- a/src/ds/app/engine/engine_io.cpp
+++ b/src/ds/app/engine/engine_io.cpp
@@ -90,7 +90,7 @@ ds::DataBuffer& EngineReceiver::getData() {
 	return mCurrentDataBuffer;
 }
 
-bool EngineReceiver::receiveBlob() {
+bool EngineReceiver::receiveBlob(const bool strict) {
 	std::string recvBuffer;
 
 	if(mUseChunker){
@@ -119,7 +119,9 @@ bool EngineReceiver::receiveBlob() {
 
 	if(mReceiveBuffers.empty()) {
 		++mNoDataCount;
-		return false;
+		if(strict) {
+			return false;
+		}
 	}
 
 	return true;

--- a/src/ds/app/engine/engine_io.h
+++ b/src/ds/app/engine/engine_io.h
@@ -64,7 +64,8 @@ public:
 	ds::DataBuffer&				getData();
 	/// Convenience for clients with a blob reader, automatically
 	/// receive and handle the data. Answer true if there was data.
-	bool						receiveBlob();
+	/// If strict, then will return false if there's no data, otherwise will only return false on error
+	bool						receiveBlob(const bool strict);
 	bool						handleBlob(ds::BlobRegistry&, ds::BlobReader&, bool& morePacketsAvailable);
 	bool						hasLostConnection() const;
 	void						clearLostConnection();

--- a/src/ds/app/engine/engine_server.cpp
+++ b/src/ds/app/engine/engine_server.cpp
@@ -335,7 +335,7 @@ void EngineServer::RunningState::update(AbstractEngineServer& engine) {
 
 	// this receive call pulls everything it can off the wire and caches it
 	// if there was an error decoding the chunks, then go back to sending a full world
-	if(!engine.mReceiver.receiveBlob()){
+	if(!engine.mReceiver.receiveBlob(false)){
 		engine.mReceiver.clearLostConnection();
 		engine.setState(engine.mSendWorldState);
 		return;


### PR DESCRIPTION
This resolves an issue where servers would give up too easily if they hadn't gotten a packet back from the client.