### PR TITLE
Tapping panoramic video player opens the media interface

### DIFF
--- a/projects/video/gstreamer-1.0/src/ds/ui/sprite/panoramic_video.cpp
+++ b/projects/video/gstreamer-1.0/src/ds/ui/sprite/panoramic_video.cpp
@@ -118,6 +118,12 @@ void main() {
 	enableMultiTouch(ds::ui::MULTITOUCH_INFO_ONLY);
 	setProcessTouchCallback([this](ds::ui::Sprite*, const ds::ui::TouchInfo& ti){
 		handleDrag(ci::vec2(ti.mDeltaPoint));		
+
+		// Handle tapping
+		auto dist = glm::distance(ti.mCurrentGlobalPoint, ti.mStartPoint);
+		if(mTappedCb && ti.mPhase == ds::ui::TouchInfo::Removed && dist < mEngine.getMinTapDistance()){
+			mTappedCb();
+		}
 	});
 }
 

--- a/projects/video/gstreamer-1.0/src/ds/ui/sprite/panoramic_video.cpp
+++ b/projects/video/gstreamer-1.0/src/ds/ui/sprite/panoramic_video.cpp
@@ -120,9 +120,10 @@ void main() {
 		handleDrag(ci::vec2(ti.mDeltaPoint));		
 
 		// Handle tapping
-		auto dist = glm::distance(ti.mCurrentGlobalPoint, ti.mStartPoint);
-		if(mTappedCb && ti.mPhase == ds::ui::TouchInfo::Removed && dist < mEngine.getMinTapDistance()){
-			mTappedCb();
+		if(mPanoTappedCb && ti.mPhase == ds::ui::TouchInfo::Removed){
+			if(glm::distance(ti.mCurrentGlobalPoint, ti.mStartPoint) < mEngine.getMinTapDistance()){
+				mPanoTappedCb();
+			}
 		}
 	});
 }

--- a/projects/video/gstreamer-1.0/src/ds/ui/sprite/panoramic_video.h
+++ b/projects/video/gstreamer-1.0/src/ds/ui/sprite/panoramic_video.h
@@ -43,8 +43,8 @@ public:
 	void				setPlayableInstances(const std::vector<std::string> instances);
 	void				setAutoSyncronize(const bool doSync); // synchronize across client/server
 
-	void setTappedCallback(std::function<void(void)> cb){
-		mTappedCb = cb;
+	void setPanoTappedCallback(std::function<void(void)> cb){
+		mPanoTappedCb = cb;
 	}
 
 protected:
@@ -80,7 +80,7 @@ private:
 	std::string			mSphereFragmentShader;
 	ci::gl::GlslProgRef	mShader;
 
-	std::function<void(void)> mTappedCb = nullptr;
+	std::function<void(void)> mPanoTappedCb = nullptr;
 
 public:
 	static void			installAsServer(ds::BlobRegistry&);

--- a/projects/video/gstreamer-1.0/src/ds/ui/sprite/panoramic_video.h
+++ b/projects/video/gstreamer-1.0/src/ds/ui/sprite/panoramic_video.h
@@ -43,6 +43,10 @@ public:
 	void				setPlayableInstances(const std::vector<std::string> instances);
 	void				setAutoSyncronize(const bool doSync); // synchronize across client/server
 
+	void setTappedCallback(std::function<void(void)> cb){
+		mTappedCb = cb;
+	}
+
 protected:
 	// These are our only chances in client mode to catch the video.
 	virtual void		onChildAdded(ds::ui::Sprite& child) override;
@@ -75,6 +79,8 @@ private:
 	std::string			mSphereVertexShader;
 	std::string			mSphereFragmentShader;
 	ci::gl::GlslProgRef	mShader;
+
+	std::function<void(void)> mTappedCb = nullptr;
 
 public:
 	static void			installAsServer(ds::BlobRegistry&);

--- a/projects/viewers/src/ds/ui/media/player/panoramic_video_player.cpp
+++ b/projects/viewers/src/ds/ui/media/player/panoramic_video_player.cpp
@@ -79,11 +79,8 @@ void PanoramicVideoPlayer::setResource(const ds::Resource& resource) {
 		}
 	});
 
-	mPanoramicVideo->setTappedCallback([this]{
-		if(mVideoInterface && !mVideoInterface->visible()){
-			mVideoInterface->setOpacity(1.0f);
-			mVideoInterface->show();
-		}
+	mPanoramicVideo->setPanoTappedCallback([this]{
+		showInterface();
 	});
 
 	setPan(mPanning);

--- a/projects/viewers/src/ds/ui/media/player/panoramic_video_player.cpp
+++ b/projects/viewers/src/ds/ui/media/player/panoramic_video_player.cpp
@@ -79,6 +79,13 @@ void PanoramicVideoPlayer::setResource(const ds::Resource& resource) {
 		}
 	});
 
+	mPanoramicVideo->setTappedCallback([this]{
+		if(mVideoInterface && !mVideoInterface->visible()){
+			mVideoInterface->setOpacity(1.0f);
+			mVideoInterface->show();
+		}
+	});
+
 	setPan(mPanning);
 	setVolume(mVolume);
 	setAutoSynchronize(mAutoSyncronize);


### PR DESCRIPTION
Currently the panoramic video player has a video interface but once it auto-hides there is no way to get it back. This makes it so that any touch that moves less than the minimum tap distance triggers the interface to reappear.