### PR TITLE
Added ability to set image loading flags from layout xml.

### DIFF
--- a/doc/basics/Dynamic Interfaces.md
+++ b/doc/basics/Dynamic Interfaces.md
@@ -353,8 +353,17 @@ Text Parameters
 
 Image Parameters
 -------------------------
-* **filename** OR **src**: File path RELATIVE to XML. For instance: src="../data/images/refresh_btn.png"
-* **filename_cache** OR **src_cache**: Exactly the same as above, but includes the ds::ui::Image::IMG_CACHE_F flag, which permanently caches the image
+* **filename** OR **src**: File path RELATIVE to XML. For instance: src="../data/images/refresh_btn.png". Image loading flags can be added to the property name seperated by underscores (_). For example filename_cache with cause the ds::ui::Image::IMG_CACHE_F flag to be passed to the loade, while filename_mipmap_cache will cause both ds::ui::Image::IMG_CACHE_F and ds::ui::Image::IMG_MIPMAP to be passed.
+	* **_cache** OR **_c**: include the ds::ui::Image::IMG_CACHE_F flag, which permanently caches the image
+	* **_mipmap** OR **_m**: include the ds::ui::Image::IMG_MIPMAP flag, which generates mipmaps for the given image.
+	* **_preload** OR **_p**: include the ds::ui::Image::IMG_PRELOAD flag, which preloads the image.
+	* **_skipmeta** OR **_s**: include the ds::ui::Image::IMG_SKIP_METADATA flag, which skips metadata loading.
+
+These flags can also be applied the the resource property when working with a model:  
+```xml
+		model="resource_mipmap:this->img_resource"
+```
+	
 * **circle_crop**: Boolean. If true, will crop image content outside of an ellipse centered within the bounding box.
 * **auto_circle_crop**: Boolean. If true, centers the crop in the middle of the image and always makes it a circle, persists through image file changes.
 

