### PR TITLE
Engine: add setting for screen:auto_size. See comment

### DIFF
--- a/src/ds/app/engine/engine.h
+++ b/src/ds/app/engine/engine.h
@@ -208,7 +208,8 @@ public:
 	ds::ui::Sprite*						getHit(const ci::vec3& point);
 
 	ui::TouchManager&					getTouchManager(){ return mTouchManager; }
-	virtual void						clearFingers( const std::vector<int> &fingers );
+	virtual void						clearFingers(const std::vector<int> &fingers);
+	virtual void						clearFingersForSprite(ui::Sprite* theSprite) { mTouchManager.clearFingersForSprite(theSprite); }
 	void								setSpriteForFinger( const int fingerId, ui::Sprite* theSprite ){ mTouchManager.setSpriteForFinger(fingerId, theSprite); }
 	ds::ui::Sprite*						getSpriteForFinger( const int fingerId ){ return mTouchManager.getSpriteForFinger(fingerId); }
 	virtual bool						shouldDiscardTouch( ci::vec2& p ){ return mTouchManager.shouldDiscardTouch(p); }

--- a/src/ds/app/engine/engine_settings.cpp
+++ b/src/ds/app/engine/engine_settings.cpp
@@ -13,6 +13,7 @@ namespace {
 std::string			PROJECT_PATH;
 // The configuration settings
 std::string			CONFIGURATION_FOLDER;
+std::string			CONFIGURATION_OVERRIDE_FOLDER;
 
 static bool			get_key_value(const std::string& arg, std::string& key, std::string& value) {
 	const std::string	SEP_SZ("=");
@@ -136,6 +137,10 @@ void EngineSettings::loadInitialSettings() {
 		? mConfiguration.getString("folder", 0, "")
 		: commandLineAppConfig;
 
+	if(!CONFIGURATION_OVERRIDE_FOLDER.empty()){
+		CONFIGURATION_FOLDER = CONFIGURATION_OVERRIDE_FOLDER;
+	}
+
 	// If the folder exists, then apply any changes to the engine file
 	if(!CONFIGURATION_FOLDER.empty()) {
 		const std::string		app = ds::Environment::expand("%APP%/settings/%CFG_FOLDER%/" + appFilename);
@@ -184,6 +189,7 @@ void EngineSettings::setDefaults(){
 	getSetting("screen:title", 0, ds::cfg::SETTING_TYPE_STRING, "The title of the window. Generally only displays if the screen mode is windowed.");
 	getSetting("screen:mode", 0, ds::cfg::SETTING_TYPE_STRING,  "How the primary window displays, including fullscreen", "borderless", "", "", "window, borderless, fullscreen");
 	getSetting("screen:always_on_top", 0, ds::cfg::SETTING_TYPE_BOOL, "Makes the window an always-on-top sort of window.", "false");
+	getSetting("screen:auto_size", 0, ds::cfg::SETTING_TYPE_STRING, "Classic uses the old src_rect/dst_rect and span_all_displays; letterbox will letterbox to your main monitor; all_span spans all displays; main_span fills the main display. letterbox requires having a world size set.", "classic", "", "", "classic, letterbox, all_span, main_span");
 	getSetting("console:show", 0, ds::cfg::SETTING_TYPE_BOOL, "Show console will create a console window, or not if this is false.", "false");
 	getSetting("idle_time", 0, ds::cfg::SETTING_TYPE_DOUBLE, "Seconds before idle happens. 300 = 5 minutes.", "300", "0", "1000");
 	getSetting("system:never_sleep", 0, ds::cfg::SETTING_TYPE_BOOL, "Prevent the system from sleeping or powering off the screen", "true");
@@ -250,6 +256,11 @@ void EngineSettings::setDefaults(){
 	getSetting("metrics:udp_host", 0, ds::cfg::SETTING_TYPE_STRING, "The host name to send udp metrics info to", "127.0.0.1");
 	getSetting("metrics:udp_port", 0, ds::cfg::SETTING_TYPE_STRING, "The port to send udp metrics info to", "8094");
 
+}
+
+
+void EngineSettings::setConfigurationOverride(std::string overrideFolder) {
+	CONFIGURATION_OVERRIDE_FOLDER = overrideFolder;
 }
 
 const std::string& EngineSettings::getConfigurationFolder() {

--- a/src/ds/app/engine/engine_settings.cpp
+++ b/src/ds/app/engine/engine_settings.cpp
@@ -261,6 +261,7 @@ void EngineSettings::setDefaults(){
 
 void EngineSettings::setConfigurationOverride(std::string overrideFolder) {
 	CONFIGURATION_OVERRIDE_FOLDER = overrideFolder;
+	CONFIGURATION_FOLDER = overrideFolder;
 }
 
 const std::string& EngineSettings::getConfigurationFolder() {

--- a/src/ds/app/engine/engine_settings.h
+++ b/src/ds/app/engine/engine_settings.h
@@ -40,6 +40,10 @@ public:
 
 	void							printStartupInfo();
 	bool							getUsingDefault() const { return !mLoadedAnySettings; };
+
+	/// anything set here during runtime will override any startup arguments or configuration.xml settings
+	/// note that this does not have an immediate effect - an app soft restart is required
+	static void						setConfigurationOverride(std::string overrideFolder);
 	static const std::string&		getConfigurationFolder();
 	static const std::string&		envProjectPath();
 	void							loadInitialSettings();

--- a/src/ds/data/color_list.cpp
+++ b/src/ds/data/color_list.cpp
@@ -5,14 +5,9 @@
 namespace ds {
 
 namespace {
-const size_t			EMPTY_ID(0);
-const std::string		EMPTY_SZ("");
 const ci::ColorA		EMPTY_COL(255, 0, 255, 255);
 }
 
-/**
-* ds::FontList
-*/
 ColorList::ColorList(){
 }
 
@@ -24,35 +19,15 @@ bool ColorList::empty() const{
 	return (mData.empty());
 }
 
-
 void ColorList::install(const ci::ColorA& color, const std::string& shortName){
-	const size_t     id = mData.size() + 1;
-	mData[id] = Entry(color, shortName);
-}
-
-size_t ColorList::getIdFromName(const std::string& n) const{
-	if(mData.empty()) return EMPTY_ID;
-	for(auto it = mData.begin(), end = mData.end(); it != end; ++it) {
-		if(it->second.mShortName == n) return it->first;
-	}
-	return EMPTY_ID;
-}
-
-const ci::ColorA& ColorList::getColorFromId(const size_t id) const{
-	if(mData.empty()) return EMPTY_COL;
-	auto it = mData.find(id);
-	if(it != mData.end()) {
-		return it->second.mColor;
-	}
-	return EMPTY_COL;
+	mData[shortName] = color;
 }
 
 const ci::ColorA& ColorList::getColorFromName(const std::string& n) const{
 	if(mData.empty()) return EMPTY_COL;
-	for(auto it = mData.begin(), end = mData.end(); it != end; ++it) {
-		if(it->second.mShortName == n){
-			return it->second.mColor;
-		}
+	auto findy = mData.find(n);
+	if(findy != mData.end()){
+		return findy->second;
 	}
 	return EMPTY_COL;
 }

--- a/src/ds/data/color_list.h
+++ b/src/ds/data/color_list.h
@@ -1,6 +1,4 @@
 #pragma once
-#ifndef DS_DATA_COLORLIST_H_
-#define DS_DATA_COLORLIST_H_
 
 #include <string>
 #include <unordered_map>
@@ -8,10 +6,6 @@
 
 namespace ds {
 
-/**
-* \class FontList
-* \brief A list of colors. Used to create a central color pallet usable by layout xmls.
-*/
 class ColorList
 {
 public:
@@ -22,25 +16,14 @@ public:
 
 	/// Short name can be supplied by the app and used to refer to colors from now on.
 	/// Often it might be something in a settings file.
-	void					install(const ci::ColorA& color, const std::string& shortName = "");
-	/// Answer > 0 for a valid ID. Name can either be the file or short name, which should never conflict.
-	size_t 					getIdFromName(const std::string&) const;
-	const ci::ColorA&		getColorFromId(const size_t id) const;
+	void					install(const ci::ColorA& color, const std::string& shortName);
+
 	/// Clients give either a shortname and I give them a color
 	const ci::ColorA&		getColorFromName(const std::string&) const;
 	const ci::ColorA&		getColorFromName(const std::wstring&) const;
 
 private:
-	class Entry {
-	public:
-		Entry()           { }
-		Entry(const ci::ColorA& color, const std::string& name) : mColor(color), mShortName(name) { }
-		ci::ColorA		  mColor;
-		std::string       mShortName;
-	};
-	std::unordered_map<size_t, Entry>	mData;
+	std::unordered_map<std::string, ci::ColorA> mData;
 };
 
 } // namespace ds
-
-#endif // DS_DATA_COLORLIST_H_

--- a/src/ds/ui/sprite/sprite.cpp
+++ b/src/ds/ui/sprite/sprite.cpp
@@ -203,6 +203,8 @@ Sprite::~Sprite() {
 	animStop();
 	cancelDelayedCall();
 
+	mEngine.clearFingersForSprite(this);
+
 	mEngine.removeFromDragDestinationList(this);
 
 	// We only want to request a delete for the sprite at the head of a tree,

--- a/src/ds/ui/sprite/sprite_engine.h
+++ b/src/ds/ui/sprite/sprite_engine.h
@@ -176,6 +176,7 @@ public:
 	virtual bool					isIdling() = 0;
 
 	virtual void					clearFingers( const std::vector<int> &fingers );
+	virtual void					clearFingersForSprite(ui::Sprite* theSprite) {};
 	virtual void					setSpriteForFinger( const int fingerId, ui::Sprite* theSprite ) = 0;
 	virtual ui::Sprite*				getSpriteForFinger( const int fingerId ) = 0;
 

--- a/src/ds/ui/touch/touch_manager.cpp
+++ b/src/ds/ui/touch/touch_manager.cpp
@@ -390,6 +390,15 @@ Sprite* TouchManager::getSpriteForFinger( const int fingerId ){
 	return mFingerDispatcher[fingerId];
 }
 
+
+void TouchManager::clearFingersForSprite(ui::Sprite* theSprite) {
+	for (auto& it : mFingerDispatcher) {
+		if(it.second == theSprite){
+			it.second = nullptr;
+		}
+	}
+}
+
 Sprite* TouchManager::getHit(const ci::vec3 &point) {
 	return mEngine.getHit(point);
 }

--- a/src/ds/ui/touch/touch_manager.h
+++ b/src/ds/ui/touch/touch_manager.h
@@ -55,6 +55,8 @@ public:
 	void									setSpriteForFinger(const int fingerId, ui::Sprite* theSprite);
 	Sprite*									getSpriteForFinger(const int fingerId);
 
+	void									clearFingersForSprite(ui::Sprite* theSprite);
+
 	void									setOverrideTranslation(const bool doOverride){ mOverrideTranslation = doOverride; }
 	void									setOverrideDimensions(const ci::vec2& dimensions){ mTouchDimensions = dimensions; }
 	void									setOverrideOffset(const ci::vec2& offset){ mTouchOffset = offset; }


### PR DESCRIPTION
<setting name="screen:auto_size" value="letterbox" type="string" comment="Classic uses the old src_rect/dst_rect and span_all_displays; letterbox will letterbox to your main monitor; all_span spans all displays; main_span fills the main display. letterbox requires having a world size set." default="classic" possibles="classic, letterbox, all_span, main_span"/>