### PR TITLE
Added support for trimming white space on images.

### DIFF
--- a/doc/basics/Dynamic Interfaces.md
+++ b/doc/basics/Dynamic Interfaces.md
@@ -406,10 +406,11 @@ Image Parameters
 	* **_mipmap** OR **_m**: include the ds::ui::Image::IMG_MIPMAP flag, which generates mipmaps for the given image.
 	* **_preload** OR **_p**: include the ds::ui::Image::IMG_PRELOAD flag, which preloads the image.
 	* **_skipmeta** OR **_s**: include the ds::ui::Image::IMG_SKIP_METADATA flag, which skips metadata loading.
+	* **_trim** OR **_t**: include the ds::ui::Image::IMG_TRIM_WHITESPACE flag, which trims all transparent edges of the image.
 
-These flags can also be applied the the resource property when working with a model:
+These flags can also be applied to the resource property when working with a model:
 ```xml
-		model="resource_mipmap:this->img_resource"
+		model="resource_mipmap_trim:this->img_resource"
 ```
 
 * **circle_crop**: Boolean. If true, will crop image content outside of an ellipse centered within the bounding box.

--- a/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
+++ b/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
@@ -1435,9 +1435,12 @@ void XmlImporter::setSpriteProperty(ds::ui::Sprite& sprite, const std::string& p
 				} else if (val == "skipmeta" || val == "s") {
 					flags |= ds::ui::Image::IMG_SKIP_METADATA_F;
 
+				} else if (val == "trim" || val == "t") {
+					flags |= ds::ui::Image::IMG_TRIM_WHITESPACE_F;
+
 				} else if (val != "filename" && val != "src") {
 					logInvalidValue(SprProps(sprite, property, value, referer, local_map),
-									" cache, mipmap, preload, skipmeta in combination with filename or src, such as "
+									" cache, mipmap, preload, skipmeta, trim in combination with filename or src, such as "
 									"filename_cache or src_mipmap_preload");
 				}
 			}

