### PR TITLE
FBO rendering fixes

### DIFF
--- a/doc/basics/Dynamic Interfaces.md
+++ b/doc/basics/Dynamic Interfaces.md
@@ -237,7 +237,7 @@ Sprite Parameters
 * **scale**: 3d vector of the scale in x, y, z. Scale is from 0.0 (nothing) to 1.0 (100%), not bounded. scale="1, 1, 1" or scale="0.5, 0.5, 1"
 * **center**: Center is where the anchor of the sprite is calculated from (for scaling and rotation) and is a percentage from 0.0 (top/left) to 1.0 (bottom/right), not bounded. center="0, 0.5, 1"
 * **clipping**: Boolean of whether to clip it's children.
-* **blend_mode**: Valid values: normal, multiply, screen, add, subtract, lighten, darken. Default = normal.
+* **blend_mode**: Valid values: normal, multiply, screen, add, subtract, lighten, darken, premultiply. Default = normal.
 * **enable**: Boolean of whether to handle touch input or not.
 * **multitouch**: String of multitouch mode. Possible values:
     * info = MULTITOUCH_INFO_ONLY

--- a/src/ds/ui/sprite/sprite.cpp
+++ b/src/ds/ui/sprite/sprite.cpp
@@ -1677,9 +1677,8 @@ void Sprite::setupFinalRenderBuffer(){
 	   getWidth() > 1.0f &&
 	   getHeight() > 1.0f
 	   ){
-		ci::gl::Fbo::Format  format;
 		//mOutputFbo = ci::gl::Fbo::create(static_cast<int>(mEngine.getSrcRect().getWidth()), static_cast<int>(mEngine.getSrcRect().getHeight()), format);
-		mOutputFbo = ci::gl::Fbo::create(static_cast<int>(getWidth()), static_cast<int>(getHeight()), format);
+		mOutputFbo = ci::gl::Fbo::create(static_cast<int>(getWidth()), static_cast<int>(getHeight()), mFboFormat);
 	} else {
 		mOutputFbo = nullptr;
 	}
@@ -1693,10 +1692,11 @@ void Sprite::setShaderExtraData(const ci::vec4& data){
 	mShaderExtraData = data;
 }
 
-void Sprite::setFinalRenderToTexture(bool render_to_texture){
+void Sprite::setFinalRenderToTexture(bool render_to_texture, ci::gl::Fbo::Format format){
 	if (render_to_texture == mIsRenderFinalToTexture) return;
 	mIsRenderFinalToTexture = render_to_texture;
 
+	mFboFormat = format;
 	setupFinalRenderBuffer();
 
 }

--- a/src/ds/ui/sprite/sprite.cpp
+++ b/src/ds/ui/sprite/sprite.cpp
@@ -1677,7 +1677,6 @@ void Sprite::setupFinalRenderBuffer(){
 	   getWidth() > 1.0f &&
 	   getHeight() > 1.0f
 	   ){
-		//mOutputFbo = ci::gl::Fbo::create(static_cast<int>(mEngine.getSrcRect().getWidth()), static_cast<int>(mEngine.getSrcRect().getHeight()), format);
 		mOutputFbo = ci::gl::Fbo::create(static_cast<int>(getWidth()), static_cast<int>(getHeight()), mFboFormat);
 	} else {
 		mOutputFbo = nullptr;

--- a/src/ds/ui/sprite/sprite.h
+++ b/src/ds/ui/sprite/sprite.h
@@ -626,7 +626,7 @@ namespace ui {
 		BlendMode				getBlendMode() const;
 
 		///	Determines if the final render will be to the display or a texture.
-		void					setFinalRenderToTexture(bool render_to_texture);
+		void					setFinalRenderToTexture(bool render_to_texture, ci::gl::Fbo::Format format = ci::gl::Fbo::Format());
 		bool					isFinalRenderToTexture();
 		//Retrieve the rendered output texture
 		ci::gl::TextureRef		getFinalOutTexture();
@@ -843,6 +843,7 @@ namespace ui {
 
 		ci::gl::TextureRef		mShaderTexture;
 		ci::gl::FboRef			mOutputFbo;
+		ci::gl::Fbo::Format		mFboFormat;
 		bool					mIsRenderFinalToTexture;
 
 		ci::vec4				mShaderExtraData;

--- a/src/ds/ui/sprite/util/blend.cpp
+++ b/src/ds/ui/sprite/util/blend.cpp
@@ -12,6 +12,9 @@ void applyBlendingMode(const BlendMode &blendMode){
 	if(blendMode == NORMAL) {
 		glBlendEquation(GL_FUNC_ADD);
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	} else if(blendMode == PREMULTIPLY) {
+		glBlendEquation(GL_FUNC_ADD);
+		glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 	} else if(blendMode == MULTIPLY) {
 		glBlendEquation(GL_FUNC_ADD);
 		glBlendFunc(GL_DST_COLOR, GL_ONE_MINUS_SRC_ALPHA);
@@ -46,6 +49,8 @@ ds::ui::BlendMode getBlendModeByString(const std::string& blendString){
 	std::transform(lowerString.begin(), lowerString.end(), lowerString.begin(), ::tolower);
 	if(lowerString == "add"){
 		return ADD;
+	} else if(lowerString == "premultiply"){
+		return PREMULTIPLY;
 	} else if(lowerString == "subtract"){
 		return SUBTRACT;
 	} else if(lowerString == "multiply"){
@@ -70,6 +75,8 @@ ds::ui::BlendMode getBlendModeByString(const std::string& blendString){
 const std::string getStringForBlendMode(const BlendMode& blendMode){
 	if(blendMode == NORMAL) {
 		return "normal";
+	} else if(blendMode == PREMULTIPLY) {
+		return "premultiply";
 	} else if(blendMode == MULTIPLY) {
 		return "multiply";
 	} else if(blendMode == SCREEN) {
@@ -94,6 +101,8 @@ const std::string getStringForBlendMode(const BlendMode& blendMode){
 bool premultiplyAlpha(const BlendMode &blendMode){
 	if(blendMode == NORMAL) {
 		return false;
+	} else if(blendMode == PREMULTIPLY) {
+		return true;
 	} else if(blendMode == MULTIPLY) {
 		return true;
 	} else if(blendMode == SCREEN) {

--- a/src/ds/ui/sprite/util/blend.h
+++ b/src/ds/ui/sprite/util/blend.h
@@ -17,7 +17,8 @@ enum BlendMode
   LIGHTEN,
   DARKEN,
   TRANSPARENT_BLACK,
-  EXCLUSION
+  EXCLUSION,
+  PREMULTIPLY
 };
 
 BlendMode getBlendModeByString(const std::string& blendString);


### PR DESCRIPTION
I added the option to set the FBO format when setting a sprite as finalRenderToTexture, so now we're able to tune the antialiasing and other texture properties.

I also added a blend mode for premultiplied-alpha drawing, which is needed to remove the dark halo effect created when drawing semi-transparent images into an FBO.