### PR TITLE
Made ds::ui::Sprite::getOpacity() a virtual function…

### DIFF
--- a/src/ds/ui/sprite/sprite.cpp
+++ b/src/ds/ui/sprite/sprite.cpp
@@ -307,7 +307,7 @@ void Sprite::drawLocalClientInternal(const ci::mat4& totalTransformation, const 
 
 		DS_REPORT_GL_ERRORS();
 
-		mDrawOpacity = mOpacity * drawParams.mParentOpacity;
+		mDrawOpacity = getOpacity() * drawParams.mParentOpacity; // Use getOpacity() to allow sprites to override this behavior.
 
 		ci::gl::color(mColor.r, mColor.g, mColor.b, mDrawOpacity);
 
@@ -337,7 +337,7 @@ void Sprite::drawLocalClientInternal(const ci::mat4& totalTransformation, const 
 
 
 	DrawParams dParams = drawParams;
-	dParams.mParentOpacity *= mOpacity;
+	dParams.mParentOpacity *= getOpacity(); // Use getOpacity() to allow sprites to override this behavior.
 
 	if ((mSpriteFlags & DRAW_SORTED_F) == 0) {
 		for (auto it = mChildren.begin(), it2 = mChildren.end(); it != it2; ++it) {
@@ -420,7 +420,7 @@ void Sprite::drawServer(const ci::mat4& trans, const DrawParams& drawParams) {
 			ci::gl::enableAlphaBlending();
 			applyBlendingMode(mBlendMode);
 
-			mDrawOpacity = mOpacity * drawParams.mParentOpacity;
+			mDrawOpacity = getOpacity() * drawParams.mParentOpacity; // Use getOpacity() to allow sprites to override this behavior.
 			ci::gl::color(mColor.r, mColor.g, mColor.b, mDrawOpacity);
 		} else {
 			ci::gl::disableAlphaBlending();

--- a/src/ds/ui/sprite/sprite.h
+++ b/src/ds/ui/sprite/sprite.h
@@ -475,7 +475,7 @@ namespace ui {
 		/** Get the opacity of this Sprite (transparency).
 			0.0 is invisible, 1.0 is fully opaque.
 			\return The current opacity value of this Sprite. */
-		float getOpacity() const;
+		virtual float getOpacity() const;
 		/** Returns the final opacity of the Sprite decided based on all its parents.
 			Useful for custom drawing routines where getOpacity() does not work.
 			The difference between this and getOpacity() is that, getOpacity() is the opacity


### PR DESCRIPTION
… to allow sprites to override the behavior of `mDrawOpacity`.

An example of this is a custom layout sprite which draws a semi-transparent background. In most cases, you don't want nested content to also end up transparent. By using `float getOpacity() const override { return 1.f; }`, you can make sure content will not be influenced.