### PR TITLE
GStreamer Registry Path fix

### DIFF
--- a/projects/video/gstreamer-1.0/src/gstreamer/gstreamer_env_check.cpp
+++ b/projects/video/gstreamer-1.0/src/gstreamer/gstreamer_env_check.cpp
@@ -36,7 +36,7 @@ bool EnvCheck::addGStreamerBinPath(){
 	// If we manually set the registry to the app directory, it can avoid some issues
 	std::string registryPath{ getEnv("GST_REGISTRY_1_0") };
 	if(registryPath.empty()) {
-		std::string localRegistryPath = ds::Environment::expand("%APP%");
+		std::string localRegistryPath = ds::Environment::expand("%APP%/.gstcache");
 		ds::Environment::replaceEnvironmentVariable("GST_REGISTRY_1_0", localRegistryPath);
 	}
 


### PR DESCRIPTION
This should allow gstreamer to successfully create a plugin registry in the application root. Should still respect GST_REGISTRY_1_0 environment variable if it exists. If it is working you will have a file called .gstcache in the application directory. (same directory as /data and /settings