### PR TITLE
Network request timeout

### DIFF
--- a/src/ds/network/http_client.h
+++ b/src/ds/network/http_client.h
@@ -56,11 +56,12 @@ class HttpClient : public ds::WorkClient {
 
 	void setResultHandler(const std::function<void(const HttpReply&)>&);
 
-	bool httpGet(const std::wstring& url);
-	bool httpPost(const std::wstring& url, const std::string& body);
-	bool httpPost(const std::wstring& url, const std::function<void(Poco::Net::HTMLForm&)>& postFn);
+	bool httpGet(const std::wstring& url, const int timeout = 30);
+	bool httpPost(const std::wstring& url, const std::string& body, const int timeout = 30);
+	bool httpPost(const std::wstring& url, const std::function<void(Poco::Net::HTMLForm&)>& postFn,
+				  const int timeout = 30);
 	bool http(const std::string& verb, const std::string& url, const std::string& body,
-			  const std::function<void(Poco::Net::HTTPRequest&)>& postFn);
+			  const std::function<void(Poco::Net::HTTPRequest&)>& postFn, const int timeout = 30);
 
   protected:
 	virtual void handleResult(std::unique_ptr<WorkRequest>&);
@@ -77,6 +78,7 @@ class HttpClient : public ds::WorkClient {
 		std::string	 mVerb;
 		std::wstring mUrl;
 		std::string	 mBody;
+		int			 mTimeout;
 		/// Utility to write multipart form data in a post
 		std::function<void(Poco::Net::HTMLForm&)> mPostFn;
 		/// Utility to write to the message
@@ -94,7 +96,8 @@ class HttpClient : public ds::WorkClient {
   private:
 	bool		sendHttp(const int opt, const std::string& verb, const std::wstring& url, const std::string& body,
 						 const std::function<void(Poco::Net::HTMLForm&)>&	 postFn,
-						 const std::function<void(Poco::Net::HTTPRequest&)>& requestFn = nullptr);
+						 const std::function<void(Poco::Net::HTTPRequest&)>& requestFn = nullptr,
+						 const int timeout = 30);
 	static bool httpAndReply(const int opt, const std::wstring& url, const std::string& body,
 							 const std::function<void(Poco::Net::HTMLForm&)>& postFn, ds::HttpReply*);
 };

