### PR TITLE
Added the ability to trim white space around text sprites…

### DIFF
--- a/doc/basics/Dynamic Interfaces.md
+++ b/doc/basics/Dynamic Interfaces.md
@@ -383,6 +383,7 @@ Text Parameters
     2. "center": Center-aligns the layout.
     3. "right": Align rows of text to the right side of the resize_limit
 * **shrink_to_bounds**: If text has 'resize_limit' set, this will set the sprite size to the size of the text texture, rather than the full resize_limit.
+* **trim_white_space**: If trim_white_space is true, the origin and size of the text is measured from the actual pixels, instead of the logical layout. The effect will be that all white space around the text is trimmed. This is useful if you want fine control over the amount of padding around the text.
 * **text_model_format**: Allows combining of plain text, data from a content model, and text
 	post-processing functions. Requires being in a smart layout, and having setContentModel called.
 	See [ContentModel & SmartLayout](#ContentModel-&-SmartLayout) below for more details.

--- a/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
+++ b/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
@@ -884,6 +884,14 @@ void XmlImporter::setSpriteProperty(ds::ui::Sprite& sprite, const std::string& p
 				logAttributionWarning(p);
 			}
 		};
+		propertyMap["trim_white_space"] = [](const SprProps& p) {
+			auto text = dynamic_cast<Text*>(&p.sprite);
+			if (text) {
+				text->setTrimWhiteSpace(parseBoolean(p.value));
+			} else {
+				logAttributionWarning(p);
+			}
+		};
 		propertyMap["shrink_to_bounds"] = [](const SprProps& p) {
 			auto text = dynamic_cast<Text*>(&p.sprite);
 			if (text) {

--- a/src/ds/ui/sprite/text.cpp
+++ b/src/ds/ui/sprite/text.cpp
@@ -141,6 +141,7 @@ Text::Text(ds::ui::SpriteEngine& eng)
   , mProbablyHasMarkup(false)
   , mAllowMarkup(true)
   , mPreserveSpanColors(false)
+  , mTrimWhiteSpace(false)
   , mEllipsizeMode(EllipsizeMode::kEllipsizeNone)
   , mWrapMode(WrapMode::kWrapModeWordChar)
   , mEngineFontScale(4.0 / 3.0)
@@ -655,6 +656,14 @@ void Text::setPreserveSpanColors(const bool preserve) {
 		mSpriteShader.setShaders(vertShader, opacityFrag, shaderNameOpaccy);
 	}
 	mSpriteShader.loadShaders();
+}
+
+void Text::setTrimWhiteSpace(const bool trim) {
+	if (mTrimWhiteSpace != trim) {
+		mTrimWhiteSpace = trim;
+		mNeedsMeasuring = true;
+		markAsDirty(LAYOUT_DIRTY);
+	}
 }
 
 void Text::onUpdateClient(const UpdateParams&) {
@@ -1216,16 +1225,21 @@ bool Text::measurePangoText() {
 			mPixelWidth	 = std::max(extentRect.width, inkRect.width);
 			mPixelHeight = std::max(extentRect.height, inkRect.height);
 
+			// Adjust size and render offset when trimming white space
+			if (mTrimWhiteSpace) mRenderOffset -= ci::vec2(inkRect.x, inkRect.y);
+			const auto pixelWidth  = float(mTrimWhiteSpace ? inkRect.width : mPixelWidth);
+			const auto pixelHeight = float(mTrimWhiteSpace ? inkRect.height : mPixelHeight);
+
 			// This is required to not break combinations of layout align & text align
 			if (extentRect.width < (int)mResizeLimitWidth) {
 				if (!mShrinkToBounds) {
-					setSize(mResizeLimitWidth, (float)mPixelHeight);
+					setSize(mResizeLimitWidth, pixelHeight);
 				} else {
 					mRenderOffset.x -= extentRect.x;
-					setSize((float)mPixelWidth, (float)mPixelHeight);
+					setSize(pixelWidth, pixelHeight);
 				}
 			} else {
-				setSize((float)mPixelWidth, (float)mPixelHeight);
+				setSize(pixelWidth, pixelHeight);
 			}
 			YGNodeMarkDirty(mYogaNode);
 

--- a/src/ds/ui/sprite/text.cpp
+++ b/src/ds/ui/sprite/text.cpp
@@ -1226,7 +1226,22 @@ bool Text::measurePangoText() {
 			mPixelHeight = std::max(extentRect.height, inkRect.height);
 
 			// Adjust size and render offset when trimming white space
-			if (mTrimWhiteSpace) mRenderOffset -= ci::vec2(inkRect.x, inkRect.y);
+			if (mTrimWhiteSpace) {
+				switch (mStyle.mAlignment) {
+				case Alignment::kCenter:
+					mRenderOffset -=
+						ci::vec2(inkRect.x + inkRect.width / 2 - (extentRect.x + extentRect.width / 2), inkRect.y);
+					break;
+				case Alignment::kRight:
+					mRenderOffset -= ci::vec2(inkRect.x + inkRect.width - (extentRect.x + extentRect.width), inkRect.y);
+					break;
+				case Alignment::kLeft:
+				case Alignment::kJustify:
+					mRenderOffset -= ci::vec2(inkRect.x, inkRect.y);
+					break;
+				}
+			}
+
 			const auto pixelWidth  = float(mTrimWhiteSpace ? inkRect.width : mPixelWidth);
 			const auto pixelHeight = float(mTrimWhiteSpace ? inkRect.height : mPixelHeight);
 

--- a/src/ds/ui/sprite/text.h
+++ b/src/ds/ui/sprite/text.h
@@ -185,6 +185,13 @@ class Text : public ds::ui::Sprite {
 	/// Gets the height of the sprite, based on the actual render height of the text if shrink to bounds is on
 	virtual float getHeight() const override;
 
+	/// Returns the actual render width of the text
+	int getPixelWidth() const { return mPixelWidth; }
+	/// Returns the actual render height of the text
+	int getPixelHeight() const { return mPixelHeight; }
+	/// Returns the actual render size of the text
+	ci::ivec2 getPixelSize() const { return {mPixelWidth, mPixelHeight}; }
+
 	/// If ellipsize mode is none and there's a resize width > 0 and the text had to wrap at all, returns true.
 	/// otherwise false
 	bool getTextWrapped();
@@ -227,6 +234,12 @@ class Text : public ds::ui::Sprite {
 	/// The default is that this is false, which renders text a little more cleanly.
 	void	   setPreserveSpanColors(const bool preserve);
 	const bool getPreserveSpanColors() { return mPreserveSpanColors; }
+
+	/// By default, text is rendered using appropriate white space around the text.
+	///	Some layouts, however, required precise control over white space. This method allows
+	///	you to adjust the text's size and render offset, effectively trimming all white space.
+	void setTrimWhiteSpace(bool trim);
+	const bool getTrimWhiteSpace() { return mTrimWhiteSpace; }
 
 	/// Text is rendered into this texture
 	/// Note: this texture has pre-multiplied alpha
@@ -289,6 +302,7 @@ class Text : public ds::ui::Sprite {
 
 	/// Rendering options
 	bool		  mPreserveSpanColors;
+	bool		  mTrimWhiteSpace;
 	EllipsizeMode mEllipsizeMode;
 	WrapMode	  mWrapMode;
 	double		  mEngineFontScale;


### PR DESCRIPTION
…by adjusting size and render offset.

This allows you to effectively crop the text for fine control over content padding. To use, just add `trim_white_space="true"` to your `<text />` sprite. Note that the texture and layout are not changed, we only adjust the render offset and measured size of the sprite.

Wtihout trimming white space, this is what text normally looks like:

![2023-09-15 14 41 32 058396](https://github.com/Unispace365/ds_cinder/assets/304908/09959b9d-c16c-4938-9f7b-23dbb11c73f3)

The pink bars around the content show the desired padding. The title "Executive Summary" almost touches the padding on the left, but on the top there is excessive space. Also, the space between the title and the separator line is too large. This is due to how text normally is measured.

By adding a `trim_white_space="true"` to your `<text />` sprite, the excessive space is trimmed and this is the result:

![2023-09-15 14 39 39 557854](https://github.com/Unispace365/ds_cinder/assets/304908/2a29e368-c261-4662-b3d5-3a5d9e5fa9e3)

Now, all space around the text is correct, closely following the desired padding settings.

Note: white space is calculated from Pango's `inkRect` and does *not* take into account the font ascender or descender. This means that in the above example, white space is trimmed above the `S` and below the `y`.