### PR TITLE
Fixes several const-correctness issues in the Sprite class…

### DIFF
--- a/src/ds/ui/sprite/sprite.cpp
+++ b/src/ds/ui/sprite/sprite.cpp
@@ -103,7 +103,7 @@ void Sprite::installAsClient(ds::BlobRegistry& registry) {
 void Sprite::handleBlobFromClient(ds::BlobReader& r) {
 	ds::DataBuffer& buf(r.mDataBuffer);
 	if (buf.read<char>() != SPRITE_ID_ATTRIBUTE) return;
-	ds::sprite_id_t id = buf.read<ds::sprite_id_t>();
+	const ds::sprite_id_t id = buf.read<ds::sprite_id_t>();
 	Sprite*			s  = r.mSpriteEngine.findSprite(id);
 	if (s) s->readFrom(r);
 }
@@ -236,7 +236,7 @@ Sprite::~Sprite() {
 	}
 }
 
-void Sprite::updateClient(const UpdateParams& p) {
+void Sprite::updateClient(const UpdateParams& updateParams) {
 	mIdleTimer.update();
 
 	if (mCheckBounds) {
@@ -244,14 +244,14 @@ void Sprite::updateClient(const UpdateParams& p) {
 	}
 
 	for (auto it = mChildren.begin(), it2 = mChildren.end(); it != it2; ++it) {
-		(*it)->updateClient(p);
+		(*it)->updateClient(updateParams);
 	}
 
-	onUpdateClient(p);
+	onUpdateClient(updateParams);
 }
 
-void Sprite::updateServer(const UpdateParams& p) {
-	mTouchProcess.update(p);
+void Sprite::updateServer(const UpdateParams& updateParams) {
+	mTouchProcess.update(updateParams);
 
 	mIdleTimer.update();
 
@@ -260,10 +260,10 @@ void Sprite::updateServer(const UpdateParams& p) {
 	}
 
 	for (auto it = mChildren.begin(), it2 = mChildren.end(); it != it2; ++it) {
-		(*it)->updateServer(p);
+		(*it)->updateServer(updateParams);
 	}
 
-	onUpdateServer(p);
+	onUpdateServer(updateParams);
 }
 
 void Sprite::drawLocalClientInternal(const ci::mat4& totalTransformation, const DrawParams& drawParams) {
@@ -280,7 +280,7 @@ void Sprite::drawLocalClientInternal(const ci::mat4& totalTransformation, const 
 		DS_REPORT_GL_ERRORS();
 		ci::gl::enableAlphaBlending();
 		applyBlendingMode(mBlendMode);
-		ci::gl::GlslProgRef shaderBase = mSpriteShader.getShader();
+		const ci::gl::GlslProgRef shaderBase = mSpriteShader.getShader();
 		if (shaderBase) {
 			DS_REPORT_GL_ERRORS();
 			shaderBase->bind();
@@ -384,7 +384,7 @@ void Sprite::drawClient(const ci::mat4& trans, const DrawParams& drawParams) {
 
 	if (mIsRenderFinalToTexture && mOutputFbo) {
 		// set the viewport and maticies to match the w/h of this object and fbo
-		ci::CameraOrtho			  camera = ci::CameraOrtho(0.0f, getWidth(), getHeight(), 0.0f, -1000.0f, 1000.0f);
+		const ci::CameraOrtho			  camera = ci::CameraOrtho(0.0f, getWidth(), getHeight(), 0.0f, -1000.0f, 1000.0f);
 		ci::gl::ScopedMatrices	  sMat;
 		ci::gl::ScopedViewport	  sVp(ci::ivec2(0), mOutputFbo->getSize());
 		ci::gl::ScopedFramebuffer sFb(mOutputFbo);
@@ -410,12 +410,12 @@ void Sprite::drawServer(const ci::mat4& trans, const DrawParams& drawParams) {
 	}
 
 	buildTransform();
-	ci::mat4 totalTransformation = trans * mTransformation;
+	const ci::mat4 totalTransformation = trans * mTransformation;
 	ci::gl::pushModelMatrix();
 
 	ci::gl::multModelMatrix(totalTransformation);
 
-	bool debugDraw = getDrawDebug();
+	const bool debugDraw = getDrawDebug();
 	if ((mSpriteFlags & TRANSPARENT_F) == 0 && (isEnabled() || debugDraw)) {
 		if (debugDraw) {
 			ci::gl::enableAlphaBlending();
@@ -496,16 +496,16 @@ void Sprite::buildRenderBatch() {
 }
 
 void Sprite::onBuildRenderBatch() {
-	auto drawRect = ci::Rectf(0.0f, 0.0f, getWidth(), getHeight());
+	const auto drawRect = ci::Rectf(0.0f, 0.0f, getWidth(), getHeight());
 	if (mCornerRadius > 0.0f) {
-		auto theGeom = ci::geom::RoundedRect(drawRect, mCornerRadius);
+		const auto theGeom = ci::geom::RoundedRect(drawRect, mCornerRadius);
 		if (mRenderBatch) {
 			mRenderBatch->replaceVboMesh(ci::gl::VboMesh::create(theGeom));
 		} else {
 			mRenderBatch = ci::gl::Batch::create(theGeom, mSpriteShader.getShader());
 		}
 	} else {
-		auto theGeom = ci::geom::Rect(drawRect);
+		const auto theGeom = ci::geom::Rect(drawRect);
 		if (mRenderBatch) {
 			mRenderBatch->replaceVboMesh(ci::gl::VboMesh::create(theGeom));
 		} else {
@@ -559,13 +559,13 @@ const ci::vec3& Sprite::getPosition() const {
 	return mPosition;
 }
 
-const ci::vec3 Sprite::getGlobalPosition() const {
+ci::vec3 Sprite::getGlobalPosition() const {
 	if (!getParent()) return ci::vec3();
 	return getParent()->localToGlobal(mPosition);
 }
 
 
-const ci::vec3 Sprite::getGlobalCenterPosition() const {
+ci::vec3 Sprite::getGlobalCenterPosition() const {
 	return getGlobalPosition() + getLocalCenterPosition();
 }
 
@@ -612,8 +612,8 @@ const ci::vec3& Sprite::getCenter() const {
 	return mCenter;
 }
 
-void Sprite::setRotation(float rotZ) {
-	doSetRotation(ci::vec3(mRotation.x, mRotation.y, rotZ));
+void Sprite::setRotation(float zRot) {
+	doSetRotation(ci::vec3(mRotation.x, mRotation.y, zRot));
 }
 
 void Sprite::setRotation(const float xRot, const float yRot, const float zRot) {
@@ -667,10 +667,10 @@ namespace {
 ci::Rectf Sprite::getBoundingBox() const {
 	const ci::mat4 t = getTransform();
 
-	glm::vec3 ul = glm::vec3(t * glm::vec4(0, 0, 0, 1));
-	glm::vec3 ll = glm::vec3(t * glm::vec4(0, getHeight(), 0, 1));
-	glm::vec3 lr = glm::vec3(t * glm::vec4(getWidth(), getHeight(), 0, 1));
-	glm::vec3 ur = glm::vec3(t * glm::vec4(getWidth(), 0, 0, 1));
+	const glm::vec3 ul = glm::vec3(t * glm::vec4(0, 0, 0, 1));
+	const glm::vec3 ll = glm::vec3(t * glm::vec4(0, getHeight(), 0, 1));
+	const glm::vec3 lr = glm::vec3(t * glm::vec4(getWidth(), getHeight(), 0, 1));
+	const glm::vec3 ur = glm::vec3(t * glm::vec4(getWidth(), 0, 0, 1));
 
 	const float left   = min(min(min(ul.x, ll.x), lr.x), ur.x);
 	const float right  = max(max(max(ul.x, ll.x), lr.x), ur.x);
@@ -685,7 +685,7 @@ ci::Rectf Sprite::getChildBoundingBox() const {
 	auto it = mChildren.begin();
 	// initialize the box to the first child and expand from there
 	ci::Rectf result = (*it)->getBoundingBox();
-	for (auto end = mChildren.end(); it != end; ++it) {
+	for (const auto end = mChildren.end(); it != end; ++it) {
 		ci::Rectf curBounds = (*it)->getBoundingBox();
 		result.include(curBounds);
 	}
@@ -742,7 +742,7 @@ void Sprite::removeChild(Sprite& child) {
 
 	onChildRemoved(child);
 
-	auto found = std::find(mChildren.begin(), mChildren.end(), &child);
+	const auto found = std::find(mChildren.begin(), mChildren.end(), &child);
 	if (found != mChildren.end()) mChildren.erase(found);
 	YGNodeRemoveChild(mYogaNode, child.mYogaNode);
 	if (child.getParent() == this) {
@@ -782,7 +782,7 @@ void Sprite::release() {
 
 bool Sprite::containsChild(Sprite* child) const {
 	if (mChildren.empty()) return false;
-	auto found = std::find(mChildren.begin(), mChildren.end(), child);
+	const auto found = std::find(mChildren.begin(), mChildren.end(), child);
 
 	if (found != mChildren.end()) {
 		return true;
@@ -792,10 +792,10 @@ bool Sprite::containsChild(Sprite* child) const {
 
 void Sprite::clearChildren() {
 	if (mChildren.empty()) return;
-	auto tempList = mChildren;
+	const auto tempList = mChildren;
 	mChildren.clear();
 
-	for (auto it : tempList) {
+	for (const auto it : tempList) {
 		it->release();
 	}
 }
@@ -834,7 +834,7 @@ void Sprite::buildTransform() const {
 	mInverseTransform = glm::inverse(mTransformation);
 }
 
-const ci::vec3 Sprite::getSize() const {
+ci::vec3 Sprite::getSize() const {
 	return ci::vec3(mWidth, mHeight, mDepth);
 }
 
@@ -872,7 +872,7 @@ void Sprite::setSize(float width, float height) {
 }
 
 void Sprite::sizeToChildBounds() {
-	ci::Rectf childBounds = getChildBoundingBox();
+	const ci::Rectf childBounds = getChildBoundingBox();
 
 	move(childBounds.x1, childBounds.y1);
 	setSize(childBounds.getWidth(), childBounds.getHeight());
@@ -982,7 +982,7 @@ void Sprite::buildGlobalTransform() const {
 
 	mGlobalTransform = mTransformation;
 
-	for (Sprite* parent = mParent; parent; parent = parent->getParent()) {
+	for (const Sprite* parent = mParent; parent; parent = parent->getParent()) {
 		parent->buildTransform();
 		mGlobalTransform = parent->mTransformation * mGlobalTransform;
 	}
@@ -990,7 +990,7 @@ void Sprite::buildGlobalTransform() const {
 	mInverseGlobalTransform = glm::inverse(mGlobalTransform);
 }
 
-void Sprite::parentEventReceived(const ds::Event& e) {
+void Sprite::parentEventReceived(const ds::Event& e) const {
 	Sprite* p = mParent;
 	while (p) {
 		p->eventReceived(e);
@@ -1008,16 +1008,16 @@ const ci::mat4& Sprite::getGlobalTransform() const {
 	return mGlobalTransform;
 }
 
-ci::vec3 Sprite::globalToLocal(const ci::vec3& globalPoint) {
+ci::vec3 Sprite::globalToLocal(const ci::vec3& globalPoint) const {
 	buildGlobalTransform();
 
-	ci::vec4 point = mInverseGlobalTransform * ci::vec4(globalPoint.x, globalPoint.y, globalPoint.z, 1.0f);
+	const ci::vec4 point = mInverseGlobalTransform * ci::vec4(globalPoint.x, globalPoint.y, globalPoint.z, 1.0f);
 	return ci::vec3(point.x, point.y, point.z);
 }
 
-ci::vec3 Sprite::localToGlobal(const ci::vec3& localPoint) {
+ci::vec3 Sprite::localToGlobal(const ci::vec3& localPoint) const {
 	buildGlobalTransform();
-	ci::vec4 point = mGlobalTransform * ci::vec4(localPoint.x, localPoint.y, localPoint.z, 1.0f);
+	const ci::vec4 point = mGlobalTransform * ci::vec4(localPoint.x, localPoint.y, localPoint.z, 1.0f);
 	return ci::vec3(point.x, point.y, point.z);
 }
 
@@ -1112,7 +1112,7 @@ Sprite* Sprite::getPerspectiveHit(CameraPick& pick) {
 	}
 
 	// Return the child hit candidate with the nearest hitZ (closest to camera)
-	auto nearestCandidate =
+	const auto nearestCandidate =
 		std::min_element(candidates.begin(), candidates.end(),
 						 [](const HitCandidate& lhs, const HitCandidate& rhs) { return lhs.second < rhs.second; });
 	if (nearestCandidate != candidates.end()) {
@@ -1249,11 +1249,11 @@ void Sprite::disableMultiTouch() {
 	mMultiTouchConstraints.clear();
 }
 
-void Sprite::callAfterDelay(const std::function<void(void)>& fn, const float delay_in_seconds) {
+void Sprite::callAfterDelay(const std::function<void(void)>& fn, const float delayInSeconds) {
 	if (!fn) return;
 	cancelDelayedCall();
 	ci::Timeline& t	   = mEngine.getTweenline().getTimeline();
-	mDelayedCallCueRef = t.add(fn, t.getCurrentTime() + delay_in_seconds);
+	mDelayedCallCueRef = t.add(fn, t.getCurrentTime() + delayInSeconds);
 }
 
 void Sprite::cancelDelayedCall() {
@@ -1271,10 +1271,10 @@ bool Sprite::checkBounds() const {
 
 	const ci::Rectf& screenRect(mEngine.getSrcRect());
 
-	float screenMinX = screenRect.getX1();
-	float screenMaxX = screenRect.getX2();
-	float screenMinY = screenRect.getY1();
-	float screenMaxY = screenRect.getY2();
+	const float screenMinX = screenRect.getX1();
+	const float screenMaxX = screenRect.getX2();
+	const float screenMinY = screenRect.getY1();
+	const float screenMaxY = screenRect.getY2();
 
 	float spriteMinX = 0.0f;
 	float spriteMinY = 0.0f;
@@ -1387,7 +1387,7 @@ void Sprite::setDragDestinationCallback(const std::function<void(Sprite*, const 
 	mDragDestinationCallback = func;
 }
 
-void Sprite::dragDestination(Sprite* sprite, const DragDestinationInfo& dragInfo) {
+void Sprite::dragDestination(Sprite* sprite, const DragDestinationInfo& dragInfo) const {
 	if (mDragDestinationCallback) mDragDestinationCallback(sprite, dragInfo);
 }
 
@@ -1553,7 +1553,7 @@ void Sprite::readAttributesFrom(ds::DataBuffer& buf) {
 			mPosition.z		 = buf.read<float>();
 			transformChanged = true;
 		} else if (id == CHECKBOUNDS_ATT) {
-			bool checkBounds = buf.read<bool>();
+			const bool checkBounds = buf.read<bool>();
 			setCheckBounds(checkBounds);
 		} else if (id == CENTER_ATT) {
 			mCenter.x		 = buf.read<float>();
@@ -1574,17 +1574,17 @@ void Sprite::readAttributesFrom(ds::DataBuffer& buf) {
 		} else if (id == BLEND_ATT) {
 			mBlendMode = buf.read<BlendMode>();
 		} else if (id == CLIP_BOUNDS_ATT) {
-			float x1 = buf.read<float>();
-			float y1 = buf.read<float>();
-			float x2 = buf.read<float>();
-			float y2 = buf.read<float>();
+			const float x1 = buf.read<float>();
+			const float y1 = buf.read<float>();
+			const float x2 = buf.read<float>();
+			const float y2 = buf.read<float>();
 			mClippingBounds.set(x1, y1, x2, y2);
 			markClippingDirty();
 		} else if (id == CORNERRADIUS_ATT) {
-			float cornerRad = buf.read<float>();
+			const float cornerRad = buf.read<float>();
 			mCornerRadius	= cornerRad;
 		} else if (id == SORTORDER_ATT) {
-			int32_t size = buf.read<int32_t>();
+			const int32_t size = buf.read<int32_t>();
 			// I'll assume anything beyond a certain size is a broken packet.
 			if (size > 0 && size < 100000) {
 				try {
@@ -1628,7 +1628,7 @@ void Sprite::setFlag(const int newBit, const bool on, const DirtyState& dirty, i
 	markAsDirty(dirty);
 }
 
-bool Sprite::getFlag(const int bit, const int flags) const {
+bool Sprite::getFlag(const int bit, const int flags) {
 	return (flags & bit) != 0;
 }
 
@@ -1668,27 +1668,27 @@ BlendMode Sprite::getBlendMode() const {
 	return mBlendMode;
 }
 
-void Sprite::setBaseShader(const std::string& location, const std::string& shadername, bool applyToChildren) {
+void Sprite::setBaseShader(const std::string& location, const std::string& shaderName, bool applyToChildren) {
 	mNeedsBatchUpdate = true;
-	mSpriteShader.setShaders(location, shadername);
+	mSpriteShader.setShaders(location, shaderName);
 	setFlag(SHADER_CHILDREN_F, applyToChildren, FLAGS_DIRTY, mSpriteFlags);
 
 	if (applyToChildren) {
 		for (auto it = mChildren.begin(), it2 = mChildren.end(); it != it2; ++it) {
-			(*it)->setBaseShader(location, shadername, applyToChildren);
+			(*it)->setBaseShader(location, shaderName, applyToChildren);
 		}
 	}
 }
 
-void Sprite::setBaseShader(const std::string& vertShader, const std::string& fragShader, const std::string& shadername,
+void Sprite::setBaseShader(const std::string& vertShader, const std::string& fragShader, const std::string& shaderName,
 						   bool applyToChildren) {
 	mNeedsBatchUpdate = true;
-	mSpriteShader.setShaders(vertShader, fragShader, shadername);
+	mSpriteShader.setShaders(vertShader, fragShader, shaderName);
 	setFlag(SHADER_CHILDREN_F, applyToChildren, FLAGS_DIRTY, mSpriteFlags);
 
 	if (applyToChildren) {
 		for (auto it = mChildren.begin(), it2 = mChildren.end(); it != it2; ++it) {
-			(*it)->setBaseShader(vertShader, fragShader, shadername, applyToChildren);
+			(*it)->setBaseShader(vertShader, fragShader, shaderName, applyToChildren);
 		}
 	}
 }
@@ -1724,25 +1724,25 @@ void Sprite::setShaderExtraData(const ci::vec4& data) {
 	mShaderExtraData = data;
 }
 
-void Sprite::setFinalRenderToTexture(bool render_to_texture, FinalRenderInfo info) {
-	if (render_to_texture == mIsRenderFinalToTexture) return;
-	mIsRenderFinalToTexture			  = render_to_texture;
+void Sprite::setFinalRenderToTexture(bool renderToTexture, FinalRenderInfo info) {
+	if (renderToTexture == mIsRenderFinalToTexture) return;
+	mIsRenderFinalToTexture			  = renderToTexture;
 	mFinalToTexture_UseLocalTransform = info.useLocalTransform;
 	mFboFormat						  = info.format;
 	setupFinalRenderBuffer();
 }
 
-void Sprite::setFinalRenderToTexture(bool render_to_texture, ci::gl::Fbo::Format format) {
+void Sprite::setFinalRenderToTexture(bool renderToTexture, ci::gl::Fbo::Format format) {
 	FinalRenderInfo info;
 	info.format = format;
-	setFinalRenderToTexture(render_to_texture, info);
+	setFinalRenderToTexture(renderToTexture, info);
 }
 
-bool Sprite::isFinalRenderToTexture() {
+bool Sprite::isFinalRenderToTexture() const {
 	return mIsRenderFinalToTexture;
 }
 
-ci::gl::TextureRef Sprite::getFinalOutTexture() {
+ci::gl::TextureRef Sprite::getFinalOutTexture() const {
 	if (mOutputFbo) {
 		return mOutputFbo->getColorTexture();
 	} else
@@ -1950,7 +1950,7 @@ void Sprite::userInputReceived() {
 }
 
 void Sprite::sendSpriteToFront(Sprite& sprite) {
-	auto found = std::find(mChildren.begin(), mChildren.end(), &sprite);
+	const auto found = std::find(mChildren.begin(), mChildren.end(), &sprite);
 	if (found == mChildren.end()) return;
 	if (*found == mChildren.back()) return;
 
@@ -1961,7 +1961,7 @@ void Sprite::sendSpriteToFront(Sprite& sprite) {
 }
 
 void Sprite::sendSpriteToBack(Sprite& sprite) {
-	auto found = std::find(mChildren.begin(), mChildren.end(), &sprite);
+	const auto found = std::find(mChildren.begin(), mChildren.end(), &sprite);
 	if (found == mChildren.end()) return;
 	if (*found == mChildren.front()) return;
 
@@ -2074,7 +2074,7 @@ void Sprite::setPerspective(const bool perspective) {
 void Sprite::setFlexboxFromStyleString(std::string style) {
 
 
-	auto settings = ds::split(style, ";", true);
+	const auto settings = ds::split(style, ";", true);
 	for (auto setting : settings) {
 		auto key_value	   = ds::split(setting, ":", true);
 		auto [key, unused] = FlexboxParser::cleanValue(key_value[0]);
@@ -2123,20 +2123,20 @@ void Sprite::setFlexboxAutoSizes() {
 
 void Sprite::setSpriteFromFlexbox() {
 	// position and size
-	auto layout = mYogaNode->getLayout();
-	auto r		= YGNodeLayoutGetRight(mYogaNode);
-	auto b		= YGNodeLayoutGetBottom(mYogaNode);
-	auto x		= YGNodeLayoutGetLeft(mYogaNode);
-	auto y		= YGNodeLayoutGetTop(mYogaNode);
-	auto w		= YGNodeLayoutGetWidth(mYogaNode);
-	auto h		= YGNodeLayoutGetHeight(mYogaNode);
-	auto bt		= YGNodeLayoutGetBorder(mYogaNode, YGEdgeTop);
+	auto       layout = mYogaNode->getLayout();
+	auto       r      = YGNodeLayoutGetRight(mYogaNode);
+	auto       b      = YGNodeLayoutGetBottom(mYogaNode);
+	const auto x      = YGNodeLayoutGetLeft(mYogaNode);
+	const auto y      = YGNodeLayoutGetTop(mYogaNode);
+	const auto w      = YGNodeLayoutGetWidth(mYogaNode);
+	const auto h      = YGNodeLayoutGetHeight(mYogaNode);
+	auto       bt     = YGNodeLayoutGetBorder(mYogaNode, YGEdgeTop);
 
 	setPosition(x, y);
 	setSize(w, h);
 }
 
-ds::cfg::Settings* Sprite::getLayoutSettings() {
+ds::cfg::Settings* Sprite::getLayoutSettings() const {
 	if (mParent != nullptr && mSettings == nullptr) {
 		return mParent->getLayoutSettings();
 	}
@@ -2182,13 +2182,13 @@ void Sprite::setTouchScaleMode(bool doSizeScale) {
 	mTouchScaleSizeMode = doSizeScale;
 }
 
-void Sprite::setInnerHitFunction(std::function<const bool(const ci::vec3&)> func) {
+void Sprite::setInnerHitFunction(const std::function<bool(const ci::vec3&)>& func) {
 	mInnerHitFunction = func;
 }
 
 void Sprite::readClientFrom(ds::DataBuffer& buf) {
 	while (buf.canRead<char>()) {
-		char cmd = buf.read<char>();
+		const char cmd = buf.read<char>();
 		if (cmd != TERMINATOR_CHAR) {
 			readClientAttributeFrom(cmd, buf);
 		} else {
@@ -2200,7 +2200,7 @@ void Sprite::readClientFrom(ds::DataBuffer& buf) {
 void Sprite::write(std::ostream& s, const size_t tab) const {
 	writeState(s, tab);
 	for (auto it = mChildren.begin(), end = mChildren.end(); it != end; ++it) {
-		Sprite* child(*it);
+		const Sprite* child(*it);
 		if (child) child->write(s, tab + 1);
 	}
 }
@@ -2270,7 +2270,7 @@ void Sprite::writeState(std::ostream& s, const size_t tab) const {
 
 // #endif
 
-void Sprite::doPropagateVisibilityChange(bool before, bool after) {
+void Sprite::doPropagateVisibilityChange(bool before, bool after) const {
 	if (before == after) return;
 
 	for (auto it = mChildren.cbegin(), it2 = mChildren.cend(); it != it2; ++it) {
@@ -2303,7 +2303,7 @@ void Sprite::setDrawDebug(const bool doDebug) {
 		mSpriteFlags &= ~DRAW_DEBUG_F;
 }
 
-bool Sprite::getDrawDebug() {
+bool Sprite::getDrawDebug() const {
 	return getFlag(DRAW_DEBUG_F, mSpriteFlags);
 }
 
@@ -2321,7 +2321,7 @@ YGSize Sprite::yogaMeasureFunc(YGNodeRef node, float width, YGMeasureMode widthM
 	return retVal;
 }
 
-const std::wstring Sprite::getSpriteName(const bool useDefault) const {
+std::wstring Sprite::getSpriteName(const bool useDefault) const {
 	if (mSpriteName.empty() && useDefault) {
 		std::wstringstream wss;
 		wss << getId();

--- a/src/ds/ui/sprite/sprite.h
+++ b/src/ds/ui/sprite/sprite.h
@@ -67,11 +67,11 @@ namespace ui {
 	class Sprite : public SpriteAnimatable {
 	  public:
 		struct FinalRenderInfo {
-			FinalRenderInfo() {}
-			FinalRenderInfo(const FinalRenderInfo&)			   = default;
-			FinalRenderInfo(FinalRenderInfo&&)				   = default;
+			FinalRenderInfo()                                  = default;
+			FinalRenderInfo(const FinalRenderInfo&)            = default;
+			FinalRenderInfo(FinalRenderInfo&&)                 = default;
 			FinalRenderInfo& operator=(const FinalRenderInfo&) = default;
-			FinalRenderInfo& operator=(FinalRenderInfo&&)	   = default;
+			FinalRenderInfo& operator=(FinalRenderInfo&&)      = default;
 
 			bool				useLocalTransform = true;
 			ci::gl::Fbo::Format format			  = ci::gl::Fbo::Format();
@@ -103,7 +103,7 @@ namespace ui {
 			\param width Initial horizontal size of the sprite.
 			\param height Initial vertical size of the sprite.		*/
 		Sprite(SpriteEngine& engine, float width = 0.0f, float height = 0.0f);
-		virtual ~Sprite();
+		~Sprite() override;
 
 		/** Update function for when this app is set to be a client.
 			Don't override this function, use onUpdateClient if you need it
@@ -158,7 +158,7 @@ namespace ui {
 
 		/** Get the width, height, and depth of this Sprite. Convenience for getWidth(), getHeight() and getDepth().
 			\return Returns a 3-dimensional vector equivalent to ci::vec3(width, height, depth).		*/
-		const ci::vec3 getSize() const;
+		ci::vec3 getSize() const;
 
 		/** Sets the width and height of the Sprite.
 			This does not affect the scale of the Sprite. Many subclasses set the size of the Sprite themselves, such as
@@ -260,12 +260,12 @@ namespace ui {
 		/** Get the position of the Sprite in global space.
 			Returns ci::vec3::zero() if this sprite has no parent.
 			\return The 3d vector of the world-space position, in pixels. */
-		const ci::vec3 getGlobalPosition() const;
+		ci::vec3 getGlobalPosition() const;
 
 		/** Get the center position of the Sprite in global space. This is a convenience that's getGlobalPostion() +
 		getLocalCenterPosition(); Returns ci::vec3::zero() + getLocalCenterPosition() if this sprite has no parent.
 		\return The 3d vector of the center of this sprite world-space position, in pixels. */
-		const ci::vec3 getGlobalCenterPosition() const;
+		ci::vec3 getGlobalCenterPosition() const;
 
 		/** Change the position of the Sprite relative to it's current position.
 			\param delta 3d vector of the amount to move the Sprite in pixels		*/
@@ -315,7 +315,7 @@ namespace ui {
 			\return center 3d vector of the center percentage. */
 		const ci::vec3& getCenter() const;
 
-		/** The "midde" of the Sprite, NOT related to setCenter and getCenter (anchor), in the parent's co-ordinate
+		/** The "middle" of the Sprite, NOT related to setCenter and getCenter (anchor), in the parent's co-ordinate
 		   space. Effectively mPosition + getLocalCenterPosition(); \return 3d Vector of the pixel position of the
 		   center of this Sprite. */
 		ci::vec3 getCenterPosition() const;
@@ -330,24 +330,24 @@ namespace ui {
 			\param zRot Sets the rotation around the z-axis, in degrees. 	*/
 		void setRotation(float zRot);
 
-		/** Set the rotation around all 3 axis'es, in degrees.
+		/** Set the rotation around all 3 axes, in degrees.
 			\param xRot Sets the rotation around the x-axis, in degrees.
 			\param yRot Sets the rotation around the y-axis, in degrees.
 			\param zRot Sets the rotation around the z-axis, in degrees. 	*/
-		void setRotation(const float xRot, const float yRot, const float zRot);
+		void setRotation(float xRot, float yRot, float zRot);
 
-		/** Set the rotation around all 3 axis'es, in degrees.
+		/** Set the rotation around all 3 axes, in degrees.
 			\param rot 3d vector of the new rotation, in degrees.*/
 		void setRotation(const ci::vec3& rot);
 
-		/** Set the rotation around all 3 given axis'es with the given degree
+		/** Set the rotation around all 3 given axes with the given degree
 			\param axis    axis to rotate around
 			\param angle   Amount of rotation in degrees */
-		void  setRotation(const ci::vec3& axis, const float angle);
+		void  setRotation(const ci::vec3& axis, float angle);
 		bool  mDoSpecialRotation;
 		float mDegree;
 
-		/** Get the rotation around all 3 axis'es, in degrees.
+		/** Get the rotation around all 3 axes, in degrees.
 			\return 3d vector of the current rotation, in degrees.*/
 		ci::vec3 getRotation() const;
 
@@ -438,9 +438,9 @@ namespace ui {
 		bool containsChild(Sprite* child) const;
 
 		/** Run a function for every child of this Sprite.
-			\param funkyTown The lambda function to be called for each Sprite.
+			\param fn The lambda function to be called for each Sprite.
 			\param recurse Call this function for all children of all children of all my children. */
-		void forEachChild(const std::function<void(Sprite&)>& funkyTown, const bool recurse = false);
+		void forEachChild(const std::function<void(Sprite&)>& fn, bool recurse = false);
 
 		/** Traverse children recursively and find a sprite the with the given name.
 			\param name The name given from layout or from setSpriteName(). */
@@ -523,7 +523,7 @@ namespace ui {
 
 		/** A convenience for notifying parents of events. Passes the event up through the parent hierarchy to the root
 		   Sprite. Calls eventReceived() for each parent. \param event The Event to be passed up the chain. */
-		void parentEventReceived(const ds::Event& event);
+		void parentEventReceived(const ds::Event& event) const;
 
 		/** Returns the parent for this Sprite, if any. Can return nullptr if there is no parent, so check before using.
 		 */
@@ -537,7 +537,7 @@ namespace ui {
 			\endcode
 			\param globalPoint The 3d vector in global coordinate space to be converted.
 			\return A local 3d vector in the coordinate space of this Sprite. */
-		ci::vec3 globalToLocal(const ci::vec3& globalPoint);
+		ci::vec3 globalToLocal(const ci::vec3& globalPoint) const;
 
 		/** Convert coordinate space from local coordinate space of this Sprite to global (world) coordinate space. May
 		   not work for perspective Sprites. For example, you could figure out where to launch a media viewer from a
@@ -547,13 +547,13 @@ namespace ui {
 			\endcode
 			\param localPoint The 3d vector in local coordinate space to be converted.
 			\return A local 3d vector in the coordinate space of this Sprite. */
-		ci::vec3 localToGlobal(const ci::vec3& localPoint);
+		ci::vec3 localToGlobal(const ci::vec3& localPoint) const;
 
 		/** Check if a global point is inside the Sprite's bounding box, does not take perspective into account.
 			\param point The global point to check if it's inside this Sprite's bounding box.
 			\param pad Extra pixel size outside this Sprite's bounding box. Useful for ad-hoc touch padding.
 			\return True if the point is inside the bounding box, false for outside. */
-		virtual bool contains(const ci::vec3& point, const float pad = 0.0f) const;
+		virtual bool contains(const ci::vec3& point, float pad = 0.0f) const;
 
 		/** Recursively checks the Sprite hierarchy list for an enabled, visible sprite with a scale > 0.0 and any size
 		   for touch picking. This is for Ortho Sprites. Perspective Sprites use getPerspectiveHit() \param point The
@@ -586,7 +586,7 @@ namespace ui {
 		void disableMultiTouch();
 
 		/** The BitMask of*/
-		const BitMask& getMultiTouchConstraints() { return mMultiTouchConstraints; }
+		const BitMask& getMultiTouchConstraints() const { return mMultiTouchConstraints; }
 
 		/** Has enableMultiTouch() been called?  */
 		bool multiTouchEnabled() const;
@@ -616,7 +616,7 @@ namespace ui {
 		/** Get notified if a double tap has occurred within the double tap threshold. */
 		void setDoubleTapCallback(const std::function<void(Sprite*, const ci::vec3&)>& func);
 
-		/** Get notified if this sprite gets dragged over any desintation sprites. Set destination sprites with
+		/** Get notified if this sprite gets dragged over any destination sprites. Set destination sprites with
 		 * mEngine.addToDragDestinationList()*/
 		void setDragDestinationCallback(const std::function<void(Sprite*, const DragDestinationInfo&)>& func);
 
@@ -632,14 +632,14 @@ namespace ui {
 			MULTITOUCH_CAN_SCALE has to be a touch flag as well as the sprite being enabled to take effect */
 		void setTouchScaleMode(bool doSizeScale);
 
-		void setInnerHitFunction(std::function<const bool(const ci::vec3&)> func);
+		void setInnerHitFunction(const std::function<bool(const ci::vec3&)>& func);
 
 		/** Calls a function after the delay in seconds. Only one function is active at a time, so if you set this
 		   twice, the first delayed call will be ignored. Also see src/ds/time_callback or mEngine.timedCallback() or
 		   mEngine.repeatedCallback() for a generic timed callback*/
-		void callAfterDelay(const std::function<void(void)>&, const float delay_in_seconds);
+		void callAfterDelay(const std::function<void()>&, float delayInSeconds);
 
-		/** Cancels any pending callAfterDelay() funcitons */
+		/** Cancels any pending callAfterDelay() functions */
 		void cancelDelayedCall();
 
 		/** This sprite is within the boundaries of the src_rect for this instance */
@@ -672,18 +672,18 @@ namespace ui {
 		// Deprecate?
 		//[[deprecated("Use FinalRenderInfo.format and setFinalRenderToTexture(bool render_to_texture, FinalRenderInfo
 		// info)")]]
-		void setFinalRenderToTexture(bool render_to_texture, ci::gl::Fbo::Format format);
-		void setFinalRenderToTexture(bool render_to_texture, FinalRenderInfo info = FinalRenderInfo());
-		bool isFinalRenderToTexture();
+		void setFinalRenderToTexture(bool renderToTexture, ci::gl::Fbo::Format format);
+		void setFinalRenderToTexture(bool renderToTexture, FinalRenderInfo info = FinalRenderInfo());
+		bool isFinalRenderToTexture() const;
 
 		// Retrieve the rendered output texture
-		ci::gl::TextureRef getFinalOutTexture();
-		void			   setupFinalRenderBuffer();
+		ci::gl::TextureRef getFinalOutTexture() const;
+		void               setupFinalRenderBuffer();
 
 		/// WARNING: ONLY shader loading is network safe. Uniforms are not synchronized.
-		void setBaseShader(const std::string& location, const std::string& shadername, bool applyToChildren = false);
+		void setBaseShader(const std::string& location, const std::string& shaderName, bool applyToChildren = false);
 		void setBaseShader(const std::string& vertShaderString, const std::string& fragShaderString,
-						   const std::string& shadername, bool applyToChildren = false);
+						   const std::string& shaderName, bool applyToChildren = false);
 
 		/// Set the resource content for a sprite. This is a base function that should be overridden by anything that
 		/// can take a Resource (Image, Video, PDF, etc)
@@ -702,7 +702,7 @@ namespace ui {
 		virtual void userInputReceived();
 
 		/// Set the number of seconds since the last userInputReceived() before this sprite reports as idle
-		void   setSecondBeforeIdle(const double);
+		void   setSecondBeforeIdle(double);
 		double secondsToIdle() const;
 		bool   isIdling() const;
 		void   startIdling();
@@ -711,24 +711,24 @@ namespace ui {
 
 		/// Prevent this sprite (and all children) from replicating. NOTE: Should
 		/// only be done once on construction, if you change it, weird things could happen.
-		void setNoReplicationOptimization(const bool = false);
+		void setNoReplicationOptimization(bool = false);
 		/// Special function to mark every sprite from me down as dirty.
 		void markTreeAsDirty();
 
 		/// When true, the touch input is automatically rotated to account for my rotation.
-		void setRotateTouches(const bool = false);
+		void setRotateTouches(bool = false);
 		bool isRotateTouches() const;
 
 		bool getPerspective() const;
 		/// Total hack resulting from my unfamiliarity with 3D systems. This can sometimes be necessary for
 		/// views that are inside of perspective cameras, but are expressed in screen coordinates.
-		void setIsInScreenCoordsHack(const bool);
+		void setIsInScreenCoordsHack(bool);
 
 		void setUseDepthBuffer(bool useDepth);
 		bool getUseDepthBuffer() const;
 
 		/// If this sprite renders locally and the radius is > 0, will draw a rounded rect
-		void  setCornerRadius(const float newRadius);
+		void  setCornerRadius(float newRadius);
 		float getCornerRadius() const;
 
 		/// Answer true if this sprite currently has any touches.
@@ -744,11 +744,11 @@ namespace ui {
 		/// Mark this sprite to be a debug sprite layer.
 		///	The primary use case is server-only or client-only setups, so the stats view can draw when not enabled and
 		/// not be colored weird. 	Client apps don't generally need to set this flag, as it happens automagically.
-		void setDrawDebug(const bool doDebug);
+		void setDrawDebug(bool doDebug);
 
 		/// If this sprite has been flagged to draw as a debug layer. Will draw in the server draw loop even if
 		/// disabled.
-		bool getDrawDebug();
+		bool getDrawDebug() const;
 
 		/// Set the name of this sprite. No guarantee of uniqueness
 		void setSpriteName(const std::wstring& name);
@@ -757,8 +757,8 @@ namespace ui {
 		// sprite is part of. The sprite need not have been created in
 		// the layout for this to work, but one of its ancestor sprite needs to have been.
 		// if this sprite or no ancestor was created via layout, then this will return nullptr
-		ds::cfg::Settings* getLayoutSettings();
-		void			   setLayoutSettings(const ds::cfg::Settings& settings);
+		ds::cfg::Settings* getLayoutSettings() const;
+		void               setLayoutSettings(const ds::cfg::Settings& settings);
 
 		// Flexbox
 		virtual void setFlexboxFromStyleString(std::string style);
@@ -770,7 +770,7 @@ namespace ui {
 										  YGMeasureMode heightMode);
 		/// Return the sprite's name, no guarantee of uniqueness. Returns the Id if there's no name set and useDefault
 		/// is true.
-		const std::wstring getSpriteName(const bool useDefault = true) const;
+		std::wstring getSpriteName(bool useDefault = true) const;
 
 		/// For use by any layout classes you may want to implement. Default = 0.0f or 0 for all of these
 		float	 mLayoutTPad;
@@ -798,7 +798,7 @@ namespace ui {
 		bool tapInfo(const TapInfo&);
 		void tap(const ci::vec3& tapPos);
 		void doubleTap(const ci::vec3& tapPos);
-		void dragDestination(Sprite* sprite, const DragDestinationInfo& dragInfo);
+		void dragDestination(Sprite* sprite, const DragDestinationInfo& dragInfo) const;
 		void processTouchInfo(const TouchInfo& touchInfo);
 		void processTouchInfoCallback(const TouchInfo& touchInfo);
 
@@ -822,7 +822,7 @@ namespace ui {
 		virtual void doSetPosition(const ci::vec3&);
 		virtual void doSetScale(const ci::vec3&);
 		virtual void doSetRotation(const ci::vec3&);
-		void		 doPropagateVisibilityChange(bool before, bool after);
+		void		 doPropagateVisibilityChange(bool before, bool after) const;
 
 		virtual void onCenterChanged() {}
 		virtual void onPositionChanged() {}
@@ -850,8 +850,8 @@ namespace ui {
 
 		void setSpriteId(const ds::sprite_id_t&);
 		/// Helper utility to set a flag
-		void setFlag(const int newBit, const bool on, const DirtyState&, int& oldFlags);
-		bool getFlag(const int bit, const int flags) const;
+		void        setFlag(int newBit, bool on, const DirtyState&, int& oldFlags);
+		static bool getFlag(int bit, int flags);
 
 		virtual void markAsDirty(const DirtyState&);
 		/// Special function that marks all children as dirty, without sending anything up the hierarchy.
@@ -870,7 +870,7 @@ namespace ui {
 		void sendSpriteToFront(Sprite& sprite);
 		void sendSpriteToBack(Sprite& sprite);
 
-		void setPerspective(const bool);
+		void setPerspective(bool);
 
 		mutable bool mBoundsNeedChecking;
 		mutable bool mInBounds;
@@ -964,12 +964,12 @@ namespace ui {
 		friend class ds::EngineRoot;
 		/// Disable copy constructor; sprites are managed by their parent and
 		/// must be allocated
-		Sprite(const Sprite&);
+		Sprite(const Sprite&) = delete;
 		/// Internal constructor just for the Engine, used to create the root sprite,
 		/// which always exists and is identical across all architectures.
-		Sprite(SpriteEngine&, const ds::sprite_id_t id, const bool perspective = false);
+		Sprite(SpriteEngine&, ds::sprite_id_t id, bool perspective = false);
 
-		void init(const ds::sprite_id_t);
+		void init(ds::sprite_id_t);
 		void readAttributesFrom(ds::DataBuffer&);
 
 		void dimensionalStateChanged();
@@ -1017,8 +1017,8 @@ namespace ui {
 		// #ifdef _DEBUG
 		/// Debugging aids to write out my state. write() calls writeState
 		/// on me and all my children.
-		void		 write(std::ostream&, const size_t tab) const;
-		virtual void writeState(std::ostream&, const size_t tab) const;
+		void         write(std::ostream&, size_t tab) const;
+		virtual void writeState(std::ostream&, size_t tab) const;
 		// #endif
 
 		static void installAsServer(ds::BlobRegistry&);


### PR DESCRIPTION
…as well as a few minor typos. The reason for this update was that I could not call globalToLocal() from a contains() method, because the former was (incorrectly) not labelled const and the latter was (correctly).