### PR TITLE
[F] Added loaded state/callback and animation ended callback.

### DIFF
--- a/projects/essentials/src/ds/ui/sprite/png_sequence_sprite.cpp
+++ b/projects/essentials/src/ds/ui/sprite/png_sequence_sprite.cpp
@@ -59,7 +59,7 @@ void PngSequenceSprite::setImages(const std::vector<std::string>& imageFiles){
 	}
 	
 	// Create new empty frame sprites as needed
-	while(mFrames.size() <= mNumFrames){
+	while(mFrames.size() < mNumFrames){
 		ds::ui::Image* img = new ds::ui::Image(mEngine);
 		addChildPtr(img); // More idiomatic
 		img->hide();

--- a/projects/essentials/src/ds/ui/sprite/png_sequence_sprite.cpp
+++ b/projects/essentials/src/ds/ui/sprite/png_sequence_sprite.cpp
@@ -14,8 +14,11 @@ PngSequenceSprite::PngSequenceSprite(SpriteEngine& engine, const std::vector<std
 	, mLoopStyle(Loop)
 	, mCurrentFrameIndex(0)
 	, mPlaying(true)
+	, mIsLoaded(false)
 	, mFrameTime(0.0f)
 	, mNumFrames(0)
+	, mAnimationEndedCallback(nullptr)
+	, mLoadedCallback(nullptr)
 {
 	mLayoutFixedAspect = true;
 	setImages(imageFiles);
@@ -32,6 +35,7 @@ PngSequenceSprite::PngSequenceSprite(SpriteEngine& engine)
 	, mLoopStyle(Loop)
 	, mCurrentFrameIndex(0)
 	, mPlaying(true)
+	, mIsLoaded(false)
 	, mFrameTime(0.0f)
 	, mNumFrames(0)
 {
@@ -41,19 +45,19 @@ PngSequenceSprite::PngSequenceSprite(SpriteEngine& engine)
 
 void PngSequenceSprite::setImages(const std::vector<std::string>& imageFiles){
 	mVisibleFrame = nullptr;
-	int i=0;
-	for(auto it = imageFiles.begin(); it < imageFiles.end(); ++it){
+	int i = 0;
+	for (auto it = imageFiles.begin(); it < imageFiles.end(); ++it) {
 		bool created_new_frames = false;
-		while ( mFrames.size() < i+1 ) {
-			ds::ui::Image* img = new ds::ui::Image( mEngine, (*it), ds::ui::Image::IMG_CACHE_F | ds::ui::Image::IMG_PRELOAD_F );
-			addChild( *img );
+		while (mFrames.size() < i + 1) {
+			ds::ui::Image* img = new ds::ui::Image(mEngine, (*it), ds::ui::Image::IMG_CACHE_F | ds::ui::Image::IMG_PRELOAD_F);
+			addChild(*img);
 			img->hide();
-			mFrames.push_back( img );
+			mFrames.push_back(img);
 			created_new_frames = true;
 		}
 
 		if (!created_new_frames)
-			mFrames[i]->setImageFile( *it, ds::ui::Image::IMG_CACHE_F | ds::ui::Image::IMG_PRELOAD_F );
+				mFrames[i]->setImageFile(*it, ds::ui::Image::IMG_CACHE_F | ds::ui::Image::IMG_PRELOAD_F);
 
 		i++;
 	}
@@ -61,10 +65,10 @@ void PngSequenceSprite::setImages(const std::vector<std::string>& imageFiles){
 	mNumFrames = static_cast<int>(imageFiles.size());
 
 	// Hide all the old frames if there were previously more frames than there are now
-	for ( i=mNumFrames; i<mFrames.size(); i++ )
+		for (i = mNumFrames; i < mFrames.size(); i++)
 		mFrames[i]->hide();
 
-	if( mNumFrames == 0 ){
+		if (mNumFrames == 0) {
 		DS_LOG_WARNING("Png Sequence didn't load any frames. Whoops.");
 		mPlaying = false;
 		return;
@@ -97,8 +101,12 @@ const bool PngSequenceSprite::isPlaying()const{
 	return mPlaying;
 }
 
-void PngSequenceSprite::setCurrentFrameIndex(const int frameIndex){
-	if(frameIndex < 0 || frameIndex > mNumFrames - 1) return;
+bool PngSequenceSprite::isLoaded() const {
+	return mIsLoaded;
+}
+
+void PngSequenceSprite::setCurrentFrameIndex(const int frameIndex) {
+	if (frameIndex < 0 || frameIndex > mNumFrames - 1) return;
 	mCurrentFrameIndex = frameIndex;
 
 	if (mVisibleFrame) {
@@ -130,28 +138,54 @@ void PngSequenceSprite::sizeToFirstImage(){
 	}
 }
 
-void PngSequenceSprite::onUpdateServer(const ds::UpdateParams& p){
+void PngSequenceSprite::setAnimationEndedCallback(const std::function<void()>& func){
+	mAnimationEndedCallback = func;
+}
+
+void PngSequenceSprite::setLoadedCallback(const std::function<void()>& func){
+	mLoadedCallback = func;
+}
+
+void PngSequenceSprite::onUpdateServer(const ds::UpdateParams& p) {
 	// Remove old (unused) Image sprites from the back of the frames if the count has changed...
-	while ( mFrames.size() > mNumFrames ) {
+	while (mFrames.size() > mNumFrames) {
 		auto last_frame = mFrames.back();
 		last_frame->release();
 		mFrames.pop_back();
 	}
 
-	if(mPlaying 
+	if (!isLoaded()) {
+		bool allFramesLoaded = true;
+		for (auto frame : mFrames) {
+			if (!frame->isLoaded()) {
+				allFramesLoaded = false;
+				break;
+			}
+		}
+
+		if (mIsLoaded != allFramesLoaded) {
+			mIsLoaded = allFramesLoaded;
+			if (mLoadedCallback && mIsLoaded) {
+				mLoadedCallback();
+			}
+		}
+	}
+
+	if (mPlaying
 	   && mNumFrames > 0
 	   && !mFrames.empty() 
-	   && mCurrentFrameIndex < mFrames.size() ){
+	   && mCurrentFrameIndex < mFrames.size()) {
 
 		bool advanceFrame(true);
 
-		if(mFrameTime > 0.0f){
+		if (mFrameTime > 0.0f) {
 			const double thisTime = ci::app::getElapsedSeconds();
 			const double deltaTime = thisTime - mLastFrameTime;
-			if(deltaTime > (double)mFrameTime){
+			if (deltaTime > (double)mFrameTime) {
 				advanceFrame = true;
 				mLastFrameTime = thisTime;
-			} else {
+			}
+			else {
 				advanceFrame = false;
 			}
 		}
@@ -189,7 +223,16 @@ void PngSequenceSprite::onUpdateServer(const ds::UpdateParams& p){
 			mVisibleFrame->show();
 		}
 
+		if (mPlaying
+			&& mNumFrames > 0
+			&& !mFrames.empty()
+			&& mAnimationEndedCallback
+			&& mCurrentFrameIndex == mFrames.size() - 1)
+		{
+			mAnimationEndedCallback();
+		}
 	}
 }
+
 } // namespace ui
 } // namespace ds

--- a/projects/essentials/src/ds/ui/sprite/png_sequence_sprite.h
+++ b/projects/essentials/src/ds/ui/sprite/png_sequence_sprite.h
@@ -44,6 +44,9 @@ PngSequenceSprite(SpriteEngine& engine, const std::vector<std::string>& imageFil
 	// Are the frames advancing?
 	const bool					isPlaying() const;
 
+	/// \brief returns true if all images are loaded.
+	virtual bool				isLoaded() const;
+
 	// Jump to a specific frame. 
 	// Frame indices outside the range of the frames are ignored.
 	void						setCurrentFrameIndex(const int frameIndex);
@@ -59,18 +62,29 @@ PngSequenceSprite(SpriteEngine& engine, const std::vector<std::string>& imageFil
 	// If there are no images, the size will be 0,0
 	void						sizeToFirstImage();
 
+	// Sets the callback that runs when an animation is done.
+	void                        setAnimationEndedCallback(const std::function<void()>& func);
+
+	// Sets the callback that is called when the images have all loaded.
+	void						setLoadedCallback(const std::function<void()>& func);
+
+
 private:
 	virtual void				onUpdateServer(const ds::UpdateParams& p) override;
+	void                        runAnimationEndedCallback();
 
 	LoopStyle					mLoopStyle;
 	int							mCurrentFrameIndex;
 	int							mNumFrames;
 	bool						mPlaying;
+	bool					    mIsLoaded;
 	float						mFrameTime;
 	double						mLastFrameTime;
 	std::vector<ds::ui::Image*>	mFrames;
-	ds::ui::Image*				mVisibleFrame = nullptr;
+	ds::ui::Image* mVisibleFrame = nullptr;
 
+	std::function<void()>       mAnimationEndedCallback;
+	std::function<void()>       mLoadedCallback;
 };
 
 } // namespace ui

--- a/projects/essentials/src/ds/ui/sprite/png_sequence_sprite.h
+++ b/projects/essentials/src/ds/ui/sprite/png_sequence_sprite.h
@@ -68,11 +68,16 @@ PngSequenceSprite(SpriteEngine& engine, const std::vector<std::string>& imageFil
 	// Sets the callback that is called when the images have all loaded.
 	void						setLoadedCallback(const std::function<void()>& func);
 
+	/// Change image flags used for internal Image sprites.
+	/// Default is: ds::ui::Image::IMG_CACHE_F | ds::ui::Image::IMG_PRELOAD_F
+	void						setImageFlags(const int flags) { mImageFlags = flags;}
 
 private:
+	void						checkLoaded();
 	virtual void				onUpdateServer(const ds::UpdateParams& p) override;
 	void                        runAnimationEndedCallback();
 
+	int							mImageFlags =  ds::ui::Image::IMG_CACHE_F | ds::ui::Image::IMG_PRELOAD_F;
 	LoopStyle					mLoopStyle;
 	int							mCurrentFrameIndex;
 	int							mNumFrames;


### PR DESCRIPTION
During the PwC Global project, I found it useful to have an "animation ended" callback that we could call to trigger certain things throughout the app. I also found that the PngSequenceSprite images take a while to all load their frames and sometimes trying to do something with them before they've loaded everything can be bad, so I added an `isLoaded()` method to the class. To take that a step further, I added a callback that is called the moment that state changes. This could be used to do things like change the state of a parent or trigger actions elsewhere.

Apologies for the autoformatting. 