--- a/projects/essentials/src/ds/ui/layout/smart_layout.cpp
+++ b/projects/essentials/src/ds/ui/layout/smart_layout.cpp
@@ -297,6 +297,9 @@ void SmartLayout::applyModelToSprite(ds::ui::Sprite* child, const std::string& c
 							} else if (val == "skipmeta" || val == "s") {
 								flags |= ds::ui::Image::IMG_SKIP_METADATA_F;
 
+							} else if (val == "trim" || val == "t") {
+								flags |= ds::ui::Image::IMG_TRIM_WHITESPACE_F;
+
 							} else if (val != "resource") {
 								DS_LOG_WARNING("Trying to set unknown flags to src/filename attribute: _"
 											   << val << "_ on sprite of type: " << typeid(child).name());

--- a/src/ds/data/resource.h
+++ b/src/ds/data/resource.h
@@ -147,10 +147,10 @@ class Resource {
 
 	ci::Rectf getCrop() const { return ci::Rectf(mCropX, mCropY, mCropX + mCropW, mCropY + mCropH); }
 	void	  setCrop(const ci::Rectf cropRect) {
-		 mCropX			  = cropRect.getX1();
-		 mCropY			  = cropRect.getY1();
-		 mCropW			  = cropRect.getWidth();
-		 mCropH			  = cropRect.getHeight();
+			 mCropX = cropRect.getX1();
+			 mCropY = cropRect.getY1();
+			 mCropW = cropRect.getWidth();
+			 mCropH = cropRect.getHeight();
 	}
 	void setCrop(const float cropX, const float cropY, const float cropW, const float cropH) {
 		mCropX = cropX;

--- a/src/ds/ui/service/load_image_service.cpp
+++ b/src/ds/ui/service/load_image_service.cpp
@@ -355,12 +355,12 @@ void LoadImageService::loadImagesThreadFn(ci::gl::ContextRef context) {
 				nextImage.mCropRect.x2 = float(area.x2) / float(isr->getWidth());
 				nextImage.mCropRect.y2 = float(area.y2) / float(isr->getHeight());
 
-				// When not loading image top-down, make sure to swap y1 and y2!
-				if constexpr (!isTopDown) {
-					std::swap(nextImage.mCropRect.y1, nextImage.mCropRect.y2);
-					nextImage.mCropRect.y1 = 1.0f - nextImage.mCropRect.y1;
-					nextImage.mCropRect.y2 = 1.0f - nextImage.mCropRect.y2;
-				}
+				//// When not loading image top-down, make sure to swap y1 and y2!
+				//if constexpr (!isTopDown) {
+				//	std::swap(nextImage.mCropRect.y1, nextImage.mCropRect.y2);
+				//	nextImage.mCropRect.y1 = 1.0f - nextImage.mCropRect.y1;
+				//	nextImage.mCropRect.y2 = 1.0f - nextImage.mCropRect.y2;
+				//}
 			}
 
 			/// once we have the surface in main-thread mode, bail out

--- a/src/ds/ui/service/load_image_service.cpp
+++ b/src/ds/ui/service/load_image_service.cpp
@@ -5,7 +5,10 @@
 #include <chrono>
 
 #include <ds/debug/logger.h>
+#include <ds/ui/sprite/image.h>
 #include <ds/util/file_meta_data.h>
+
+#include <cinder/ip/Trim.h>
 
 namespace {
 template <typename Clock = std::chrono::high_resolution_clock>
@@ -172,7 +175,7 @@ void LoadImageService::update(const ds::UpdateParams&) {
 		auto filecallbacks = mCallbacks.find(it.mFilePath);
 		if (filecallbacks != mCallbacks.end()) {
 			for (auto cit : filecallbacks->second) {
-				cit.second(it.mTexture, it.mError, it.mErrorMsg);
+				cit.second(it.mTexture, it.mTexCoords, it.mError, it.mErrorMsg);
 			}
 			mCallbacks.erase(filecallbacks);
 		}
@@ -181,8 +184,8 @@ void LoadImageService::update(const ds::UpdateParams&) {
 	newCompletedRequests.clear();
 }
 
-void LoadImageService::acquire(const std::string& filePath, const int flags, void* requester,
-							   LoadedCallback loadedCallback) {
+void LoadImageService::acquire(const std::string&    filePath, const int flags, Image* requester,
+                               const LoadedCallback& loadedCallback) {
 	if (filePath.empty()) {
 		DS_LOG_VERBOSE(6, "LoadImageService got a blank file path.");
 		return;
@@ -205,11 +208,14 @@ void LoadImageService::acquire(const std::string& filePath, const int flags, voi
 		if (inFind->second.mLoading == false) {
 			DS_LOG_VERBOSE(4, "LoadImageService using an in-use image for " << filePath
 																			<< " refs=" << inFind->second.mRefs);
-			loadedCallback(inFind->second.mTexture, inFind->second.mError, inFind->second.mErrorMsg);
+			loadedCallback(inFind->second.mTexture, inFind->second.mTexCoords, inFind->second.mError, inFind->second.mErrorMsg);
 			return;
 		}
 	} else {
-		mInUseImages[filePath]			= ImageLoadRequest(filePath, flags);
+		// Obtain cropping information, used for trimming white space.
+		const auto resource = requester->getImageResource();
+
+		mInUseImages[filePath]			= ImageLoadRequest(filePath, flags, resource.getCrop());
 		mInUseImages[filePath].mLoading = true; // Indicates that this request has been added to the loading queue
 	}
 
@@ -229,7 +235,7 @@ void LoadImageService::acquire(const std::string& filePath, const int flags, voi
 }
 
 
-void LoadImageService::release(const std::string& filePath, void* referrer) {
+void LoadImageService::release(const std::string& filePath, Image* referrer) {
 	if (filePath.empty()) return;
 
 	/// Remove the callback for this path and referrer
@@ -322,7 +328,9 @@ void LoadImageService::loadImagesThreadFn(ci::gl::ContextRef context) {
 		} else {
 			fmt.setMinFilter(GL_LINEAR);
 		}
-		// fmt.loadTopDown(false);
+
+		constexpr bool isTopDown = false;
+		fmt.loadTopDown(isTopDown);
 
 		try {
 			ci::ImageSourceRef isr;
@@ -330,6 +338,27 @@ void LoadImageService::loadImagesThreadFn(ci::gl::ContextRef context) {
 				isr = ci::loadImage(nextImage.mFilePath);
 			} catch (std::exception excp) {
 				isr = ci::loadImage(ci::loadUrl(nextImage.mFilePath));
+			}
+
+			// trim white space if requested
+			const bool trimWhiteSpace = ((nextImage.mFlags & ds::ui::Image::IMG_TRIM_WHITESPACE_F) != 0);
+			if (trimWhiteSpace) {
+				const auto w	  = float(isr->getWidth());
+				const auto h			= float(isr->getHeight());
+				const auto bounds		= ci::Area(int(nextImage.mTexCoords.x1 * w), int(nextImage.mTexCoords.y1 * h),
+												   int(nextImage.mTexCoords.x2 * w), int(nextImage.mTexCoords.y2 * h));
+				const auto	area		= ci::ip::findNonTransparentArea(ci::Surface(isr), bounds);
+				nextImage.mTexCoords.x1 = float(area.x1) / float(isr->getWidth());
+				nextImage.mTexCoords.y1 = float(area.y1) / float(isr->getHeight());
+				nextImage.mTexCoords.x2 = float(area.x2) / float(isr->getWidth());
+				nextImage.mTexCoords.y2 = float(area.y2) / float(isr->getHeight());
+
+				// When not loading image top-down, make sure to swap y1 and y2!
+				if constexpr (!isTopDown) {
+					std::swap(nextImage.mTexCoords.y1, nextImage.mTexCoords.y2);
+					nextImage.mTexCoords.y1 = 1.0f - nextImage.mTexCoords.y1;
+					nextImage.mTexCoords.y2 = 1.0f - nextImage.mTexCoords.y2;
+				}
 			}
 
 			/// once we have the surface in main-thread mode, bail out

--- a/src/ds/ui/service/load_image_service.h
+++ b/src/ds/ui/service/load_image_service.h
@@ -7,6 +7,7 @@
 #include <ds/app/auto_update.h>
 
 namespace ds::ui {
+class Image;
 class SpriteEngine;
 
 /**
@@ -15,7 +16,7 @@ class SpriteEngine;
  */
 class LoadImageService : public ds::AutoUpdate {
   public:
-	typedef std::function<void(ci::gl::TextureRef, const bool errored, const std::string& errMsg)> LoadedCallback;
+	typedef std::function<void(ci::gl::TextureRef, ci::Rectf, const bool errored, const std::string& errMsg)> LoadedCallback;
 
 	LoadImageService(SpriteEngine& eng);
 	~LoadImageService();
@@ -31,10 +32,10 @@ class LoadImageService : public ds::AutoUpdate {
 	/// Important! Be sure to call release before the requester goes away
 	/// The callback will be called one time only, and calls back if there is an error or it succeeds.
 	/// All callbacks happen in the update cycle
-	void acquire(const std::string& filePath, const int flags, void* requester, LoadedCallback loadedCallback);
+	void acquire(const std::string& filePath, const int flags, Image* requester, const LoadedCallback& loadedCallback);
 
 	/// You must call release if you no longer want the image or the reffer is about to be released
-	void release(const std::string& filePath, void* requester);
+	void release(const std::string& filePath, Image* requester);
 
 	/// \brief Starts the threads to load stuff and creates OpenGL contexts
 	/// Can be called multiple times, will reinit the loading threads if the load_image:threads
@@ -53,29 +54,23 @@ class LoadImageService : public ds::AutoUpdate {
   private:
 	/// Keeps track of requests for images, in-use images, and cached images
 	struct ImageLoadRequest {
-		ImageLoadRequest()
-		  : mFilePath("")
-		  , mFlags(0)
-		  , mTexture(nullptr)
-		  , mRefs(0)
-		  , mLoading(false) {}
+		ImageLoadRequest() = default;
 
-		ImageLoadRequest(const std::string filePath, const int flags)
+		ImageLoadRequest(const std::string& filePath, int flags, const ci::Rectf& coords)
 		  : mFilePath(filePath)
 		  , mFlags(flags)
-		  , mError(false)
-		  , mTexture(nullptr)
-		  , mRefs(1)
-		  , mLoading(false) {}
+		  , mTexCoords(coords)
+		  , mRefs(1) {}
 
 		std::string		   mFilePath;
-		int				   mFlags;
+		int				   mFlags = 0;
 		bool			   mError = false;
 		std::string		   mErrorMsg;
+		ci::Rectf		   mTexCoords{0, 0, 1, 1}; // only used for cropping and trimming white space - TODO rename?
 		ci::gl::TextureRef mTexture;
 		ci::ImageSourceRef mImageSourceRef; // only for main-thread image creation
-		int				   mRefs;
-		bool			   mLoading;
+		int				   mRefs	= 0;
+		bool			   mLoading = false;
 	};
 
 

--- a/src/ds/ui/service/load_image_service.h
+++ b/src/ds/ui/service/load_image_service.h
@@ -59,14 +59,14 @@ class LoadImageService : public ds::AutoUpdate {
 		ImageLoadRequest(const std::string& filePath, int flags, const ci::Rectf& coords)
 		  : mFilePath(filePath)
 		  , mFlags(flags)
-		  , mTexCoords(coords)
+		  , mCropRect(coords)
 		  , mRefs(1) {}
 
 		std::string		   mFilePath;
 		int				   mFlags = 0;
 		bool			   mError = false;
 		std::string		   mErrorMsg;
-		ci::Rectf		   mTexCoords{0, 0, 1, 1}; // only used for cropping and trimming white space - TODO rename?
+		ci::Rectf		   mCropRect{0, 0, 1, 1}; // passed in by the loader, subsequently adjusted if trimming white space
 		ci::gl::TextureRef mTexture;
 		ci::ImageSourceRef mImageSourceRef; // only for main-thread image creation
 		int				   mRefs	= 0;

--- a/src/ds/ui/sprite/image.cpp
+++ b/src/ds/ui/sprite/image.cpp
@@ -235,14 +235,12 @@ void Image::setImageFile(const std::string& filename, const int flags) {
 					mResource.setCrop(coords);
 					imageChanged();
 
-					// Make sure parent layout is updated prior to checking status.
+					// Make sure all parent layouts are updated prior to checking status.
 					auto parent = getParent();
 					while (parent) {
 						auto layout = dynamic_cast<ds::ui::LayoutSprite*>(parent);
-						if (layout) {
-							layout->runLayout();
-							break;
-						}
+						if (layout) layout->runLayout();
+
 						parent = parent->getParent();
 					}
 				}
@@ -518,7 +516,7 @@ void Image::onBuildRenderBatch() {
 	auto drawRect = mDrawRect.mOrthoRect;
 	if (getPerspective()) drawRect = mDrawRect.mPerspRect;
 	if (mCornerRadius > 0.0f) {
-		auto theGeom = ci::geom::RoundedRect(drawRect, mCornerRadius*(1.f/getScale().x));
+		auto theGeom = ci::geom::RoundedRect(drawRect, mCornerRadius * (1.f / getScale().x));
 		if (mRenderBatch) {
 			mRenderBatch->replaceVboMesh(ci::gl::VboMesh::create(theGeom));
 		} else {
@@ -526,18 +524,18 @@ void Image::onBuildRenderBatch() {
 		}
 
 	} else {
-	ci::vec2 ul = ci::vec2(0.f, 0.f);
-	ci::vec2 ur = ci::vec2(1.f, 0.f);
-	ci::vec2 lr = ci::vec2(1.f, 1.f);
-	ci::vec2 ll = ci::vec2(0.f, 1.f);
-		if(!mResource.empty()){
+		ci::vec2 ul = ci::vec2(0.f, 0.f);
+		ci::vec2 ur = ci::vec2(1.f, 0.f);
+		ci::vec2 lr = ci::vec2(1.f, 1.f);
+		ci::vec2 ll = ci::vec2(0.f, 1.f);
+		if (!mResource.empty()) {
 			auto crop = mResource.getCrop();
-			ul = crop.getUpperLeft();
-			ur = crop.getUpperRight();
-			lr = crop.getLowerRight();
-			ll = crop.getLowerLeft();
+			ul		  = crop.getUpperLeft();
+			ur		  = crop.getUpperRight();
+			lr		  = crop.getLowerRight();
+			ll		  = crop.getLowerLeft();
 
-			//drawRect = ci::Rectf()
+			// drawRect = ci::Rectf()
 		}
 		auto theGeom = ci::geom::Rect(drawRect).texCoords(ll, lr, ur, ul);
 		if (mRenderBatch) {
@@ -555,13 +553,13 @@ void Image::doOnImageLoaded() {
 										 static_cast<float>(mTextureRef->getWidth()), 0.0f);
 
 
-			float orthoW = mTextureRef->getWidth();
-			float orthoH = mTextureRef->getHeight();
-			if (!mResource.empty()) {
-				auto crop = mResource.getCrop();
-				orthoW = orthoW * crop.getWidth();
-				orthoH = orthoH * crop.getHeight();
-			}
+		float orthoW = mTextureRef->getWidth();
+		float orthoH = mTextureRef->getHeight();
+		if (!mResource.empty()) {
+			auto crop = mResource.getCrop();
+			orthoW	  = orthoW * crop.getWidth();
+			orthoH	  = orthoH * crop.getHeight();
+		}
 
 		mDrawRect.mOrthoRect = ci::Rectf(0.0f, 0.0f, orthoW, orthoH);
 	}

--- a/src/ds/ui/sprite/image.cpp
+++ b/src/ds/ui/sprite/image.cpp
@@ -535,7 +535,15 @@ void Image::onBuildRenderBatch() {
 			lr		  = crop.getLowerRight();
 			ll		  = crop.getLowerLeft();
 
-			// drawRect = ci::Rectf()
+			// Invert y-coordinates if image is not loaded top-down.
+			if (!mTextureRef->isTopDown()) {
+				std::swap(ul, ll);
+				std::swap(ur, lr);
+				ul.y = 1.0f - ul.y;
+				ur.y = 1.0f - ur.y;
+				lr.y = 1.0f - lr.y;
+				ll.y = 1.0f - ll.y;
+			}
 		}
 		auto theGeom = ci::geom::Rect(drawRect).texCoords(ll, lr, ur, ul);
 		if (mRenderBatch) {

--- a/src/ds/ui/sprite/image.h
+++ b/src/ds/ui/sprite/image.h
@@ -25,6 +25,8 @@ class Image : public Sprite {
 	static const int IMG_ENABLE_MIPMAP_F = (1 << 2);
 	/// Skip using metadata to size image sprite before loading
 	static const int IMG_SKIP_METADATA_F = (1 << 3);
+	/// Trim image white space
+	static const int IMG_TRIM_WHITESPACE_F = (1 << 4);
 
 
 	static Image& makeImage(SpriteEngine&, const std::string& filename, Sprite* parent = nullptr);
@@ -145,8 +147,8 @@ class Image : public Sprite {
 		ci::Rectf mOrthoRect;
 	} mDrawRect;
 
-	bool			   mCircleCropped;
-	bool			   mCircleCropCentered;
+	bool mCircleCropped;
+	bool mCircleCropCentered;
 	ci::gl::TextureRef mTextureRef;
 	std::string		   mFilename;
 	ds::Resource	   mResource;


### PR DESCRIPTION
This PR adds functionality to trim transparent pixels from images. To enable, use `resource_trim:this->media;` in your XML layout file (note the `trim`). You can also combine this with other flags, like `resource_mipmap_trim:this->media;`.

This also works with cropping. Trimming uses the specified crop rectangle as its bounds, then further adjusts the cropping rectangle based on the alpha channel contents.

Trimming is performed in the image loading thread, using Cinder's built-in functions.

Image data is never discarded. Similar to cropping, only the relevant portion of the image will be shown and measured.

**Call for review**: please take a look at https://github.com/paulhoux/ds_cinder/blob/5481300f2311f2bcc0d23db680bf561596b7a012/src/ds/ui/sprite/image.cpp#L233-L248  

These lines of code adjust the resource crop rectangle, notify others of the change and then do a `runLayout` on the first parent LayoutSprite it finds. This is required to make sure the layout uses the trimmed image measurements, not the untrimmed ones. However, isn't there a more elegant way to do this? It should be done prior to the `checkStatus()` call. 