### PR TITLE
Engine can now enable/disable idling. This will prevent the idleCheck…

### DIFF
--- a/src/ds/app/engine/engine.h
+++ b/src/ds/app/engine/engine.h
@@ -128,6 +128,12 @@ class Engine : public ui::SpriteEngine {
 	void		 startTuio(ds::App&);
 	void		 stopTuio();
 
+	/// Returns whether idle events and checks are enabled.
+	bool isIdlingEnabled() const override { return mIdlingEnabled; }
+
+	/// Sets whether idle events and checks are enabled.
+	void enableIdling(bool enable) override { mIdlingEnabled = enable; }
+
 	/// It's been enough time since the last input and is in idle mode
 	virtual bool isIdling() override;
 
@@ -333,6 +339,7 @@ class Engine : public ui::SpriteEngine {
 	DrawParams	 mDrawParams;
 	float		 mLastTime;
 	bool		 mIdling;
+	bool		 mIdlingEnabled;
 	float		 mLastTouchTime;
 
 	/// Main tuio input

--- a/src/ds/ui/sprite/sprite_engine.h
+++ b/src/ds/ui/sprite/sprite_engine.h
@@ -167,6 +167,9 @@ class SpriteEngine {
 	Sprite* getDragDestinationSprite(const ci::vec3& globalPoint, Sprite* draggingSprite);
 
 	double getElapsedTimeSeconds() const;
+	
+	virtual bool isIdlingEnabled() const { return true; }
+	virtual void enableIdling(bool enable) {}
 
 	int			 getIdleTimeout() const;
 	void		 setIdleTimeout(int idleTimeout);


### PR DESCRIPTION
… from running and no events will be transmitted while not enabled. Use it to temporarily disable idling e.g. during a transition.