### PR TITLE
Media viewer setting to not loop pdfs

### DIFF
--- a/projects/viewers/src/ds/ui/media/interface/video_volume_control.cpp
+++ b/projects/viewers/src/ds/ui/media/interface/video_volume_control.cpp
@@ -57,13 +57,16 @@ void VideoVolumeControl::setStyle(VideoVolumeStyle newStyle) {
 
 	} else if (mStyle == VideoVolumeStyle::SLIDER) {
 		setSize(mTheSize * 2.f, mTheSize);
+		const auto imageFlags = ds::ui::Image::IMG_ENABLE_MIPMAP_F | ds::ui::Image::IMG_CACHE_F;
 		// Slider is made up of 3 parts:
 		// 'mute' - Button to toggle between muted / unmuted
 		// 'track' - the background of the slider showing it's overall length
 		// 'fill' - the filled portion of the slider
 		// 'nub' - the visual handle at the current slider position
 		mSliderSprites.mMuteButton =
-			new ds::ui::ImageButton(mEngine, mVolumeHighImage, mMuteImage, (mTheSize - mButtHeight) / 2.0f);
+			new ds::ui::ImageButton(mEngine, "", "", (mTheSize - mButtHeight) / 2.0f);
+		mSliderSprites.mMuteButton->setNormalImage(mVolumeHighImage, imageFlags);
+		mSliderSprites.mMuteButton->setHighImage(mMuteImage, imageFlags);
 		mSliderSprites.mMuteButton->setScale((mTheSize - (mButtHeight * 0.5f)) /
 											 mSliderSprites.mMuteButton->getHeight());
 		mSliderSprites.mMuteButton->setCenter(0.5f, 0.5f);

--- a/projects/viewers/src/ds/ui/media/media_viewer_settings.h
+++ b/projects/viewers/src/ds/ui/media/media_viewer_settings.h
@@ -33,6 +33,7 @@ struct MediaViewerSettings {
 	  , mCacheImages(false)
 	  , mMipMapImages(true)
 	  , mPdfCanShowLinks(true)
+	  , mPdfLoop(true)
 	  , mVideoPanning(0.0f)
 	  , mVideoVolume(1.0f)
 	  , mVideoAutoSync(true)
@@ -105,6 +106,9 @@ struct MediaViewerSettings {
 
 	/// When the PDF gets touch-toggled, show any internal PDF links. default = true
 	bool mPdfCanShowLinks;
+
+	/// Should the PDF loop or stop on last page
+	bool mPdfLoop;
 
 	/// Called back when a PDF link is tapped
 	std::function<void(ds::pdf::PdfLinkInfo)> mPdfLinkTappedCallback;

--- a/projects/viewers/src/ds/ui/media/player/pdf_player.cpp
+++ b/projects/viewers/src/ds/ui/media/player/pdf_player.cpp
@@ -311,6 +311,7 @@ void PDFPlayer::setMediaViewerSettings(const MediaViewerSettings& settings) {
 	mInterfaceBelowMedia = settings.mInterfaceBelowMedia;
 	mInterfaceBottomPad	 = settings.mInterfaceBottomPad;
 	mCanShowLinks		 = settings.mPdfCanShowLinks;
+	mLoopPages			 = settings.mPdfLoop;
 	setLinkClickedCallback(settings.mPdfLinkTappedCallback);
 }
 
@@ -383,13 +384,25 @@ int PDFPlayer::getPageCount() const {
 
 void PDFPlayer::nextPage() {
 	mCurrentPage++;
-	if (mCurrentPage > mNumPages) mCurrentPage = 1;
+	if (mCurrentPage > mNumPages) {
+		if(mLoopPages){
+			mCurrentPage = 1; 
+		}else{
+			mCurrentPage = mNumPages;
+		}
+	}
 	setPageNum(mCurrentPage);
 }
 
 void PDFPlayer::prevPage() {
 	mCurrentPage--;
-	if (mCurrentPage < 1) mCurrentPage = mNumPages;
+	if (mCurrentPage < 1) {
+		if(mLoopPages){
+			mCurrentPage = mNumPages; 
+		}else{
+			mCurrentPage = 1;
+		}
+	}
 	setPageNum(mCurrentPage);
 }
 

--- a/projects/viewers/src/ds/ui/media/player/pdf_player.h
+++ b/projects/viewers/src/ds/ui/media/player/pdf_player.h
@@ -101,6 +101,7 @@ class PDFPlayer : public ds::ui::IPdf {
 	bool		  mLetterbox;
 	bool		  mShowingLinks = false;
 	bool		  mCanShowLinks = true;
+	bool		  mLoopPages	= true;
 
 	std::function<void(void)>				mPageChangeCallback;
 	std::function<void(void)>				mGoodStatusCallback;

--- a/src/ds/app/engine/engine.cpp
+++ b/src/ds/app/engine/engine.cpp
@@ -1397,6 +1397,7 @@ void Engine::resetIdleTimeout() {
 	for (size_t i = 0; i < numRoots - 1; i++) {
 		// don't clear the last root, which is the debug draw
 		if (getRootBuilder(i).mDebugDraw) continue;
+		getRootSprite(i).setSecondBeforeIdle(mData.mIdleTimeout);
 		getRootSprite(i).resetIdleTimer();
 	}
 


### PR DESCRIPTION
This retains the default behavior of PDFs looping, but adds a setting the MediaViewerSettings object to disable looping when going past the beginning/end of the PDF.