--- a/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
+++ b/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
@@ -796,51 +796,34 @@ void XmlImporter::setSpriteProperty(ds::ui::Sprite& sprite, const std::string& p
 	else if (property.rfind("filename",0)==0 || property.rfind("src",0) == 0) {
 		//else if (property == "filename" || property == "src" || property == "filename_cache" || property == "src_cache") {
 
-		bool cache = false;
-		bool mipmap = false;
-		bool skipmeta = false;
-		bool preload = false;
-		bool error = false;
-		if(property.find("_")!= std::string::npos)
-		{
-			std::regex flagregex("_+");
-			auto itr = std::sregex_token_iterator(property.begin(), property.end(), flagregex, -1);
-			++itr; //skip src or filename;
-			for (; itr != std::sregex_token_iterator(); ++itr) {
-				auto val = itr->str();
-				if (itr->str() == "cache" || itr->str()== "c")
-				{
-					cache = true;
-				} else 
-				if(itr->str() == "mipmap" || itr->str()=="m")
-				{
-					mipmap = true;
-				} else
-				if (itr->str() == "preload" || itr->str() == "p")
-				{
-					preload = true;
-				} else
-				if (itr->str() == "skipmeta" || itr->str() == "s")
-				{
-					skipmeta = true;
-				} else
-				{
-					DS_LOG_WARNING("Trying to set unknown flags to src/filename attribute: _" << itr->str()
+		int  flags = 0;
+		if (property.find("_") != std::string::npos) {
+
+			auto theFlags = ds::split(property, "_", true);
+			for (auto val : theFlags) {
+
+				if (val == "cache" || val == "c") {
+					flags |= ds::ui::Image::IMG_CACHE_F;
+
+				}
+				else if (val == "mipmap" || val == "m") {
+					flags |= ds::ui::Image::IMG_ENABLE_MIPMAP_F;
+
+				}
+				else if (val == "preload" ||val== "p") {
+					flags |= ds::ui::Image::IMG_PRELOAD_F;
+
+				}
+				else if (val == "skipmeta" ||val == "s") {
+					flags |= ds::ui::Image::IMG_SKIP_METADATA_F;
+
+				}
+				else if (val != "filename" && val != "src") {
+					DS_LOG_WARNING("Trying to set unknown flags to src/filename attribute: _" << val
 						<< "_ on sprite of type: " << typeid(sprite).name());
 				}
 			}
-			if((cache | mipmap | preload | skipmeta) == false)
-			{
-				DS_LOG_WARNING("Malformed src/filename flags to attribute: _" << property
-					<< "_ on sprite of type: " << typeid(sprite).name());
-			}
 		}
-	
-		int  flags  = 0;
-		if (cache) flags |= ds::ui::Image::IMG_CACHE_F;
-		if (mipmap) flags |= ds::ui::Image::IMG_ENABLE_MIPMAP_F;
-		if (preload) flags |= ds::ui::Image::IMG_PRELOAD_F;
-		if (skipmeta) flags |= ds::ui::Image::IMG_SKIP_METADATA_F;
 		
 		auto imgBtn = dynamic_cast<ImageButton*>(&sprite);
 		auto image = dynamic_cast<Image*>(&sprite);

--- a/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
+++ b/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
@@ -792,11 +792,58 @@ void XmlImporter::setSpriteProperty(ds::ui::Sprite& sprite, const std::string& p
 		} else if (layBtn) {
 			layBtn->setClickFn([layBtn, value] { dispatchStringEvents(value, layBtn, layBtn->getGlobalPosition()); });
 		}
-	} else if (property == "filename" || property == "src" || property == "filename_cache" || property == "src_cache") {
-		auto imgBtn = dynamic_cast<ImageButton*>(&sprite);
-		auto image  = dynamic_cast<Image*>(&sprite);
+	}
+	else if (property.rfind("filename",0)==0 || property.rfind("src",0) == 0) {
+		//else if (property == "filename" || property == "src" || property == "filename_cache" || property == "src_cache") {
+
+		bool cache = false;
+		bool mipmap = false;
+		bool skipmeta = false;
+		bool preload = false;
+		bool error = false;
+		if(property.find("_")!= std::string::npos)
+		{
+			std::regex flagregex("_+");
+			auto itr = std::sregex_token_iterator(property.begin(), property.end(), flagregex, -1);
+			++itr; //skip src or filename;
+			for (; itr != std::sregex_token_iterator(); ++itr) {
+				auto val = itr->str();
+				if (itr->str() == "cache" || itr->str()== "c")
+				{
+					cache = true;
+				} else 
+				if(itr->str() == "mipmap" || itr->str()=="m")
+				{
+					mipmap = true;
+				} else
+				if (itr->str() == "preload" || itr->str() == "p")
+				{
+					preload = true;
+				} else
+				if (itr->str() == "skipmeta" || itr->str() == "s")
+				{
+					skipmeta = true;
+				} else
+				{
+					DS_LOG_WARNING("Trying to set unknown flags to src/filename attribute: _" << itr->str()
+						<< "_ on sprite of type: " << typeid(sprite).name());
+				}
+			}
+			if((cache | mipmap | preload | skipmeta) == false)
+			{
+				DS_LOG_WARNING("Malformed src/filename flags to attribute: _" << property
+					<< "_ on sprite of type: " << typeid(sprite).name());
+			}
+		}
+	
 		int  flags  = 0;
-		if (property == "filename_cache" || property == "src_cache") flags = ds::ui::Image::IMG_CACHE_F;
+		if (cache) flags |= ds::ui::Image::IMG_CACHE_F;
+		if (mipmap) flags |= ds::ui::Image::IMG_ENABLE_MIPMAP_F;
+		if (preload) flags |= ds::ui::Image::IMG_PRELOAD_F;
+		if (skipmeta) flags |= ds::ui::Image::IMG_SKIP_METADATA_F;
+		
+		auto imgBtn = dynamic_cast<ImageButton*>(&sprite);
+		auto image = dynamic_cast<Image*>(&sprite);
 		std::string filePath = value;
 		if (!value.empty()) filePath = filePathRelativeTo(referer, value);
 		if (image) {

--- a/projects/essentials/src/ds/ui/layout/smart_layout.cpp
+++ b/projects/essentials/src/ds/ui/layout/smart_layout.cpp
@@ -264,58 +264,38 @@ void SmartLayout::applyModelToSprite(ds::ui::Sprite* child, const std::string& c
 				auto		sprPropToSet = keyVals[0];
 				auto		theProp		 = childProps[1];
 				std::string actualValue  = "";
-
-
-
 				
 				if (sprPropToSet.rfind( "resource",0)==0) {
-					bool cache = false;
-					bool mipmap = false;
-					bool skipmeta = false;
-					bool preload = false;
-					bool error = false;
-					if (sprPropToSet.find("_") != std::string::npos)
-					{
-						std::regex flagregex("_{1}");
-						auto itr = std::sregex_token_iterator(sprPropToSet.begin(), sprPropToSet.end(), flagregex, -1);
-						++itr; //skip "resource"
-						for (; itr != std::sregex_token_iterator(); ++itr) {
-							if (itr->str() == "cache" || itr->str() == "c")
-							{
-								cache = true;
+
+					int  flags = 0;
+					if (sprPropToSet.find("_") != std::string::npos) {
+
+						auto theFlags = ds::split(sprPropToSet, "_", true);
+						for (auto val : theFlags) {
+
+							if (val == "cache" || val == "c") {
+								flags |= ds::ui::Image::IMG_CACHE_F;
+
 							}
-							else if (itr->str() == "mipmap" || itr->str() == "m")
-							{
-									mipmap = true;
+							else if (val == "mipmap" || val == "m") {
+								flags |= ds::ui::Image::IMG_ENABLE_MIPMAP_F;
+
 							}
-							else if (itr->str() == "preload" || itr->str() == "p")
-							{
-								preload = true;
+							else if (val == "preload" || val == "p") {
+								flags |= ds::ui::Image::IMG_PRELOAD_F;
+
 							}
-							else if (itr->str() == "skipmeta" || itr->str() == "s")
-							{
-								skipmeta = true;
+							else if (val == "skipmeta" || val == "s") {
+								flags |= ds::ui::Image::IMG_SKIP_METADATA_F;
+
 							}
-							else
-							{
-								DS_LOG_WARNING("Trying to set unknown flags to src/filename attribute: _" << itr->str()
-												<< "_ on sprite of type: " << typeid(child).name());
+							else if (val != "resource" ) {
+								DS_LOG_WARNING("Trying to set unknown flags to src/filename attribute: _" << val
+									<< "_ on sprite of type: " << typeid(child).name());
 							}
-						}
-						if ((cache | mipmap | preload | skipmeta) == false)
-						{
-							DS_LOG_WARNING("Malformed src/filename flags to attribute: _" << sprPropToSet 
-								<< "_ on sprite of type: " << typeid(child).name());
 						}
 					}
 
-					int  flags = 0;
-					if (cache) flags |= ds::ui::Image::IMG_CACHE_F;
-					if (mipmap) flags |= ds::ui::Image::IMG_ENABLE_MIPMAP_F;
-					if (preload) flags |= ds::ui::Image::IMG_PRELOAD_F;
-					if (skipmeta) flags |= ds::ui::Image::IMG_SKIP_METADATA_F;
-
-					
 					setSpriteImage(childName, theNode.getProperty(theProp).getResource(), flags);
 				} else if(sprPropToSet == "media_player_src") {
 					auto theResource = theNode.getProperty(theProp).getResource();

--- a/projects/essentials/src/ds/ui/layout/smart_layout.h
+++ b/projects/essentials/src/ds/ui/layout/smart_layout.h
@@ -69,9 +69,11 @@ class SmartLayout : public ds::ui::LayoutSprite {
 	void setSpriteFont(const std::string& spriteName, const std::string& textCfgName);
 
 	/// Set the image file for an Image sprite with name of spriteName. Image path is automatically expanded
-	void setSpriteImage(const std::string& spriteName, const std::string& imagePath, bool cache = false, bool skipMetaData = false);
+	void setSpriteImage(const std::string& spriteName, const std::string& imagePath, bool cache = false, bool skipMetaData = false); 
+	void setSpriteImage(const std::string& spriteName, const std::string& imagePath, int flags = 0);
 	/// Set the image resource for an Image sprite with name of spriteName.
 	void setSpriteImage(const std::string& spriteName, ds::Resource imageResource, bool cache = false, bool skipMetaData = false);
+	void setSpriteImage(const std::string& spriteName, ds::Resource imageResource, int flags = 0);
 
 	/// Set the tap function on a sprite named spriteName
 	void setSpriteTapFn(const std::string&											 spriteName,


### PR DESCRIPTION

Changes src/filename property and resource model target to accept image loading flags a __flag_. This makes the change backward compatible with src_cache and resource_cache.

examples:
`<image src_cache="%APP%/data/images/super.png"/>` - caches the image.
`<image src_mipmap="%APP%/data/images/super.png"/>`- adds mipmaps for the image.
`<image src_cache_mipmap="%APP%/data/images/super.png"/>`- cahces and mipmaps the image.
`<image src_c_m="%APP%/data/images/super.png"/>`- same as above but shorthand syntax.

flags:
_cache/_c
_mipmap/_m
_skipmeta/_s
_preload/_p
