### PR TITLE
Pano cam updates tsd

### DIFF
--- a/projects/video/gstreamer-1.0/src/ds/ui/sprite/panoramic_video.h
+++ b/projects/video/gstreamer-1.0/src/ds/ui/sprite/panoramic_video.h
@@ -19,12 +19,14 @@ class PanoramicVideo : public ds::ui::Sprite
 {
 
 public:
-	PanoramicVideo(ds::ui::SpriteEngine&);
+	PanoramicVideo(ds::ui::SpriteEngine&, const bool textureInvertX = false);
 
 	virtual void		setResource(const ds::Resource& resource) override;
 	void				loadVideo(const std::string& videoPath);
 	ds::ui::Video*		getVideo() const;
 	void				resetCamera();
+	void setCameraRotation(ci::vec2 setter);
+	ci::vec2			getCameraRotation();
 
 
 	// Sets how fast dragging around is. Higher numbers are slower panning, lower numbers are faster
@@ -66,6 +68,7 @@ private:
 
 	bool				mInvertX;
 	bool				mInvertY;
+	bool				mTexInvertX;
 	float				mXSensitivity;
 	float				mYSensitivity;
 
@@ -78,6 +81,7 @@ private:
 	bool				mAutoSync;
 	std::string			mSphereVertexShader;
 	std::string			mSphereFragmentShader;
+	std::string			mSphereFragmentShaderInvertX;
 	ci::gl::GlslProgRef	mShader;
 
 	std::function<void(void)> mPanoTappedCb = nullptr;

--- a/projects/viewers/src/ds/ui/media/player/panoramic_video_player.cpp
+++ b/projects/viewers/src/ds/ui/media/player/panoramic_video_player.cpp
@@ -19,12 +19,13 @@
 namespace ds {
 namespace ui {
 
-PanoramicVideoPlayer::PanoramicVideoPlayer(ds::ui::SpriteEngine& eng, const bool embedInterface)
+PanoramicVideoPlayer::PanoramicVideoPlayer(ds::ui::SpriteEngine& eng, const bool embedInterface, const bool textureInvertX)
 	: ds::ui::Sprite(eng)
 	, mVideo(nullptr)
 	, mPanoramicVideo(nullptr)
 	, mVideoInterface(nullptr)
 	, mEmbedInterface(embedInterface)
+	, mTextureInvertX(textureInvertX)
 	, mInterfaceBelowMedia(false)
 	, mShowInterfaceAtStart(true)
 	, mAutoSyncronize(true)
@@ -45,7 +46,7 @@ void PanoramicVideoPlayer::setResource(const ds::Resource& resource) {
 
 	clear();
 
-	mPanoramicVideo = new ds::ui::PanoramicVideo(mEngine);
+	mPanoramicVideo = new ds::ui::PanoramicVideo(mEngine, mTextureInvertX);
 	addChildPtr(mPanoramicVideo);
 	mPanoramicVideo->setSize(1920.0f, 1080.0f);
 	mPanoramicVideo->loadVideo(resource.getAbsoluteFilePath());

--- a/projects/viewers/src/ds/ui/media/player/panoramic_video_player.h
+++ b/projects/viewers/src/ds/ui/media/player/panoramic_video_player.h
@@ -21,7 +21,7 @@ struct MediaViewerSettings;
 */
 class PanoramicVideoPlayer : public ds::ui::Sprite {
 public:
-	PanoramicVideoPlayer(ds::ui::SpriteEngine& eng, const bool embedInterface = true);
+	PanoramicVideoPlayer(ds::ui::SpriteEngine& eng, const bool embedInterface = true, const bool textureInvertX = false);
 
 	virtual void						setResource(const ds::Resource& resource) override;
 	void								setMedia(const std::string mediaPath);
@@ -84,6 +84,7 @@ protected:
 	ds::ui::GstVideo*							mVideo;
 	bool										mEmbedInterface;
 	bool										mShowInterfaceAtStart;
+	bool										mTextureInvertX;
 	std::function<void(void)>					mGoodStatusCallback;
 	std::function<void(void)>					mVideoCompleteCallback;
 	std::function<void(const std::string&)>		mErrorMsgCallback;


### PR DESCRIPTION
Updates to panoramic video player so that the shader geometry can be flipped on instantiation in the special snowflake case of P57 Terrace Photo Opp, whereby the app needs to display a spherical video stream, but mirror it because it is a photobooth preview. Should be innocuous behavior to code predating this change.