### PR TITLE
Video volume control

### DIFF
--- a/projects/viewers/src/ds/ui/media/interface/video_volume_control.cpp
+++ b/projects/viewers/src/ds/ui/media/interface/video_volume_control.cpp
@@ -56,7 +56,7 @@ void VideoVolumeControl::setStyle(VideoVolumeStyle newStyle) {
 		}
 
 	} else if (mStyle == VideoVolumeStyle::SLIDER) {
-		setSize(mTheSize * 2.25f, mTheSize);
+		setSize(mTheSize * 2.f, mTheSize);
 		// Slider is made up of 3 parts:
 		// 'mute' - Button to toggle between muted / unmuted
 		// 'track' - the background of the slider showing it's overall length

--- a/projects/viewers/src/ds/ui/media/interface/video_volume_control.cpp
+++ b/projects/viewers/src/ds/ui/media/interface/video_volume_control.cpp
@@ -175,21 +175,19 @@ void VideoVolumeControl::onUpdateServer(const ds::UpdateParams& updateParams) {
 				}
 			}
 		} else if (mStyle == VideoVolumeStyle::SLIDER) {
+			const auto imageFlags = ds::ui::Image::IMG_ENABLE_MIPMAP_F | ds::ui::Image::IMG_CACHE_F;
+
 			if (isMuted || vol <= std::numeric_limits<float>::epsilon()) {
-				mSliderSprites.mMuteButton->setNormalImage(mMuteImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
-																		   ds::ui::Image::IMG_CACHE_F);
-				mSliderSprites.mMuteButton->setHighImage((mLastVolume < 0.5f) ? mVolumeLowImage : mVolumeHighImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
-																		 ds::ui::Image::IMG_CACHE_F);
+				mSliderSprites.mMuteButton->setNormalImage(mMuteImage, imageFlags);
+
+				const auto& highImage = (mLastVolume < 0.5f) ? mVolumeLowImage : mVolumeHighImage;
+				mSliderSprites.mMuteButton->setHighImage(highImage, imageFlags);
 			} else if (vol < 0.5f) {
-				mSliderSprites.mMuteButton->setNormalImage(mVolumeLowImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
-																				ds::ui::Image::IMG_CACHE_F);
-				mSliderSprites.mMuteButton->setHighImage(mMuteImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
-																			  ds::ui::Image::IMG_CACHE_F);
+				mSliderSprites.mMuteButton->setNormalImage(mVolumeLowImage, imageFlags);
+				mSliderSprites.mMuteButton->setHighImage(mMuteImage, imageFlags);
 			} else {
-				mSliderSprites.mMuteButton->setNormalImage(mVolumeHighImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
-																				 ds::ui::Image::IMG_CACHE_F);
-				mSliderSprites.mMuteButton->setHighImage(mMuteImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
-																			   ds::ui::Image::IMG_CACHE_F);
+				mSliderSprites.mMuteButton->setNormalImage(mVolumeHighImage, imageFlags);
+				mSliderSprites.mMuteButton->setHighImage(mMuteImage, imageFlags);
 			}
 
 			mSliderSprites.mSliderFill->setSize(vol * mSliderSprites.mSliderTrack->getWidth(),

--- a/projects/viewers/src/ds/ui/media/interface/video_volume_control.cpp
+++ b/projects/viewers/src/ds/ui/media/interface/video_volume_control.cpp
@@ -16,7 +16,7 @@ namespace ds::ui {
 
 VideoVolumeControl::VideoVolumeControl(ds::ui::SpriteEngine& eng, const float theSize, const float buttHeight,
 									   const ci::Color interfaceColor, VideoVolumeStyle style)
-  : ds::ui::Sprite(eng, theSize * 2.5f, theSize)
+  : ds::ui::Sprite(eng, theSize * 1.5f, theSize)
   , mStyle(style)
   , mLinkedVideo(nullptr)
   , mLinkedYouTube(nullptr)
@@ -34,6 +34,7 @@ void VideoVolumeControl::setStyle(VideoVolumeStyle newStyle) {
 	clearChildren();
 	mBars.clear();
 	if (mStyle == VideoVolumeStyle::CLASSIC) {
+		setSize(mTheSize * 1.5f, mTheSize);
 		const int barCount = 5;
 
 		const float floatNumBars = (float)(barCount);
@@ -55,6 +56,7 @@ void VideoVolumeControl::setStyle(VideoVolumeStyle newStyle) {
 		}
 
 	} else if (mStyle == VideoVolumeStyle::SLIDER) {
+		setSize(mTheSize * 2.25f, mTheSize);
 		// Slider is made up of 3 parts:
 		// 'mute' - Button to toggle between muted / unmuted
 		// 'track' - the background of the slider showing it's overall length

--- a/projects/viewers/src/ds/ui/media/interface/video_volume_control.cpp
+++ b/projects/viewers/src/ds/ui/media/interface/video_volume_control.cpp
@@ -63,9 +63,10 @@ void VideoVolumeControl::setStyle(VideoVolumeStyle newStyle) {
 		// 'fill' - the filled portion of the slider
 		// 'nub' - the visual handle at the current slider position
 		mSliderSprites.mMuteButton =
-			new ds::ui::ImageButton(mEngine, mVolumeHighImage, mVolumeLowImage, (mTheSize - mButtHeight) / 2.0f);
-		mSliderSprites.mMuteButton->setScale(mTheSize / mSliderSprites.mMuteButton->getHeight());
-		mSliderSprites.mMuteButton->setCenter(0.0f, 0.5f);
+			new ds::ui::ImageButton(mEngine, mVolumeHighImage, mMuteImage, (mTheSize - mButtHeight) / 2.0f);
+		mSliderSprites.mMuteButton->setScale((mTheSize - (mButtHeight * 0.5f)) /
+											 mSliderSprites.mMuteButton->getHeight());
+		mSliderSprites.mMuteButton->setCenter(0.5f, 0.5f);
 		mSliderSprites.mMuteButton->setPosition(0.0f, getHeight() / 2.f);
 		mSliderSprites.mMuteButton->setClickFn([this] {
 			if (mMuted) {
@@ -76,7 +77,9 @@ void VideoVolumeControl::setStyle(VideoVolumeStyle newStyle) {
 		});
 		addChildPtr(mSliderSprites.mMuteButton);
 
-		ci::vec2 trackPos = ci::vec2(mSliderSprites.mMuteButton->getScaleWidth() + 8.f, getHeight() / 2.f);
+		auto muteOffset = mSliderSprites.mMuteButton->getScaleWidth() / 2.f; // Mute button is centered, only need half
+		const auto padding	= mSliderHeight;
+		ci::vec2   trackPos = ci::vec2(muteOffset + padding, getHeight() / 2.f);
 
 		mSliderSprites.mSliderTrack = new ds::ui::Sprite(mEngine, getWidth() - (trackPos.x), mSliderHeight);
 		mSliderSprites.mSliderTrack->setTransparent(false);
@@ -173,20 +176,20 @@ void VideoVolumeControl::onUpdateServer(const ds::UpdateParams& updateParams) {
 			}
 		} else if (mStyle == VideoVolumeStyle::SLIDER) {
 			if (isMuted || vol <= std::numeric_limits<float>::epsilon()) {
-				mSliderSprites.mMuteButton->setHighImage(mMuteImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
-																		 ds::ui::Image::IMG_CACHE_F);
 				mSliderSprites.mMuteButton->setNormalImage(mMuteImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
 																		   ds::ui::Image::IMG_CACHE_F);
+				mSliderSprites.mMuteButton->setHighImage((mLastVolume < 0.5f) ? mVolumeLowImage : mVolumeHighImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
+																		 ds::ui::Image::IMG_CACHE_F);
 			} else if (vol < 0.5f) {
-				mSliderSprites.mMuteButton->setHighImage(mVolumeLowImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
-																			  ds::ui::Image::IMG_CACHE_F);
 				mSliderSprites.mMuteButton->setNormalImage(mVolumeLowImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
 																				ds::ui::Image::IMG_CACHE_F);
+				mSliderSprites.mMuteButton->setHighImage(mMuteImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
+																			  ds::ui::Image::IMG_CACHE_F);
 			} else {
-				mSliderSprites.mMuteButton->setHighImage(mVolumeHighImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
-																			   ds::ui::Image::IMG_CACHE_F);
 				mSliderSprites.mMuteButton->setNormalImage(mVolumeHighImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
 																				 ds::ui::Image::IMG_CACHE_F);
+				mSliderSprites.mMuteButton->setHighImage(mMuteImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
+																			   ds::ui::Image::IMG_CACHE_F);
 			}
 
 			mSliderSprites.mSliderFill->setSize(vol * mSliderSprites.mSliderTrack->getWidth(),

--- a/projects/viewers/src/ds/ui/media/interface/video_volume_control.cpp
+++ b/projects/viewers/src/ds/ui/media/interface/video_volume_control.cpp
@@ -5,23 +5,35 @@
 
 #include <ds/app/environment.h>
 #include <ds/debug/logger.h>
+#include <ds/ui/button/image_button.h>
 #include <ds/ui/sprite/sprite_engine.h>
 #include <ds/util/string_util.h>
 
 #include <ds/ui/media/player/youtube_player.h>
 #include <ds/ui/sprite/video.h>
 
-namespace ds { namespace ui {
+namespace ds::ui {
 
-	VideoVolumeControl::VideoVolumeControl(ds::ui::SpriteEngine& eng, const float theSize, const float buttHeight,
-										   const ci::Color interfaceColor)
-	  : ds::ui::Sprite(eng, theSize * 1.5f, theSize)
-	  , mLinkedVideo(nullptr)
-	  , mLinkedYouTube(nullptr)
-	  , mOffOpacity(0.2f) {
-		// setTransparent(false);
-		// setColor(ci::Color(0.5f, 0.0f, 0.0f));
+VideoVolumeControl::VideoVolumeControl(ds::ui::SpriteEngine& eng, const float theSize, const float buttHeight,
+									   const ci::Color interfaceColor, VideoVolumeStyle style)
+  : ds::ui::Sprite(eng, theSize * 2.5f, theSize)
+  , mStyle(style)
+  , mLinkedVideo(nullptr)
+  , mLinkedYouTube(nullptr)
+  , mInterfaceColor(interfaceColor)
+  , mTheSize(theSize)
+  , mButtHeight(buttHeight)
+  , mOffOpacity(0.2f) {
 
+	setStyle(mStyle);
+}
+
+void VideoVolumeControl::setStyle(VideoVolumeStyle newStyle) {
+	mStyle = newStyle;
+
+	clearChildren();
+	mBars.clear();
+	if (mStyle == VideoVolumeStyle::CLASSIC) {
 		const int barCount = 5;
 
 		const float floatNumBars = (float)(barCount);
@@ -30,76 +42,165 @@ namespace ds { namespace ui {
 		float		xp			 = 0.0f;
 
 		for (int k = 0; k < barCount; ++k) {
-			ds::ui::Sprite* s = new ds::ui::Sprite(mEngine, barWiddy, buttHeight * (float)(k + 1) / floatNumBars);
+			ds::ui::Sprite* s = new ds::ui::Sprite(mEngine, barWiddy, mButtHeight * (float)(k + 1) / floatNumBars);
 			if (!s) continue;
 			s->setTransparent(false);
 			s->setCenter(0.0f, 1.0f);
-			s->setColor(interfaceColor);
-			s->setPosition(xp, getHeight() / 2.0f + buttHeight / 2.0f);
+			s->setColor(mInterfaceColor);
+			s->setPosition(xp, getHeight() / 2.0f + mButtHeight / 2.0f);
 			mBars.push_back(s);
 			addChild(*s);
 
 			xp += barWiddy + gapPading;
 		}
 
-		enable(true);
-		enableMultiTouch(ds::ui::MULTITOUCH_INFO_ONLY);
-		setProcessTouchCallback([this](ds::ui::Sprite* bs, const ds::ui::TouchInfo& ti) {
-			if (ti.mFingerIndex != 0 || ti.mPhase == ds::ui::TouchInfo::Removed) return;
-			float local_x = globalToLocal(ti.mCurrentGlobalPoint).x;
-			if (local_x < 0.0f) {
-				setVolume(0.0f);
-			} else if (local_x > getWidth()) {
-				setVolume(1.0f);
+	} else if (mStyle == VideoVolumeStyle::SLIDER) {
+		// Slider is made up of 3 parts:
+		// 'mute' - Button to toggle between muted / unmuted
+		// 'track' - the background of the slider showing it's overall length
+		// 'fill' - the filled portion of the slider
+		// 'nub' - the visual handle at the current slider position
+		mSliderSprites.mMuteButton =
+			new ds::ui::ImageButton(mEngine, mVolumeHighImage, mVolumeLowImage, (mTheSize - mButtHeight) / 2.0f);
+		mSliderSprites.mMuteButton->setScale(mTheSize / mSliderSprites.mMuteButton->getHeight());
+		mSliderSprites.mMuteButton->setCenter(0.0f, 0.5f);
+		mSliderSprites.mMuteButton->setPosition(0.0f, getHeight() / 2.f);
+		mSliderSprites.mMuteButton->setClickFn([this] {
+			if (mMuted) {
+				setVolume(mLastVolume);
 			} else {
-				setVolume(local_x / getWidth());
+				setVolume(0.f);
 			}
 		});
+		addChildPtr(mSliderSprites.mMuteButton);
+
+		ci::vec2 trackPos = ci::vec2(mSliderSprites.mMuteButton->getScaleWidth() + 8.f, getHeight() / 2.f);
+
+		mSliderSprites.mSliderTrack = new ds::ui::Sprite(mEngine, getWidth() - (trackPos.x), mSliderHeight);
+		mSliderSprites.mSliderTrack->setTransparent(false);
+		mSliderSprites.mSliderTrack->setColor(mInterfaceColor);
+		mSliderSprites.mSliderTrack->setCenter(0.f, 0.5f);
+		mSliderSprites.mSliderTrack->setOpacity(mOffOpacity);
+		mSliderSprites.mSliderTrack->setPosition(trackPos);
+		addChildPtr(mSliderSprites.mSliderTrack);
+
+		mSliderSprites.mSliderFill = new ds::ui::Sprite(mEngine, getWidth() - (trackPos.x), mSliderHeight);
+		mSliderSprites.mSliderFill->setTransparent(false);
+		mSliderSprites.mSliderFill->setColor(mInterfaceColor);
+		mSliderSprites.mSliderFill->setCenter(0.f, 0.5f);
+		mSliderSprites.mSliderFill->setPosition(trackPos);
+		addChildPtr(mSliderSprites.mSliderFill);
+
+		mSliderSprites.mSliderNub = new ds::ui::Sprite(mEngine, mNubSize, mNubSize);
+		mSliderSprites.mSliderNub->setTransparent(false);
+		mSliderSprites.mSliderNub->setColor(mInterfaceColor);
+		mSliderSprites.mSliderNub->setCenter(0.5f, 0.5f);
+		mSliderSprites.mSliderNub->setPosition(trackPos);
+		addChildPtr(mSliderSprites.mSliderNub);
 	}
 
-	void VideoVolumeControl::linkVideo(ds::ui::GstVideo* vid) {
-		mLinkedVideo = vid;
+	enable(true);
+	enableMultiTouch(ds::ui::MULTITOUCH_INFO_ONLY);
+	setProcessTouchCallback([this](ds::ui::Sprite* bs, const ds::ui::TouchInfo& ti) {
+		if (ti.mFingerIndex != 0 || ti.mPhase == ds::ui::TouchInfo::Removed) return;
+
+		float local_x = 0.f;
+		float local_w = getWidth();
+		if (mStyle == VideoVolumeStyle::CLASSIC) {
+			local_x = globalToLocal(ti.mCurrentGlobalPoint).x;
+		} else if (mStyle == VideoVolumeStyle::SLIDER) {
+			local_x = mSliderSprites.mSliderTrack->globalToLocal(ti.mCurrentGlobalPoint).x;
+			local_w = mSliderSprites.mSliderTrack->getWidth();
+		}
+		if (local_x <= 0.0f) {
+			setVolume(0.0f);
+		} else if (local_x > local_w) {
+			setVolume(1.0f);
+		} else {
+			setVolume(local_x / local_w);
+		}
+	});
+}
+
+void VideoVolumeControl::linkVideo(ds::ui::GstVideo* vid) {
+	mLinkedVideo = vid;
+}
+
+
+void VideoVolumeControl::linkYouTube(ds::ui::YouTubeWeb* linkedYouTube) {
+	mLinkedYouTube = linkedYouTube;
+}
+
+void VideoVolumeControl::setVolume(const float v) {
+	if (mLinkedVideo) {
+		if (mLinkedVideo->getIsMuted() && v > 0.0f) {
+			mLinkedVideo->setMute(false);
+		}
+		mLinkedVideo->setVolume(v);
 	}
 
+	if (mLinkedYouTube) {
+		mLinkedYouTube->setVolume(v);
+	}
+}
 
-	void VideoVolumeControl::linkYouTube(ds::ui::YouTubeWeb* linkedYouTube) {
-		mLinkedYouTube = linkedYouTube;
+void VideoVolumeControl::onUpdateServer(const ds::UpdateParams& updateParams) {
+	float vol = 0.0f;
+	if (mLinkedVideo) {
+		vol = mLinkedVideo->getVolume();
+		if (mLinkedVideo->getIsMuted()) {
+			vol = 0.0f;
+		}
 	}
 
-	void VideoVolumeControl::setVolume(const float v) {
-		if (mLinkedVideo) {
-			if (mLinkedVideo->getIsMuted() && v > 0.0f) {
-				mLinkedVideo->setMute(false);
+	if (mLinkedYouTube) {
+		vol = mLinkedYouTube->getVolume();
+	}
+
+	bool isMuted = (vol <= std::numeric_limits<float>::epsilon());
+
+	if (isMuted != mMuted || abs(mLastVolume - vol) > std::numeric_limits<float>::epsilon()) {
+		if (mStyle == VideoVolumeStyle::CLASSIC) {
+			for (int k = 0; k < mBars.size(); ++k) {
+				const float bar_v = static_cast<float>(k + 1) / static_cast<float>(mBars.size());
+				if (vol >= bar_v) {
+					mBars[k]->setOpacity(1.0f);
+				} else {
+					mBars[k]->setOpacity(mOffOpacity);
+				}
 			}
-			mLinkedVideo->setVolume(v);
-		}
-
-		if (mLinkedYouTube) {
-			mLinkedYouTube->setVolume(v);
-		}
-	}
-
-	void VideoVolumeControl::onUpdateServer(const ds::UpdateParams& updateParams) {
-		float vol = 0.0f;
-		if (mLinkedVideo) {
-			vol = mLinkedVideo->getVolume();
-			if (mLinkedVideo->getIsMuted()) {
-				vol = 0.0f;
-			}
-		}
-
-		if (mLinkedYouTube) {
-			vol = mLinkedYouTube->getVolume();
-		}
-
-		for (int k = 0; k < mBars.size(); ++k) {
-			const float bar_v = static_cast<float>(k + 1) / static_cast<float>(mBars.size());
-			if (vol >= bar_v) {
-				mBars[k]->setOpacity(1.0f);
+		} else if (mStyle == VideoVolumeStyle::SLIDER) {
+			if (isMuted || vol <= std::numeric_limits<float>::epsilon()) {
+				mSliderSprites.mMuteButton->setHighImage(mMuteImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
+																		 ds::ui::Image::IMG_CACHE_F);
+				mSliderSprites.mMuteButton->setNormalImage(mMuteImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
+																		   ds::ui::Image::IMG_CACHE_F);
+			} else if (vol < 0.5f) {
+				mSliderSprites.mMuteButton->setHighImage(mVolumeLowImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
+																			  ds::ui::Image::IMG_CACHE_F);
+				mSliderSprites.mMuteButton->setNormalImage(mVolumeLowImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
+																				ds::ui::Image::IMG_CACHE_F);
 			} else {
-				mBars[k]->setOpacity(mOffOpacity);
+				mSliderSprites.mMuteButton->setHighImage(mVolumeHighImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
+																			   ds::ui::Image::IMG_CACHE_F);
+				mSliderSprites.mMuteButton->setNormalImage(mVolumeHighImage, ds::ui::Image::IMG_ENABLE_MIPMAP_F |
+																				 ds::ui::Image::IMG_CACHE_F);
 			}
-		}
-	}
 
-}} // namespace ds::ui
+			mSliderSprites.mSliderFill->setSize(vol * mSliderSprites.mSliderTrack->getWidth(),
+												mSliderSprites.mSliderFill->getHeight());
+
+			mSliderSprites.mSliderNub->setPosition(mSliderSprites.mSliderTrack->getPosition().x +
+													   (vol * mSliderSprites.mSliderTrack->getWidth()),
+												   mSliderSprites.mSliderNub->getPosition().y);
+		}
+
+		if (!isMuted) {
+			// Save the last volume when muting to restore when unmuting
+			mLastVolume = vol;
+		}
+		mMuted = isMuted;
+	}
+}
+
+} // namespace ds::ui

--- a/projects/viewers/src/ds/ui/media/interface/video_volume_control.h
+++ b/projects/viewers/src/ds/ui/media/interface/video_volume_control.h
@@ -2,34 +2,71 @@
 
 #include "ds/ui/media/media_interface.h"
 
-namespace ds { namespace ui {
-	class GstVideo;
-	class YouTubeWeb;
+namespace ds::ui {
+class GstVideo;
+class YouTubeWeb;
+class ImageButton;
 
-	/**
-	 * \class VideoVolumeControl
-	 *			Control audio volume for a video
-	 */
-	class VideoVolumeControl : public ds::ui::Sprite {
-	  public:
-		VideoVolumeControl(ds::ui::SpriteEngine& eng, const float theSize = 50.0f, const float buttHeight = 25.0f,
-						   const ci::Color interfaceColor = ci::Color::white());
+enum class VideoVolumeStyle { CLASSIC, SLIDER };
+struct VideoVolumeSliderSprites {
+	ds::ui::ImageButton* mMuteButton  = nullptr;
+	ds::ui::Sprite*		 mSliderTrack = nullptr;
+	ds::ui::Sprite*		 mSliderFill  = nullptr;
+	ds::ui::Sprite*		 mSliderNub	  = nullptr;
+};
+/**
+ * \class VideoVolumeControl
+ *			Control audio volume for a video
+ */
+class VideoVolumeControl : public ds::ui::Sprite {
+  public:
+	VideoVolumeControl(ds::ui::SpriteEngine& eng, const float theSize = 50.0f, const float buttHeight = 25.0f,
+					   const ci::Color	interfaceColor = ci::Color::white(),
+					   VideoVolumeStyle style		   = VideoVolumeStyle::CLASSIC);
 
-		void linkVideo(ds::ui::GstVideo* linkedVideo);
-		void linkYouTube(ds::ui::YouTubeWeb* linkedYouTube);
-		void setVolume(const float v);
+	void linkVideo(ds::ui::GstVideo* linkedVideo);
+	void linkYouTube(ds::ui::YouTubeWeb* linkedYouTube);
+	void setVolume(const float v);
 
-		// do not release the bars here, this is to modify their values
-		std::vector<ds::ui::Sprite*>& getBars() { return mBars; }
+	void			 setStyle(VideoVolumeStyle newStyle);
+	VideoVolumeStyle getStyle() { return mStyle; }
+	// do not release the bars here, this is to modify their values
+	std::vector<ds::ui::Sprite*>& getBars() { return mBars; }
+	VideoVolumeSliderSprites&	  getSliderSprites() { return mSliderSprites; }
 
-	  protected:
-		virtual void onUpdateServer(const ds::UpdateParams& updateParams) override;
+	void setSliderHeight(float height) { mSliderHeight = height; }
+	void setNubSize(float height) { mNubSize = height; }
+	void setMuteImage(const std::string& imgLocation) { mMuteImage = imgLocation; }
+	void setVolumeLowImage(const std::string& imgLocation) { mVolumeLowImage = imgLocation; }
+	void setVolumeHighImage(const std::string& imgLocation) { mVolumeHighImage = imgLocation; }
 
-		ds::ui::GstVideo*	mLinkedVideo;
-		ds::ui::YouTubeWeb* mLinkedYouTube;
+  protected:
+	virtual void onUpdateServer(const ds::UpdateParams& updateParams) override;
 
-		std::vector<ds::ui::Sprite*> mBars;
-		float						 mOffOpacity;
-	};
+	VideoVolumeStyle mStyle = VideoVolumeStyle::CLASSIC;
 
-}} // namespace ds::ui
+	ds::ui::GstVideo*	mLinkedVideo;
+	ds::ui::YouTubeWeb* mLinkedYouTube;
+
+	ci::Color mInterfaceColor;
+	float	  mTheSize	  = 50.f;
+	float	  mButtHeight = 25.f;
+
+	// For classic style
+	std::vector<ds::ui::Sprite*> mBars;
+
+	// For Slider style
+	VideoVolumeSliderSprites mSliderSprites;
+	float					 mSliderHeight	  = 8.f;
+	float					 mNubSize		  = 12.f;
+	std::string				 mMuteImage		  = "%APP%/data/images/media_interface/mute.png";
+	std::string				 mVolumeLowImage  = "%APP%/data/images/media_interface/volume_low.png";
+	std::string				 mVolumeHighImage = "%APP%/data/images/media_interface/volume_high.png";
+
+
+	float mOffOpacity;
+	float mLastVolume = -1.f;
+	bool  mMuted	  = false;
+};
+
+} // namespace ds::ui


### PR DESCRIPTION
Add an optional alternate design for video player volume controls within the media interface.

Current (default) is bars of increasing height and tapping/dragging selects some subset of bars, setting volume. This can be confusing when trying to mute, and doesn't display full range of the slider.

Slider (new) can be set with `VideoVolumeControl::setStyle(VideoVolumeStyle::SLIDER)`. This version has a mute/volume icon that can be tapped to mute/unmute, and a slider made up of a track (overall slider bar), fill (the filled portion of the bar) and a nub (the current slider end location. When muting, it retains the last volume setting and reverts to it on un-mute.

When not muted, the button transitions from a low volume image ( >0% to 50%) and a high volume image (>50%).

Also added are getters for manipulating the various sprites used which is typical in waffles apps to style to interface.