--- a/src/ds/network/https_client.cpp
+++ b/src/ds/network/https_client.cpp
@@ -15,7 +15,7 @@ namespace ds { namespace net {
 	}
 
 	void HttpsRequest::makeSyncGetRequest(const std::string& url, const bool peerVerify, const bool hostVerify,
-										  const bool isDownloadMedia, const std::string& downloadfile) {
+										  const bool isDownloadMedia, const std::string& downloadfile, const long timeout) {
 		if (url.empty()) {
 			DS_LOG_WARNING("Couldn't make a get request in HttpsRequest because the url is empty");
 			return;
@@ -23,7 +23,8 @@ namespace ds { namespace net {
 
 		DS_LOG_VERBOSE(2, "HttpsRequest::makeGetRequest url=" << url << " peer=" << peerVerify << " host=" << hostVerify
 															  << " isDownload=" << isDownloadMedia
-															  << " downloadFile=" << downloadfile);
+															  << " downloadFile=" << downloadfile
+															  << " timeout=" << timeout);
 
 		IndividualRequest req;
 		req.mInput			 = url;
@@ -33,11 +34,12 @@ namespace ds { namespace net {
 		req.mVerboseOutput	 = mVerbose;
 		req.mIsDownloadMedia = isDownloadMedia;
 		req.mDownloadFile	 = downloadfile;
+		req.mTimeout		 = timeout;
 		req.run();
 	}
 
 	void HttpsRequest::makeGetRequest(const std::string& url, const bool peerVerify, const bool hostVerify,
-									  const bool isDownloadMedia, const std::string& downloadfile) {
+									  const bool isDownloadMedia, const std::string& downloadfile, const long timeout) {
 		if (url.empty()) {
 			DS_LOG_WARNING("Couldn't make a get request in HttpsRequest because the url is empty");
 			return;
@@ -45,9 +47,10 @@ namespace ds { namespace net {
 
 		DS_LOG_VERBOSE(2, "HttpsRequest::makeGetRequest url=" << url << " peer=" << peerVerify << " host=" << hostVerify
 															  << " isDownload=" << isDownloadMedia
-															  << " downloadFile=" << downloadfile);
+															  << " downloadFile=" << downloadfile
+															  << " timeout=" << timeout);
 
-		mRequests.start([this, url, peerVerify, hostVerify, isDownloadMedia, downloadfile](IndividualRequest& q) {
+		mRequests.start([this, url, peerVerify, hostVerify, isDownloadMedia, downloadfile, timeout](IndividualRequest& q) {
 			q.mInput		   = url;
 			q.mVerifyHost	   = hostVerify;
 			q.mVerifyPeers	   = peerVerify;
@@ -55,12 +58,13 @@ namespace ds { namespace net {
 			q.mVerboseOutput   = mVerbose;
 			q.mIsDownloadMedia = isDownloadMedia;
 			q.mDownloadFile	   = downloadfile;
+			q.mTimeout		   = timeout;
 		});
 	}
 
 	void HttpsRequest::makeGetRequest(const std::string& url, std::vector<std::string> headers, const bool peerVerify,
 									  const bool hostVerify, const bool isDownloadMedia,
-									  const std::string& downloadfile) {
+									  const std::string& downloadfile, const long timeout) {
 		if (url.empty()) {
 			DS_LOG_WARNING("Couldn't make a get request in HttpsRequest because the url is empty");
 			return;
@@ -68,10 +72,11 @@ namespace ds { namespace net {
 
 		DS_LOG_VERBOSE(2, "HttpsRequest::makeGetRequest url=" << url << " peer=" << peerVerify << " host=" << hostVerify
 															  << " isDownload=" << isDownloadMedia
-															  << " downloadFile=" << downloadfile);
+															  << " downloadFile=" << downloadfile
+															  << " timeout=" << timeout);
 
 		mRequests.start(
-			[this, url, peerVerify, hostVerify, headers, isDownloadMedia, downloadfile](IndividualRequest& q) {
+			[this, url, peerVerify, hostVerify, headers, isDownloadMedia, downloadfile, timeout](IndividualRequest& q) {
 				q.mInput		   = url;
 				q.mVerifyHost	   = hostVerify;
 				q.mVerifyPeers	   = peerVerify;
@@ -80,13 +85,15 @@ namespace ds { namespace net {
 				q.mHeaders		   = headers;
 				q.mIsDownloadMedia = isDownloadMedia;
 				q.mDownloadFile	   = downloadfile;
+				q.mTimeout		   = timeout;
 			});
 	}
 
 	void HttpsRequest::makeSyncPostRequest(const std::string& url, const std::string& postData,
 										   const bool peerVerify /*= true*/, const bool hostVerify /*= true*/,
 										   const std::string& customRequest, std::vector<std::string> headers,
-										   const bool isDownloadMedia, const std::string& downloadfile) {
+										   const bool isDownloadMedia, const std::string& downloadfile,
+										   const long timeout) {
 		if (url.empty()) {
 			DS_LOG_WARNING("Couldn't make a post request in HttpsRequest because the url is empty");
 			return;
@@ -94,7 +101,7 @@ namespace ds { namespace net {
 
 		DS_LOG_VERBOSE(2, "HttpsRequest::makePostRequest url="
 							  << url << " postData=" << postData << " peer=" << peerVerify << " host=" << hostVerify
-							  << " isDownload=" << isDownloadMedia << " downloadFile=" << downloadfile);
+							  << " isDownload=" << isDownloadMedia << " downloadFile=" << downloadfile << " timeout=" << timeout);
 
 		IndividualRequest req;
 		req.mInput			 = url;
@@ -104,13 +111,15 @@ namespace ds { namespace net {
 		req.mVerboseOutput	 = mVerbose;
 		req.mIsDownloadMedia = isDownloadMedia;
 		req.mDownloadFile	 = downloadfile;
+		req.mTimeout		 = timeout;
 		req.run();
 	}
 
 	void HttpsRequest::makePostRequest(const std::string& url, const std::string& postData,
 									   const bool peerVerify /*= true*/, const bool hostVerify /*= true*/,
 									   const std::string& customRequest, std::vector<std::string> headers,
-									   const bool isDownloadMedia, const std::string& downloadfile) {
+									   const bool isDownloadMedia, const std::string& downloadfile,
+									   const long timeout) {
 		if (url.empty()) {
 			DS_LOG_WARNING("Couldn't make a post request in HttpsRequest because the url is empty");
 			return;
@@ -118,10 +127,10 @@ namespace ds { namespace net {
 
 		DS_LOG_VERBOSE(2, "HttpsRequest::makePostRequest url="
 							  << url << " postData=" << postData << " peer=" << peerVerify << " host=" << hostVerify
-							  << " isDownload=" << isDownloadMedia << " downloadFile=" << downloadfile);
+							  << " isDownload=" << isDownloadMedia << " downloadFile=" << downloadfile << " timeout=" << timeout);
 
 		mRequests.start([this, url, postData, peerVerify, hostVerify, customRequest, headers, isDownloadMedia,
-						 downloadfile](IndividualRequest& q) {
+						 downloadfile, timeout](IndividualRequest& q) {
 			q.mInput		   = url;
 			q.mPostData		   = postData;
 			q.mVerifyHost	   = hostVerify;
@@ -132,6 +141,7 @@ namespace ds { namespace net {
 			q.mVerboseOutput   = mVerbose;
 			q.mIsDownloadMedia = isDownloadMedia;
 			q.mDownloadFile	   = downloadfile;
+			q.mTimeout		   = timeout;
 		});
 	}
 
@@ -206,7 +216,8 @@ namespace ds { namespace net {
 		CURL* curl = curl_easy_init();
 		if (curl) {
 
-			curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 30L);
+			curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, mTimeout);
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT, mTimeout);
 
 			if (mVerboseOutput) {
 				curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);

--- a/src/ds/network/https_client.h
+++ b/src/ds/network/https_client.h
@@ -26,13 +26,15 @@ namespace ds { namespace net {
 		/// verifyHosts if false will use try to connect even if the certificate doesn't match the domain (Much less
 		/// secure)
 		void makeGetRequest(const std::string& url, const bool verifyPeers = true, const bool verifyHosts = true,
-							const bool isDownloadMedia = false, const std::string& downloadfile = "");
+							const bool isDownloadMedia = false, const std::string& downloadfile = "",
+							const long timeout = 30L);
 		void makeGetRequest(const std::string& url, std::vector<std::string> headers, const bool verifyPeers = true,
 							const bool verifyHosts = true, const bool isDownloadMedia = false,
-							const std::string& downloadfile = "");
+							const std::string& downloadfile = "", const long timeout = 30L);
 		/// Same as makeGetRequest, but runs syncronously
 		void makeSyncGetRequest(const std::string& url, const bool verifyPeers = true, const bool verifyHosts = true,
-								const bool isDownloadMedia = false, const std::string& downloadfile = "");
+								const bool isDownloadMedia = false, const std::string& downloadfile = "",
+								const long timeout = 30L);
 
 		/// The url is the full request url
 		/// The postData is something like name=jeeves&project=ds_cinder
@@ -42,13 +44,15 @@ namespace ds { namespace net {
 		void makePostRequest(const std::string& url, const std::string& postData, const bool verifyPeers = true,
 							 const bool verifyHosts = true, const std::string& customrequest = "",
 							 std::vector<std::string> headers = std::vector<std::string>(),
-							 const bool isDownloadMedia = false, const std::string& downloadfile = "");
+							 const bool isDownloadMedia = false, const std::string& downloadfile = "",
+							 const long timeout = 30L);
 
 		/// Same as makePostRequest, but runs syncronously
 		void makeSyncPostRequest(const std::string& url, const std::string& postData, const bool verifyPeers = true,
 								 const bool verifyHosts = true, const std::string& customrequest = "",
 								 std::vector<std::string> headers = std::vector<std::string>(),
-								 const bool isDownloadMedia = false, const std::string& downloadfile = "");
+								 const bool isDownloadMedia = false, const std::string& downloadfile = "",
+								 const long timeout = 30L);
 
 		/// If errored == true, then something went wrong and the reply will have the error message
 		/// Otherwise it will be whatever was returned from the server
@@ -85,6 +89,7 @@ namespace ds { namespace net {
 			bool					 mVerboseOutput;
 			bool					 mIsDownloadMedia;
 			std::string				 mDownloadFile;
+			long					 mTimeout;
 		};
 
 		void																	onRequestComplete(IndividualRequest&);


### PR DESCRIPTION
### **Problem:**
Timeouts were broken for HTTPS requests, and were non-configurable (hard-coded 30 seconds) for both HTTP and HTTPS requests.

### **Solution:**
Followed [this CURL documentation](https://curl.se/libcurl/c/CURLOPT_TIMEOUT.html) to fix HTTPS request timeout (keeping old style as well in case of unknown applicability), and gave both HTTP and HTTPS requests an optional timeout parameter (default of 30).

### **Example:**
[Hartford Steam Boiler Hallway Application](https://github.com/Unispace365/hsb_hallway) API Call [snippet](https://github.com/Unispace365/hsb_hallway/blob/master/src/utility/api_sensor_handler.cpp#L139-L140)
```
long timeout = mEngine.getAppSettings().getInt("api:timeout:seconds", 0, 20);
mHttpsRequest.makePostRequest(sensorUrl, data, true, true, "", headers, false, "", timeout);
```