### PR TITLE
This commit adds ds::ui::Grid, a CSS Grid Layout implementation

### DIFF
--- a/doc/basics/Dynamic Interfaces.md
+++ b/doc/basics/Dynamic Interfaces.md
@@ -94,6 +94,7 @@ Xml Element Name                                                      | DsCinder
 [text](#Text-Parameters)                                              | ds::ui::Text
 [gradient](#Gradient-Parameters)                                      | ds::ui::GradientSprite
 [layout](#Layout-Parameters)                                          | ds::ui::LayoutSprite
+[grid](#Grid-Parameters)                                              | ds::ui::Grid
 [persp_layout](#Perspective-Layout-Parameters)                        | ds::ui::PerspectiveLayout
 [circle](#Circle-Parameters)                                          | ds::ui::Circle
 [border](#Border-Parameters)                                          | ds::ui::Border
@@ -327,10 +328,16 @@ Sprite Parameters
 		1. default. does nothing. reverts to logic above.
 		2. letterbox. Force sprite to letterbox.
 		3. fill. Force sprite to fill the space.
+	* **grid_column**: Sets the column or columns in which this sprite will be placed within a Grid layout.
+	* **grid_row**: Sets the row or rows in which this sprite will be placed within a Grid layout.
+	* **min_width**: Sets the minimum width in pixels of this sprite when placed within a Grid layout.
+	* **max_width**: Sets the maximum width in pixels of this sprite when placed within a Grid layout.
+	* **min_height**: Sets the minimum height in pixels of this sprite when placed within a Grid layout.
+	* **max_height**: Sets the maximum height in pixels of this sprite when placed within a Grid layout.
+	* **fit**: Currently only used within a Grid layout, this will adjust the sprite's scale and position to make it fit the assigned layout area. Defaults to "xMinYMin". The property takes a string like "xMinYmid meet" (case insensitive), where "xMin" = left aligned, "xMid" = centered and "xMax" = right aligned; "yMin" = top aligned, "yMid" = centered and "yMax" = bottom aligned; "meet" (optional) will reduce the scale of the sprite until it fits the smallest of width and height (similar to letterboxing), where "slice" (optional) will increase the scale of the sprite until it fits the largest of width and height (some portions of the sprite will not be seen). If set to "none", will scale the sprite non-uniformly to fit the area. See also: https://www.dofactory.com/html/svg/preserveaspectratio 
 
 Layout Parameters
 ------------------------------------------------------------
-
 * **layout_type**: For a LayoutSprite only (has no effect on children).
     1. vert: (Default) lays out all children in a vertical (top to bottom) flow.
     2. horiz: Lays out children horizontally (left to right)
@@ -357,6 +364,14 @@ Perspective Layout Parameters
 * **persp_near_clip**: Float for the near clipping distance, only if auto clip is disabled
 * **persp_far_clip**: Float for the far clipping distance, only if auto clip is disabled
 * **persp_enabled**: Bool to enable or disable rendering in 3d at all
+
+Grid Parameters
+------------------------------------------------------------
+* **grid_template_columns**: Specifies the columns of the Grid in CSS-style notation. The string contains one or more values, separated by a space. Each value can be a fixed size (e.g. "100px", "25%"), an intrinsic (e.g. "min-content", "max-content") or a function (e.g. "auto", "minmax(10px, 100x)"). In additional, free space can be assigned using fractional values, e.g. to divide the layout into 3 equally spaced columns, you can use "1fr 1fr 1fr". Finally, you can use the repeat function to more easily set multiple columns: "repeat(3, 1fr)".
+* **grid_template_rows**: Specifies the rows of the Grid in CSS-style notation.
+* **grid_gap**: Specifies a gap between the columns and rows of the Grid, e.g. "10px" or "5%".
+* **grid_column_gap**: Specifies a gap between the columns of the Grid, e.g. "10px" or "5%".
+* **grid_row_gap**: Specifies a gap between the rows of the Grid, e.g. "10px" or "5%".
 
 Text Parameters
 ------------------------------------------------------------

--- a/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
+++ b/projects/essentials/src/ds/ui/interface_xml/interface_xml_importer.cpp
@@ -18,6 +18,7 @@
 #include <ds/ui/button/sprite_button.h>
 #include <ds/ui/control/control_check_box.h>
 #include <ds/ui/control/control_slider.h>
+#include <ds/ui/grid/grid.h>
 #include <ds/ui/layout/layout_sprite.h>
 #include <ds/ui/layout/perspective_layout.h>
 #include <ds/ui/scroll/centered_scroll_area.h>
@@ -331,6 +332,21 @@ void XmlImporter::setSpriteProperty(ds::ui::Sprite& sprite, const std::string& p
 			ci::vec3 v = parseVector(p.value);
 			p.sprite.setSize(v.x, v.y);
 		};
+		propertyMap["min-width"] = propertyMap["min_width"] = [](const SprProps& p) {
+			p.sprite.setWidthMin(p.value);
+		};
+		propertyMap["max-width"] = propertyMap["max_width"] = [](const SprProps& p) {
+			p.sprite.setWidthMax(p.value);
+		};
+		propertyMap["min-height"] = propertyMap["min_height"] = [](const SprProps& p) {
+			p.sprite.setHeightMin(p.value);
+		};
+		propertyMap["max-height"] = propertyMap["max_height"] = [](const SprProps& p) {
+			p.sprite.setHeightMax(p.value);
+		};
+		propertyMap["fit"] = [](const SprProps& p) {
+			p.sprite.setFit(p.value);
+		};
 		propertyMap["color"] = [](const SprProps& p) {
 			p.sprite.setTransparent(false);
 			p.sprite.setColorA(parseColor(p.value, p.engine));
@@ -404,6 +420,14 @@ void XmlImporter::setSpriteProperty(ds::ui::Sprite& sprite, const std::string& p
 			p.sprite.mLayoutTPad = (county > 1) ? ds::string_to_float(pads[1]) : 0.0f;
 			p.sprite.mLayoutRPad = (county > 2) ? ds::string_to_float(pads[2]) : 0.0f;
 			p.sprite.mLayoutBPad = (county > 3) ? ds::string_to_float(pads[3]) : 0.0f;
+		};
+		propertyMap["grid-column"] = propertyMap["grid_column"] = [](const SprProps& p) {
+			const char* sInOut = p.value.c_str();
+			p.sprite.setColumnSpan(Grid::parseSpan(&sInOut));
+		};
+		propertyMap["grid-row"] = propertyMap["grid_row"] = [](const SprProps& p) {
+			const char* sInOut = p.value.c_str();
+			p.sprite.setRowSpan(Grid::parseSpan(&sInOut));
 		};
 		propertyMap["layout_size_mode"] = [](const SprProps& p) {
 			const auto sizeMode = p.value;
@@ -552,6 +576,48 @@ void XmlImporter::setSpriteProperty(ds::ui::Sprite& sprite, const std::string& p
 			auto layoutsprite = dynamic_cast<LayoutSprite*>(&p.sprite);
 			if (layoutsprite) {
 				layoutsprite->setSkipHiddenChildren(parseBoolean(p.value));
+			} else {
+				logAttributionWarning(p);
+			}
+		};
+
+		// Grid specific attributes
+		propertyMap["grid-template-columns"] = propertyMap["grid_template_columns"] = [](const SprProps& p) {
+			auto grid = dynamic_cast<Grid*>(&p.sprite);
+			if (grid) {
+				grid->setColumns(p.value);
+			} else {
+				logAttributionWarning(p);
+			}
+		};
+		propertyMap["grid-template-rows"] = propertyMap["grid_template_rows"] = [](const SprProps& p) {
+			auto grid = dynamic_cast<Grid*>(&p.sprite);
+			if (grid) {
+				grid->setRows(p.value);
+			} else {
+				logAttributionWarning(p);
+			}
+		};
+		propertyMap["grid-gap"] = propertyMap["grid_gap"] = [](const SprProps& p) {
+			auto grid = dynamic_cast<Grid*>(&p.sprite);
+			if (grid) {
+				grid->setGap(p.value);
+			} else {
+				logAttributionWarning(p);
+			}
+		};
+		propertyMap["grid-column-gap"] = propertyMap["grid_column_gap"] = [](const SprProps& p) {
+			auto grid = dynamic_cast<Grid*>(&p.sprite);
+			if (grid) {
+				grid->setColumnGap(p.value);
+			} else {
+				logAttributionWarning(p);
+			}
+		};
+		propertyMap["grid-row-gap"] = propertyMap["grid_row_gap"] = [](const SprProps& p) {
+			auto grid = dynamic_cast<Grid*>(&p.sprite);
+			if (grid) {
+				grid->setRowGap(p.value);
 			} else {
 				logAttributionWarning(p);
 			}
@@ -1874,6 +1940,8 @@ ds::ui::Sprite* XmlImporter::createSpriteByType(ds::ui::SpriteEngine& engine, co
 	} else if (type == "layout") {
 		auto layoutSprite = new ds::ui::LayoutSprite(engine);
 		spriddy			  = layoutSprite;
+	} else if (type == "grid") {
+		spriddy = new ds::ui::Grid(engine);
 	} else if (type == "border") {
 		spriddy = new ds::ui::Border(engine);
 	} else if (type == "circle") {

--- a/src/ds/ui/grid/grid.cpp
+++ b/src/ds/ui/grid/grid.cpp
@@ -1,0 +1,1066 @@
+#include "stdafx.h"
+
+#include "ds/ui/grid/grid.h"
+#include "ds/util/parse_util.h"
+
+namespace {
+
+using namespace ds::ui;
+
+// GridItem functions.
+
+float getWidthMin(const Sprite* item) {
+	return item->getWidthMin();
+}
+
+float getWidthMax(const Sprite* item) {
+	return item->getWidthMax();
+}
+
+float getHeightMin(const Sprite* item) {
+	return item->getHeightMin();
+}
+
+float getHeightMax(const Sprite* item) {
+	return item->getHeightMax();
+}
+
+const Range<size_t>& getColumnSpan(const Sprite* item) {
+	return item->getColumnSpan();
+}
+
+const Range<size_t>& getRowSpan(const Sprite* item) {
+	return item->getRowSpan();
+}
+
+// Accumulator functions.
+
+float& getTrackUsedBreadthRef(Grid::Track& track) {
+	return track.usedBreadth;
+}
+
+float& getTrackMaxBreadthRef(Grid::Track& track) {
+	return track.maxBreadth;
+}
+
+// Breadth functions.
+
+float getTrackBase(const Grid::Track& track) {
+	return track.usedBreadth;
+}
+
+float getTrackMaxBreadth(const Grid::Track& track) {
+	return track.maxBreadth;
+}
+
+SizingFn getSizingMin(const Grid::Track& track) {
+	return track.min;
+}
+
+SizingFn getSizingMax(const Grid::Track& track) {
+	return track.max;
+}
+
+// TracksForGrowthBeyondConstraint functions.
+
+// Identity function.
+std::vector<Grid::Track*> getTracks(const std::vector<Grid::Track*>& tracks) {
+	return tracks;
+}
+
+std::vector<Grid::Track*> getTracksMinIsMax(const std::vector<Grid::Track*>& tracks) {
+	std::vector<Grid::Track*> result;
+
+	for (const auto& track : tracks) {
+		if (track->min.isMaxContent()) result.push_back(track);
+	}
+
+	return result;
+}
+
+std::vector<Grid::Track*> getTracksMinIsMinOrMax(const std::vector<Grid::Track*>& tracks) {
+	std::vector<Grid::Track*> result;
+
+	for (const auto& track : tracks) {
+		if (track->min.isMinContent() || track->min.isMaxContent()) result.push_back(track);
+	}
+
+	return result;
+}
+
+std::vector<Grid::Track*> getTracksMaxIsMinOrMax(const std::vector<Grid::Track*>& tracks) {
+	std::vector<Grid::Track*> result;
+
+	for (const auto& track : tracks) {
+		if (track->max.isMinContent() || track->max.isMaxContent()) result.push_back(track);
+	}
+
+	return result; // result.empty() ? tracks : result;
+}
+
+std::vector<Grid::Track*> getTracksMaxIsMax(const std::vector<Grid::Track*>& tracks) {
+	std::vector<Grid::Track*> result;
+
+	for (const auto& track : tracks) {
+		if (track->max.isMaxContent()) result.push_back(track);
+	}
+
+	return result; // result.empty() ? tracks : result;
+}
+
+// Subset functions.
+
+// Converts a set of tracks into a set of track pointers for further processing.
+std::vector<Grid::Track*> getAllTracks(const std::vector<Grid::Track>& tracks) {
+	std::vector<Grid::Track*> result;
+
+	for (const auto& track : tracks)
+		result.push_back(const_cast<Grid::Track*>(&track));
+
+	return result;
+}
+
+// Given a set of \a tracks, it returns a set of pointers to all tracks covered by \a item.
+std::vector<Grid::Track*> getSpannedTracks(const std::vector<Grid::Track>& tracks, const Sprite* item,
+										   const SpanFn& spanFn) {
+	std::vector<Grid::Track*> result;
+
+	const auto& span = spanFn(item);
+	for (size_t i = span.min; i < span.max; ++i) {
+		if (i < tracks.size()) result.push_back(const_cast<Grid::Track*>(tracks.data() + i));
+	}
+
+	return result;
+}
+
+// Returns the set of grid tracks whose MaxTrackSizingFunction is a flexible length.
+std::vector<Grid::Track*> getFlexTracks(const std::vector<Grid::Track*>& tracks) {
+	std::vector<Grid::Track*> result;
+
+	for (auto track : tracks)
+		if (track->max.isFlex()) result.push_back(track);
+
+	return result;
+}
+
+// Returns the set of grid items whose span count equals \a spanCount.
+std::vector<Sprite*> getItemsWithSpanCount(const std::vector<Sprite*>& items, const SpanFn& spanFn, size_t spanCount) {
+	std::vector<Sprite*> result;
+
+	for (auto item : items) {
+		const auto& span = spanFn(item);
+		if (span.count() == spanCount) result.push_back(item);
+	}
+
+	return result;
+}
+
+// AdditionalSpace functions.
+
+float calcAdditionSpaceBase(const std::vector<Grid::Track>& tracks, const Sprite* item, const SizeFn& sizeFn,
+							const SpanFn& spanFn) {
+	float result = sizeFn(item);
+
+	for (const auto track : getSpannedTracks(tracks, item, spanFn)) {
+		result -= track->usedBreadth;
+	}
+
+	return glm::max(0.f, result);
+}
+
+float calcAdditionSpaceLimit(const std::vector<Grid::Track>& tracks, const Sprite* item, const SizeFn& sizeFn,
+							 const SpanFn& spanFn) {
+	float result = sizeFn(item);
+
+	for (const auto track : getSpannedTracks(tracks, item, spanFn)) {
+		if (std::isfinite(track->maxBreadth))
+			result -= track->maxBreadth;
+		else
+			result -= track->usedBreadth;
+	}
+
+	return glm::max(0.f, result);
+}
+
+} // namespace
+
+namespace ds::ui {
+
+Grid::Grid(SpriteEngine& engine)
+  : Sprite(engine) {
+	setTransparent(false); // For debugging.
+}
+
+void Grid::setColumns(const std::string& def) {
+	mColumns.clear();
+	try {
+		parse(mColumns, def);
+	} catch (const std::exception& exc) {
+		DS_LOG_ERROR(exc.what() << " in " << def)
+	}
+}
+
+void Grid::setRows(const std::string& def) {
+	mRows.clear();
+	try {
+		parse(mRows, def);
+	} catch (const std::exception& exc) {
+		DS_LOG_ERROR(exc.what() << " in " << def)
+	}
+}
+
+void Grid::setColumnGap(const std::string& def) {
+	mColumnGap = Value(def);
+}
+
+void Grid::setRowGap(const std::string& def) {
+	mRowGap = Value(def);
+}
+
+void Grid::setGap(const std::string& def) {
+	mColumnGap = mRowGap = Value(def);
+}
+
+ci::Rectf Grid::calcArea(const Range<size_t>& column, const Range<size_t>& row) const {
+	const auto x1 = calcColumnPos(column.min);
+	const auto y1 = calcRowPos(row.min);
+	const auto x2 = calcColumnPos(column.max - 1) + mColumns.at(column.max - 1).usedBreadth;
+	const auto y2 = calcRowPos(row.max - 1) + mRows.at(row.max - 1).usedBreadth;
+
+	return {x1, y1, x2, y2};
+}
+
+float Grid::calcWidth() const {
+	return calcColumnPos(mColumns.size());
+}
+
+float Grid::calcHeight() const {
+	return calcRowPos(mRows.size());
+}
+
+void Grid::drawLocalClient() {
+	if (mNeedsLayout) runLayout();
+}
+
+void Grid::drawPostLocalClient() {
+#if 0
+		ci::gl::ScopedColor		 sc(1, 1, 1);
+		ci::gl::ScopedBlendAlpha sb;
+		ci::gl::ScopedGlslProg	 sp(getStockShader(ci::gl::ShaderDef().color()));
+
+		ci::gl::color(ci::ColorA8u(255, 204, 0, 255));
+		for (size_t row = 0; row < mRows.size(); ++row) {
+			for (size_t col = 0; col < mColumns.size(); ++col) {
+				ci::gl::drawStrokedRect(calcArea({col, col + 1}, {row, row + 1}));
+			}
+		}
+
+		float width	 = calcWidth();
+		float height = calcHeight();
+
+		ci::gl::color(ci::ColorA8u(255, 204, 0, 255));
+		ci::gl::drawStrokedRect({0, 0, width, height}, 15);
+
+		ci::gl::color(ci::ColorA8u(255, 102, 0, 128));
+		for (const auto item : allItems()) {
+			ci::gl::drawStrokedRect(calcArea(item), 15);
+		}
+	}
+#endif
+}
+
+void Grid::addChild(Sprite& newChild) {
+	mNeedsLayout = true;
+	Sprite::addChild(newChild);
+}
+
+bool Grid::setAvailableSize(const ci::vec2& size) {
+	if (mNeedsLayout) runLayout();
+
+	const float w = mMinWidth.asUser(this, Value::HORIZONTAL);
+	const float h = mMinHeight.asUser(this, Value::VERTICAL);
+
+	const float width  = calcWidth();
+	const float height = calcHeight();
+	if (!approxEqual(width, w)) mMinWidth = Value(width, Value::PIXELS);
+	if (!approxEqual(height, h)) mMinHeight = Value(height, Value::PIXELS);
+
+	return !approxEqual(width, w) || !approxEqual(height, h);
+}
+
+bool Grid::areaOverlapsItem(const ci::Rectf& area, const Sprite* item) const {
+	const auto& col		 = item->getColumnSpan();
+	const auto& row		 = item->getRowSpan();
+	const auto	itemArea = calcArea(col, row);
+	return itemArea.intersects(area);
+}
+
+bool Grid::areaOverlapsItems(const ci::Rectf& area, const std::vector<Sprite*>& items) const {
+	for (const auto item : items) {
+		if (areaOverlapsItem(area, item)) return true;
+	}
+	return false;
+}
+
+void Grid::runLayout() {
+	if (!mNeedsLayout) return;
+
+	ci::Timer t{true};
+
+	// Initialize item spans, taken from the sprites. These are then updated during layout.
+	// TODO sort items by specified order, see: https://drafts.csswg.org/css-flexbox-1/#order-modified-document-order
+	auto items = allItems();
+
+	try {
+		bool hasChanged = false;
+		for (;;) {
+			// 1. Call ComputedUsedBreadthOfGridTracks for grid columns to resolve their logical width.
+			computeUsedBreadthOfGridTracks(Value::Direction::HORIZONTAL, mColumns, ::getColumnSpan, ::getWidthMin,
+										   ::getWidthMax);
+
+			// 2. Call ComputedUsedBreadthOfGridTracks for grid rows to resolve their logical height.
+			// TODO The logical width of grid Columns from the prior step is used in the formatting of grid items in
+			// content-sized grid rows to determine their required height.
+			computeUsedBreadthOfGridTracks(Value::Direction::VERTICAL, mRows, ::getRowSpan, ::getHeightMin,
+										   ::getHeightMax);
+
+			// 3. If the minimum content size of any grid item has changed based on available height for the grid
+			// item as computed in step 2, adjust the min content size of the grid item and restart the grid track
+			// sizing algorithm (once only).
+			if (hasChanged) break;
+
+			size_t colCursor{0};
+			size_t rowCursor{0};
+
+			for (auto item : items) {
+				auto col = item->getColumnSpan();
+				auto row = item->getRowSpan();
+
+				// TEMP while we don't have auto grid item placement
+				if (row.min == row.max) {
+					if (rowCursor >= mRows.size()) continue;
+					row = {rowCursor, rowCursor + 1};
+				}
+				if (col.min == col.max) {
+					col = {colCursor, colCursor + 1};
+					if (++colCursor >= mColumns.size()) {
+						colCursor = 0;
+						++rowCursor;
+					}
+				}
+
+				const auto area = calcArea(col, row);
+				hasChanged |= item->setAvailableSize(area.getSize());
+			}
+
+			if (!hasChanged) break;
+
+			DS_LOG_VERBOSE(0, "Restarting layout because content size has changed.");
+		}
+	} catch (const std::exception& exc) {
+		DS_LOG_ERROR(exc.what())
+	}
+
+	t.stop();
+	std::stringstream ss;
+	ss << std::string("Running layout on ds::ui::Grid took ");
+	ss << t.getSeconds() << " seconds.";
+	DS_LOG_VERBOSE(0, ss.str());
+
+	// Updates the size of the grid.
+	setSize(calcWidth(), calcHeight());
+
+	// Position anything that's not auto-positioned.
+	size_t colCursor{0};
+	size_t rowCursor{0};
+
+	for (auto item : items) {
+		auto col = item->getColumnSpan();
+		auto row = item->getRowSpan();
+
+		// TEMP while we don't have auto grid item placement
+		if (row.min == row.max) {
+			if (rowCursor >= mRows.size()) continue;
+			row = {rowCursor, rowCursor + 1};
+		}
+		if (col.min == col.max) {
+			col = {colCursor, colCursor + 1};
+			if (++colCursor >= mColumns.size()) {
+				colCursor = 0;
+				++rowCursor;
+			}
+		}
+
+		const auto area = calcArea(col, row);
+		item->fitInsideArea(area);
+	}
+
+#if 0 // Automatic Grid Item Placement Algorithm.
+
+	// Process the items locked to a given row.
+	for (auto item : items) {
+		const auto& col = item->getColumnSpan();
+		const auto& row = item->getRowSpan();
+		if (col.count() && row.count()) continue;
+		if (row.count()) {
+			for (size_t i = 0; i < mColumns.size(); ++i) {
+				const auto area = calcArea({i, i + 1}, row);
+				if (!areaOverlapsItems(area, items)) {
+					item->setColumnSpan({i, i + 1});
+
+					item->setPosition(area.x1, area.y1);
+					item->setSize(area.getWidth(), area.getHeight());
+
+					auto text = dynamic_cast<Text*>(item);
+					if (text) text->setResizeLimit(area.getWidth(), area.getHeight());
+					break;
+				}
+			}
+		}
+	}
+
+	// Determine the number of columns in the implicit grid.
+	size_t numColumns = mColumns.size();
+	for (auto item : items) {
+		const auto& col = item->getColumnSpan();
+		if (col.count()) {
+			numColumns = glm::max(numColumns, col.max);
+		}
+	}
+
+	// Position the remaining grid items.
+	Range<size_t> cursor{0, 1};
+	for (auto item : items) {
+		const auto& col = item->getColumnSpan();
+		const auto& row = item->getRowSpan();
+		if (col.count() && row.count()) continue;
+		if (col.count()) {
+			// Set the column position of the cursor to be equal to the inline-start index of the grid item.
+			cursor = {0, 1};
+
+			// Increment the auto-placement cursor’s row position until a value is found where the grid item does
+			// not overlap any occupied grid cells (creating new rows in the implicit grid as necessary). Position
+			// the item’s block-start edge to the auto-placement cursor’s row position.
+			auto area = calcArea(col, cursor);
+			while (cursor.min < mRows.size() && areaOverlapsItems(area, items)) {
+				++cursor.min;
+				++cursor.max;
+
+				// TODO create new row
+				if (cursor.max > mRows.size()) break;
+
+				area = calcArea(col, cursor);
+			}
+
+			item->setRowSpan(cursor);
+
+			item->setPosition(area.x1, area.y1);
+			item->setSize(area.getWidth(), area.getHeight());
+
+			auto text = dynamic_cast<Text*>(item);
+			if (text) text->setResizeLimit(area.getWidth(), area.getHeight());
+		} else {
+			item->setRowSpan({0,1});
+
+			cursor = {0,1};
+
+			// Increment the column position of the auto-placement cursor until this item’s grid area does not overlap
+			// any occupied grid cells or overflow the number of columns determined in the previous step.
+			auto area = calcArea(cursor, row);
+			while (areaOverlapsItems(area, items)) {
+				++cursor.min;
+				++cursor.max;
+				if(cursor.max > numColumns) break;
+
+				area = calcArea(cursor, row);
+			}
+
+			// If a non-overlapping position was found in the previous step, position the item’s inline-start and
+			// block-start edges to the auto-placement cursor’s column and row position, respectively Otherwise,
+			// increment the auto-placement cursor’s row position (creating new rows in the implicit grid as necessary),
+			// set its column position to 1, and return to the previous step.
+			
+			item->setColumnSpan(cursor);
+
+			item->setPosition(area.x1, area.y1);
+			item->setSize(area.getWidth(), area.getHeight());
+
+			auto text = dynamic_cast<Text*>(item);
+			if (text) text->setResizeLimit(area.getWidth(), area.getHeight());
+		}
+	}
+#endif
+	mInitialized = true;
+	mNeedsLayout = false;
+
+	onLayoutUpdate();
+}
+
+float Grid::calcPos(size_t index, const std::vector<Track>& tracks, float gap) {
+	float allocatedSpace = 0;
+	for (size_t i = 0; i < index && i < tracks.size(); ++i) {
+		if (!std::isfinite(tracks.at(i).usedBreadth)) continue;
+		allocatedSpace += tracks.at(i).usedBreadth;
+	}
+
+	return allocatedSpace + static_cast<float>(countGaps(index, tracks)) * gap;
+}
+
+float Grid::calcPos(size_t index, const std::vector<Track*>& tracks, float gap) {
+	float allocatedSpace = 0;
+	for (size_t i = 0; i < index && i < tracks.size(); ++i) {
+		if (!std::isfinite(tracks.at(i)->usedBreadth)) continue;
+		allocatedSpace += tracks.at(i)->usedBreadth;
+	}
+
+	return allocatedSpace + static_cast<float>(countGaps(index, tracks)) * gap;
+}
+
+int Grid::countGaps(size_t index, const std::vector<Track>& tracks) {
+	int count = -1;
+	for (size_t i = 0; i <= index && i < tracks.size(); ++i) {
+		if (!std::isfinite(tracks.at(i).usedBreadth)) continue;
+		if (tracks.at(i).usedBreadth > 0 || tracks.at(i).isFlex())
+			++count; // Note: Incorrect if flex tracks end up being zero.
+	}
+	return glm::max(0, count);
+}
+
+int Grid::countGaps(size_t index, const std::vector<Track*>& tracks) {
+	int count = -1;
+	for (size_t i = 0; i <= index && i < tracks.size(); ++i) {
+		if (!std::isfinite(tracks.at(i)->usedBreadth)) continue;
+		if (tracks.at(i)->usedBreadth > 0 || tracks.at(i)->isFlex())
+			++count; // Note: Incorrect if flex tracks end up being zero.
+	}
+	return glm::max(0, count);
+}
+
+void Grid::computeUsedBreadthOfGridTracks(Value::Direction direction, std::vector<Track>& tracks, const SpanFn& spanFn,
+										  const SizeFn& minFn, const SizeFn& maxFn) {
+	const auto spaceToFill	= (direction == Value::HORIZONTAL) ? getWidth() : getHeight();
+	const auto viewportSize = glm::vec2{mEngine.getWorldWidth(), mEngine.getWorldHeight()};
+	const auto gap =
+		(direction == Value::HORIZONTAL) ? mColumnGap.asUser(this, direction) : mRowGap.asUser(this, direction);
+
+	// Initialize per grid track variables.
+	for (auto& track : tracks)
+		track.initialize({spaceToFill, viewportSize});
+
+	// Resolve content-based TrackSizingFunctions
+	resolveContentBasedTrackSizingFunctions(tracks, allItems(), spanFn, minFn, maxFn);
+
+	// Grow all grid tracks from their UsedBreadth up to their MaxBreadth value until RemainingSpace is exhausted.
+
+	// If RemainingSpace is defined
+	float remainingSpace = calculateRemainingSpace(tracks, spaceToFill, gap);
+	if (!approxZero(remainingSpace)) {
+		// Iterate over all grid tracks and assign UsedBreadth to UpdatedTrackBreadth.
+		for (auto& track : tracks)
+			track.updatedTrackBreadth = track.usedBreadth;
+
+		// Call DistributeSpaceToTracks
+		distributeSpaceToTracks(tracks, remainingSpace, getTrackMaxBreadth, getAllTracks(tracks), {}, getTrackBase);
+
+		// Iterate over all grid tracks and assign UpdatedTrackBreadth to UsedBreadth
+		for (auto& track : tracks)
+			track.usedBreadth = track.updatedTrackBreadth;
+	} else {
+		for (auto& track : tracks)
+			track.usedBreadth = track.maxBreadth;
+	}
+
+	// Grow all grid tracks having a flexible length as the MaxTrackSizingFunction.
+	float normalizedFlexBreadth = 0;
+
+	// If RemainingSpace is defined
+	remainingSpace = calculateRemainingSpace(tracks, spaceToFill, gap);
+	if (!approxZero(remainingSpace)) {
+		normalizedFlexBreadth = calculateNormalizedFlexBreadth(getAllTracks(tracks), spaceToFill, gap);
+	} else {
+		// i
+		for (const auto& track : tracks) {
+			if (track.max.isFlex()) {
+				normalizedFlexBreadth = glm::max(normalizedFlexBreadth, track.usedBreadth / track.flexValue());
+			}
+		}
+		//  ii
+		for (const auto item : allItems()) {
+			const auto spanned					 = getSpannedTracks(tracks, item, spanFn);
+			const auto itemNormalizedFlexBreadth = calculateNormalizedFlexBreadth(spanned, maxFn(item), gap);
+			normalizedFlexBreadth				 = glm::max(normalizedFlexBreadth, itemNormalizedFlexBreadth);
+		}
+	}
+
+	for (auto& track : tracks)
+		track.usedBreadth = glm::max(track.usedBreadth, normalizedFlexBreadth * track.flexValue());
+}
+
+void Grid::resolveContentBasedTrackSizingFunctions(std::vector<Track>& tracks, const std::vector<Sprite*>& items,
+												   const SpanFn& spanFn, const SizeFn& minFn, const SizeFn& maxFn) {
+	// Filter all grid items into a set, such that each grid item has either a SpanCount of 1 or does not cross a
+	// flex-sized grid track.
+	std::vector<Sprite*> filtered;
+
+	for (auto item : items) {
+		bool isFlex = false;
+
+		const auto& span = spanFn(item);
+		if (span.count() > 1) {
+			for (size_t i = span.min; i < span.max; ++i) {
+				if (i < tracks.size() && tracks.at(i).max.isFlex()) {
+					isFlex = true;
+					break;
+				}
+			}
+		}
+
+		if (!isFlex) filtered.push_back(item);
+	}
+
+	if (filtered.empty()) return;
+
+	// Group all grid items in the filtered set by their SpanCount ascending.
+	std::sort(filtered.begin(), filtered.end(), [spanFn](const Sprite* a, const Sprite* b) { //
+		return spanFn(a).count() < spanFn(b).count();
+	});
+
+	const auto maxSpanCount = spanFn(filtered.back()).count();
+	for (size_t spanCount = 1; spanCount <= maxSpanCount; ++spanCount) {
+		const auto group = getItemsWithSpanCount(filtered, spanFn, spanCount);
+		if (group.empty()) continue;
+
+		// Resolve content-based MinTrackSizingFunctions.
+		resolveContentBasedTrackSizingFunctionsForItems(
+			tracks, //
+			group,	// All grid items in the current group.
+			[minFn,
+			 spanFn](const std::vector<Track>& t,
+					 const Sprite* i) { // A function which given a grid item returns the min-content size of that
+										// grid item less the summed UsedBreadth of all grid tracks it covers.
+				return calcAdditionSpaceBase(t, i, minFn, spanFn);
+			},
+			getTrackMaxBreadth, // A function which given a grid track returns its MaxBreadth.
+			[spanFn](const std::vector<Track>& t,
+					 const Sprite* i) { // A function which given a grid item returns the set of grid tracks covered by
+										// that grid item that have a min-content or max-content MinTrackSizingFunction.
+				const auto spanned = getSpannedTracks(t, i, spanFn);
+				return getTracksMinIsMinOrMax(spanned);
+			},
+			getTracksMaxIsMinOrMax, // A function which given a set of grid tracks returns the subset of grid tracks
+									// having a min-content or max-content MaxTrackSizingFunction. If that set is the
+									// empty set, return the input set instead.
+			getTrackUsedBreadthRef	// A function which given a grid track returns a reference to its UsedBreadth
+									// variable.
+		);
+
+		resolveContentBasedTrackSizingFunctionsForItems(
+			tracks, //
+			group,	// All grid items in the current group.
+			[maxFn,
+			 spanFn](const std::vector<Track>& t,
+					 const Sprite* i) { // A function which given a grid item returns the max-content size of that
+										// grid item less the summed UsedBreadth of all Grid tracks it covers.
+				return calcAdditionSpaceBase(t, i, maxFn, spanFn);
+			},
+			getTrackMaxBreadth, // A function which given a grid track returns its MaxBreadth.
+			[spanFn](const std::vector<Track>& t,
+					 const Sprite* i) { // A function which given a grid item returns the set of grid tracks covered
+										// by that grid item that have a max-content MinTrackSizingFunction.
+				const auto spanned = getSpannedTracks(t, i, spanFn);
+				return getTracksMinIsMax(spanned);
+			},
+			getTracksMaxIsMax, // A function which given a set of grid tracks returns the subset of grid tracks having a
+							   // max-content MaxTrackSizingFunction. If that set is the empty set, return the input set
+							   // instead.
+			getTrackUsedBreadthRef // A function which given a grid track returns a reference to its UsedBreadth
+								   // variable.
+		);
+
+		// Resolve content-based MaxTrackSizingFunctions.
+		resolveContentBasedTrackSizingFunctionsForItems(
+			tracks, //
+			group,	// All grid items in the current group.
+			[minFn,
+			 spanFn](const std::vector<Track>& t,
+					 const Sprite* i) { // A function which given a grid item returns the min-content size of that
+										// grid item less the summed MaxBreadth (unless the MaxBreadth is infinite, in
+										// which case use the UsedBreadth) of all grid tracks it covers.
+				return calcAdditionSpaceLimit(t, i, minFn, spanFn);
+			},
+			getTrackMaxBreadth, // A function which given a grid track returns its MaxBreadth.
+			[spanFn](const std::vector<Track>& t,
+					 const Sprite* i) { //  A function which given a grid item returns the set of grid tracks covered by
+				//  that grid item that have a min-content or max-content MaxTrackSizingFunction.
+				const auto spanned = getSpannedTracks(t, i, spanFn);
+				return getTracksMaxIsMinOrMax(spanned);
+			},
+			getTracks,			  // The identity function.
+			getTrackMaxBreadthRef // A function which given a grid track returns a reference to its MaxBreadth variable.
+		);
+
+		resolveContentBasedTrackSizingFunctionsForItems(
+			tracks, //
+			group,	// All grid items in the current group.
+			[maxFn,
+			 spanFn](const std::vector<Track>& t,
+					 const Sprite* i) { // A function which given a grid item returns the max-content size of that
+										// grid item less the summed MaxBreadth (unless the MaxBreadth is infinite, in
+										// which case use the UsedBreadth) of all grid tracks it covers.
+				return calcAdditionSpaceLimit(t, i, maxFn, spanFn);
+			},
+			[group](const Track& track) { // A function which given a grid track returns infinity if the grid
+										  // track's SpanGroupInWhichMaxBreadthWasMadeFinite is equal to the
+										  // current group; otherwise return the grid track's MaxBreadth.
+				if (track.spanGroupInWhichMaxBreadthWasMadeFinite == group)
+					return std::numeric_limits<float>::infinity();
+				return track.maxBreadth;
+			},
+			[spanFn](const std::vector<Track>& t,
+					 const Sprite* i) { // A function which given a grid item returns the set of grid tracks covered
+										// by that grid item that have a max-content MaxTrackSizingFunction.
+				const auto spanned = getSpannedTracks(t, i, spanFn);
+				return getTracksMaxIsMax(spanned);
+			},
+			getTracks,			  // The identity function.
+			getTrackMaxBreadthRef // A function which given a Grid track returns a reference to its MaxBreadth variable.
+		);
+	}
+
+	// For each grid track from the set of all grid tracks:
+	for (auto& track : tracks) {
+		if (!std::isfinite(track.maxBreadth)) track.maxBreadth = track.usedBreadth;
+	}
+}
+
+void Grid::resolveContentBasedTrackSizingFunctionsForItems(std::vector<Track>&						tracks, //
+														   const std::vector<Sprite*>&				items,
+														   const AdditionalSpaceFn&					spaceFn,
+														   const TrackGrowthConstraintFn&			constraintFn,
+														   const TracksForGrowthFn&					tracksFn,
+														   const TracksForGrowthBeyondConstraintFn& tracksBeyondFn,
+														   const AccumulatorFn&						accumulatorFn) {
+	// A function which given a grid track returns the UsedBreadth of the grid track if Accumulator returns infinity;
+	// otherwise the value of the Accumulator is returned.
+	const auto currentBreadthFn = [accumulatorFn](const Track& t) {
+		const auto acc = accumulatorFn(const_cast<Track&>(t));
+		return std::isfinite(acc) ? acc : t.usedBreadth;
+	};
+
+	// Iterate over all grid tracks and assign UsedBreadth to UpdatedTrackBreadth.
+	for (auto& track : tracks)
+		track.updatedTrackBreadth = accumulatorFn(track);
+
+	// DistributeSpaceToTracks.
+	for (const auto item : items) {
+		const auto spaceToDistribute = spaceFn(tracks, item);
+		if (approxZero(spaceToDistribute)) continue;
+
+		const auto tracksForGrowth = tracksFn(tracks, item);
+		if (tracksForGrowth.empty()) continue;
+
+		distributeSpaceToTracks(tracks, spaceToDistribute, constraintFn, tracksForGrowth,
+								tracksBeyondFn(tracksForGrowth), currentBreadthFn);
+	}
+
+	// Iterate over all grid tracks and assign UpdatedTrackBreadth to UsedBreadth
+	for (auto& track : tracks) {
+		if (!std::isfinite(accumulatorFn(track)) && std::isfinite(track.updatedTrackBreadth))
+			track.spanGroupInWhichMaxBreadthWasMadeFinite = items;
+		accumulatorFn(track) = track.updatedTrackBreadth;
+	}
+}
+
+void Grid::distributeSpaceToTracks(std::vector<Track>& tracks, float spaceToDistribute,
+								   const TrackGrowthConstraintFn& constraintFn, std::vector<Track*> tracksFn,
+								   const std::vector<Track*>& tracksBeyond, const BreadthFn& currentBreadthFn) {
+	// 1. Sort TracksForGrowth by TrackGrowthConstraint( t ) - CurrentBreadth( t ) ascending.
+	std::sort(tracksFn.begin(), tracksFn.end(), [constraintFn, currentBreadthFn](Track* a, Track* b) {
+		const auto na = constraintFn(*a) - currentBreadthFn(*a);
+		const auto nb = constraintFn(*b) - currentBreadthFn(*b);
+		return na < nb;
+	});
+
+	// 2.
+	for (size_t i = 0; i < tracksFn.size(); ++i) {
+		const auto t = tracksFn.at(i);
+		const auto share =
+			glm::min(spaceToDistribute / float(tracksFn.size() - i), constraintFn(*t) - currentBreadthFn(*t));
+		t->tempBreadth = currentBreadthFn(*t) + share;
+		spaceToDistribute -= share;
+	}
+
+	// 3.
+	if (spaceToDistribute > 0) {
+		for (size_t i = 0; i < tracksBeyond.size(); ++i) {
+			const auto t	 = tracksBeyond.at(i);
+			const auto share = spaceToDistribute / float(tracksBeyond.size() - i);
+			t->tempBreadth += share;
+			spaceToDistribute -= share;
+		}
+	}
+
+	// 4.
+	for (const auto& track : tracksFn) {
+		if (std::isfinite(track->updatedTrackBreadth))
+			track->updatedTrackBreadth = glm::max(track->updatedTrackBreadth, track->tempBreadth);
+		else
+			track->updatedTrackBreadth = track->tempBreadth;
+	}
+}
+
+float Grid::calculateNormalizedFlexBreadth(const std::vector<Track*>& tracks, float spaceToFill, float gap) {
+	// 1.
+	const float allocatedSpace = calcPos(tracks.size(), tracks, gap);
+
+	// 2.
+	auto flexTracks = getFlexTracks(tracks);
+
+	// 3.
+	for (const auto& track : flexTracks)
+		track->normalizedFlexValue = track->usedBreadth / track->flexValue();
+
+	// 4.
+	std::sort(flexTracks.begin(), flexTracks.end(),
+			  [](const Track* a, const Track* b) { return a->normalizedFlexValue < b->normalizedFlexValue; });
+
+	// 5 + 6.
+	float spaceNeededFromFlexTracks	 = spaceToFill - allocatedSpace;
+	float currentBandFractionBreadth = 0;
+	float accumulatedFractions		 = 0;
+
+	// 7.
+	for (const auto track : flexTracks) {
+		if (track->normalizedFlexValue > currentBandFractionBreadth) {
+			if (track->normalizedFlexValue * accumulatedFractions > spaceNeededFromFlexTracks) break;
+			currentBandFractionBreadth = track->normalizedFlexValue;
+		}
+		accumulatedFractions += track->flexValue();
+		spaceNeededFromFlexTracks += track->usedBreadth;
+	}
+
+	// 8.
+	return spaceNeededFromFlexTracks / accumulatedFractions;
+}
+
+float Grid::calculateRemainingSpace(const std::vector<Track>& tracks, float spaceToFill, float gap) {
+	if (std::isinf(spaceToFill) || std::isnan(spaceToFill)) return std::numeric_limits<float>::signaling_NaN();
+	const float allocatedSpace = calcPos(tracks.size(), tracks, gap);
+	return glm::max(0.0f, spaceToFill - allocatedSpace);
+}
+
+std::vector<Sprite*> Grid::allItems() {
+	return getChildren();
+}
+
+std::vector<Sprite*> Grid::nonFlexibleItems(const std::vector<Track>& tracks, const SpanFn& spanFn) {
+	std::vector<Sprite*> result = allItems();
+
+	for (auto itr = result.begin(); itr != result.end();) {
+		const size_t count = result.size();
+
+		const auto& span = spanFn(*itr);
+		for (size_t i = span.min; i < span.max; ++i) {
+			if (i < tracks.size() && tracks.at(i).max.isFlex()) {
+				itr = result.erase(itr);
+				break;
+			}
+		}
+
+		if (count == result.size()) ++itr;
+	}
+
+	std::sort(result.begin(), result.end(), [spanFn](const Sprite* a, const Sprite* b) { //
+		return spanFn(a).count() < spanFn(b).count();
+	});
+
+	return result;
+}
+
+void Grid::parse(std::vector<Track>& tracks, const std::string& def) {
+	auto sInOut = def.c_str();
+	skipSpace(&sInOut);
+
+	while (*sInOut) {
+		if (strncmp(sInOut, "repeat", 6) == 0) {
+			sInOut += 6;
+			skipSpaceOrParenthesis(&sInOut);
+			// TODO: add support for auto-fill and auto-fit
+			const auto n = parseInt(&sInOut);
+			if (n <= 0) throw std::runtime_error("Error parsing repeat(): expected counter > 0");
+			skipSpaceOrComma(&sInOut);
+			auto s = fetchUntil(&sInOut, ')');
+			skipSpaceOrParenthesis(&sInOut);
+			for (int i = 0; i < n; ++i) {
+				parse(tracks, s);
+			}
+		} else if (*sInOut == '[') {
+			sInOut += 1;
+			auto s = fetchUntil(&sInOut, ']');
+			DS_LOG_WARNING("Grid line names '" << s << "' are currently not supported.");
+			sInOut += 1;
+			skipSpace(&sInOut);
+		} else {
+			tracks.emplace_back(&sInOut); // Create track.
+			skipSpace(&sInOut);
+		}
+	}
+}
+
+Range<size_t> Grid::parseSpan(const char** sInOut) {
+	skipSpace(sInOut);
+	const auto minimum = parseInt(sInOut) - 1;
+	skipUntil(sInOut, '/');
+	auto maximum = minimum + 1;
+	if (**sInOut == '/') {
+		(*sInOut)++;
+		skipSpace(sInOut);
+		if (isNumeric(**sInOut))
+			maximum = parseInt(sInOut) - 1;
+		else if (strncmp(*sInOut, "span", 4) == 0) {
+			*sInOut += 4;
+			skipSpace(sInOut);
+			maximum = minimum + parseInt(sInOut);
+		}
+	}
+
+	assert(minimum >= 0);
+	assert(maximum >= 0);
+	assert(minimum <= maximum);
+
+	return {size_t(minimum), size_t(maximum)};
+}
+
+SizingFn::SizingFn(const std::string& str) {
+	const char* sInOut = str.c_str();
+	parse(&sInOut);
+}
+
+SizingFn::SizingFn(const char** sInOut) {
+	parse(sInOut);
+}
+
+void SizingFn::parse(const char** sInOut) {
+	skipSpace(sInOut);
+	if (strncmp(*sInOut, "auto", 4) == 0) {
+		*sInOut += 4;
+		mUnit = UNDEFINED;
+	} else if (strncmp(*sInOut, "min-content", 11) == 0) {
+		*sInOut += 11;
+		mUnit = MIN_CONTENT;
+	} else if (strncmp(*sInOut, "max-content", 11) == 0) {
+		*sInOut += 11;
+		mUnit = MAX_CONTENT;
+	} else {
+		mValue = Value(sInOut);
+		mUnit  = FIXED;
+	}
+}
+
+Grid::Track::Track(const std::string& str) {
+	const char* sInOut = str.c_str();
+	parse(&sInOut);
+}
+
+Grid::Track::Track(const char** sInOut) {
+	parse(sInOut);
+}
+
+void Grid::Track::parse(const char** sInOut) {
+	skipSpace(sInOut);
+	if (strncmp(*sInOut, "auto", 4) == 0) {
+		*sInOut += 4;
+		min = SizingFn("min-content");
+		max = SizingFn("max-content");
+	} else if (strncmp(*sInOut, "minmax", 6) == 0) {
+		*sInOut += 6;
+		skipSpaceOrParenthesis(sInOut);
+		min = SizingFn(sInOut);
+		skipSpaceOrComma(sInOut);
+		max = SizingFn(sInOut);
+		skipSpaceOrParenthesis(sInOut);
+	} else if (strncmp(*sInOut, "fit-content", 11) ==
+			   0) { // TODO not yet in the specification used for this version of the code.
+		*sInOut += 11;
+		skipSpaceOrParenthesis(sInOut);
+		min = max = SizingFn(sInOut);
+		if (!min.isIntrinsic()) throw std::runtime_error("Sizing function must be intrinsic");
+		skipSpaceOrParenthesis(sInOut);
+	} else { // includes flex values
+		min = max = SizingFn(sInOut);
+	}
+}
+
+void Grid::Track::initialize(const Value::Dimensions& dimensions) {
+	// Sizing functions should be properly initialized before running the algorithm.
+	assert(min);
+	assert(max);
+
+	tempBreadth			= 0;
+	updatedTrackBreadth = 0;
+	updatedLimit		= 0;
+
+	// SpanGroupInWhichMaxBreadthWasMadeFinite = null
+	spanGroupInWhichMaxBreadthWasMadeFinite.clear();
+
+	if (min.isFixed()) {
+		// If MinTrackSizingFunction is a percentage or length, then UsedBreadth = resolved length
+		usedBreadth = min.value().asUser(dimensions);
+	} else {
+		// If MinTrackSizingFunction is min-content, max-content, or a flexible length, then UsedBreadth = 0
+		usedBreadth = 0;
+	}
+
+	if (max.isFixed()) {
+		// If MaxTrackSizingFunction is percentage or length, then MaxBreadth = resolved length.
+		// If the resolved length of the MaxTrackSizingFunction is less than the MinTrackSizingFunction, MaxBreadth =
+		// UsedBreadth.
+		maxBreadth = glm::max(usedBreadth, max.value().asUser(dimensions));
+	} else if (max.isFlex()) {
+		// If MaxTrackSizingFunction is a flexible length, then MaxBreadth = UsedBreadth
+		maxBreadth = usedBreadth;
+	} else {
+		// If MaxTrackSizingFunction is min-content, or max-content, then MaxBreadth = Infinity
+		maxBreadth = std::numeric_limits<float>::infinity();
+	}
+}
+
+} // namespace ds::ui
+
+namespace {
+
+auto INIT = []() {
+	ds::App::AddStartup([](ds::Engine& e) {
+		// Register the properties for our grid.
+		e.registerSpritePropertySetter<Grid>("grid-template-columns",
+											 [](Grid& grid, const std::string& theValue,
+												const std::string& fileReferrer) { grid.setColumns(theValue); });
+		e.registerSpritePropertySetter<Grid>(
+			"grid-template-rows",
+			[](Grid& grid, const std::string& theValue, const std::string& fileReferrer) { grid.setRows(theValue); });
+		e.registerSpritePropertySetter<Grid>(
+			"grid-gap",
+			[](Grid& grid, const std::string& theValue, const std::string& fileReferrer) { grid.setGap(theValue); });
+		e.registerSpritePropertySetter<Grid>("grid-column-gap",
+											 [](Grid& grid, const std::string& theValue,
+												const std::string& fileReferrer) { grid.setColumnGap(theValue); });
+		e.registerSpritePropertySetter<Grid>(
+			"grid-row-gap",
+			[](Grid& grid, const std::string& theValue, const std::string& fileReferrer) { grid.setRowGap(theValue); });
+
+		// Register sprite properties used by the grid system.
+		e.registerSpritePropertySetter<Sprite>(
+			"grid-column", [](Sprite& item, const std::string& theValue, const std::string& fileReferrer) {
+				const char* sInOut = theValue.c_str();
+				item.setColumnSpan(Grid::parseSpan(&sInOut));
+			});
+		e.registerSpritePropertySetter<Sprite>(
+			"grid-row", [](Sprite& item, const std::string& theValue, const std::string& fileReferrer) {
+				const char* sInOut = theValue.c_str();
+				item.setRowSpan(Grid::parseSpan(&sInOut));
+			});
+	});
+	return true;
+}();
+
+}

--- a/src/ds/ui/grid/grid.cpp
+++ b/src/ds/ui/grid/grid.cpp
@@ -558,7 +558,7 @@ int Grid::countGaps(size_t index, const std::vector<Track*>& tracks) {
 	int count = -1;
 	for (size_t i = 0; i <= index && i < tracks.size(); ++i) {
 		if (!std::isfinite(tracks.at(i)->usedBreadth)) continue;
-		if (tracks.at(i)->usedBreadth > 0 /*|| tracks.at(i)->isFlex()*/ // Note: counting flex tracks would be incorrect if flex tracks end up being zero.)
+		if (tracks.at(i)->usedBreadth > 0 /*|| tracks.at(i)->isFlex()*/) // Note: counting flex tracks would be incorrect if flex tracks end up being zero.)
 			++count;
 	}
 	return glm::max(0, count);

--- a/src/ds/ui/grid/grid.cpp
+++ b/src/ds/ui/grid/grid.cpp
@@ -187,8 +187,25 @@ float calcAdditionSpaceLimit(const std::vector<Grid::Track>& tracks, const Sprit
 namespace ds::ui {
 
 Grid::Grid(SpriteEngine& engine)
-  : Sprite(engine) {
+  : Sprite(engine)
+  , mEventClient(engine) {
 	setTransparent(false); // For debugging.
+
+	// Listen to SpriteDimensionsChangedEvent.
+	mEventClient.listenToEvents<SpriteDimensionsChangedEvent>([this](const SpriteDimensionsChangedEvent& e) {
+		// No need to flag grid as dirty if it already is dirty.
+		if(mNeedsLayout) return;
+
+		// Check if sprite is a child of this grid.
+		auto parent = e.getParent();
+		while (parent && parent != this)
+			parent = parent->getParent();
+
+		if (parent) {
+			// Flag grid as dirty, so we can run the layout on the next update.
+			mNeedsLayout = true;
+		}
+	});
 }
 
 void Grid::setColumns(const std::string& def) {

--- a/src/ds/ui/grid/grid.cpp
+++ b/src/ds/ui/grid/grid.cpp
@@ -134,6 +134,16 @@ std::vector<Grid::Track*> getSpannedTracks(const std::vector<Grid::Track>& track
 }
 
 // Returns the set of grid tracks whose MaxTrackSizingFunction is a flexible length.
+std::vector<Grid::Track*> getFlexTracks(const std::vector<Grid::Track>& tracks) {
+	std::vector<Grid::Track*> result;
+
+	for (auto track : tracks)
+		if (track.max.isFlex()) result.push_back(&track);
+
+	return result;
+}
+
+// Returns the set of grid tracks whose MaxTrackSizingFunction is a flexible length.
 std::vector<Grid::Track*> getFlexTracks(const std::vector<Grid::Track*>& tracks) {
 	std::vector<Grid::Track*> result;
 
@@ -618,6 +628,12 @@ void Grid::computeUsedBreadthOfGridTracks(Value::Direction direction, std::vecto
 			const auto itemNormalizedFlexBreadth = calculateNormalizedFlexBreadth(spanned, maxFn(item), gap);
 			normalizedFlexBreadth				 = glm::max(normalizedFlexBreadth, itemNormalizedFlexBreadth);
 		}
+	}
+
+	// Apply gap correction to normalizedFlexBreadth.
+	if (!approxZero(normalizedFlexBreadth)) {
+		const auto count = getFlexTracks(tracks).size();
+		if (count > 1) normalizedFlexBreadth = glm::max(0.f, normalizedFlexBreadth - gap * (count - 1));
 	}
 
 	for (auto& track : tracks)

--- a/src/ds/ui/grid/grid.cpp
+++ b/src/ds/ui/grid/grid.cpp
@@ -295,6 +295,14 @@ bool Grid::setAvailableSize(const ci::vec2& size) {
 	return !approxEqual(width, w) || !approxEqual(height, h);
 }
 
+void Grid::fitInsideArea(const ci::Rectf& area) {
+	const auto changed = setAvailableSize(area.getSize());
+	const auto bounds  = ci::Rectf{0, 0, getWidth(), getHeight()};
+	const auto fit	   = mFit.calcTransform(area, bounds, false);
+	setScale(fit[0][0], fit[1][1]);
+	setPosition(fit[2]);
+}
+
 bool Grid::areaOverlapsItem(const ci::Rectf& area, const Sprite* item) const {
 	const auto& col		 = item->getColumnSpan();
 	const auto& row		 = item->getRowSpan();

--- a/src/ds/ui/grid/grid.cpp
+++ b/src/ds/ui/grid/grid.cpp
@@ -198,10 +198,7 @@ Grid::Grid(SpriteEngine& engine)
 
 		// Check if sprite is a child of this grid.
 		auto parent = e.getParent();
-		while (parent && parent != this)
-			parent = parent->getParent();
-
-		if (parent) {
+		if (parent == this) {
 			// Flag grid as dirty, so we can run the layout on the next update.
 			mNeedsLayout = true;
 		}

--- a/src/ds/ui/grid/grid.cpp
+++ b/src/ds/ui/grid/grid.cpp
@@ -222,6 +222,11 @@ void Grid::setGap(const std::string& def) {
 }
 
 ci::Rectf Grid::calcArea(const Range<size_t>& column, const Range<size_t>& row) const {
+	if (column.min == column.max || row.min == row.max) return {0, 0, getWidth(), getHeight()};
+	if (column.min >= mColumns.size() || column.max > mColumns.size() || row.min >= mRows.size() ||
+		row.max > mRows.size())
+		return {0, 0, getWidth(), getHeight()};
+
 	const auto x1 = calcColumnPos(column.min);
 	const auto y1 = calcRowPos(row.min);
 	const auto x2 = calcColumnPos(column.max - 1) + mColumns.at(column.max - 1).usedBreadth;

--- a/src/ds/ui/grid/grid.cpp
+++ b/src/ds/ui/grid/grid.cpp
@@ -548,8 +548,8 @@ int Grid::countGaps(size_t index, const std::vector<Track>& tracks) {
 	int count = -1;
 	for (size_t i = 0; i <= index && i < tracks.size(); ++i) {
 		if (!std::isfinite(tracks.at(i).usedBreadth)) continue;
-		if (tracks.at(i).usedBreadth > 0 || tracks.at(i).isFlex())
-			++count; // Note: Incorrect if flex tracks end up being zero.
+		if (tracks.at(i).usedBreadth > 0 /*|| tracks.at(i).isFlex()*/) // Note: counting flex tracks would be incorrect if flex tracks end up being zero.
+			++count;
 	}
 	return glm::max(0, count);
 }
@@ -558,8 +558,8 @@ int Grid::countGaps(size_t index, const std::vector<Track*>& tracks) {
 	int count = -1;
 	for (size_t i = 0; i <= index && i < tracks.size(); ++i) {
 		if (!std::isfinite(tracks.at(i)->usedBreadth)) continue;
-		if (tracks.at(i)->usedBreadth > 0 || tracks.at(i)->isFlex())
-			++count; // Note: Incorrect if flex tracks end up being zero.
+		if (tracks.at(i)->usedBreadth > 0 /*|| tracks.at(i)->isFlex()*/ // Note: counting flex tracks would be incorrect if flex tracks end up being zero.)
+			++count;
 	}
 	return glm::max(0, count);
 }
@@ -853,9 +853,11 @@ float Grid::calculateNormalizedFlexBreadth(const std::vector<Track*>& tracks, fl
 			  [](const Track* a, const Track* b) { return a->normalizedFlexValue < b->normalizedFlexValue; });
 
 	// 5 + 6.
-	float spaceNeededFromFlexTracks	 = spaceToFill - allocatedSpace;
+	float spaceNeededFromFlexTracks	 = glm::max(0.f, spaceToFill - allocatedSpace);
 	float currentBandFractionBreadth = 0;
 	float accumulatedFractions		 = 0;
+
+	if(flexTracks.empty()) return 0;
 
 	// 7.
 	for (const auto track : flexTracks) {

--- a/src/ds/ui/grid/grid.h
+++ b/src/ds/ui/grid/grid.h
@@ -1,0 +1,210 @@
+#pragma once
+
+/*
+ * Implementation of the CSS Grid Layout algorithm as described in:
+ * https://www.w3.org/TR/2013/WD-css3-grid-layout-20130402/#layout-algorithm
+ *
+ * Author: Paul Houx, Downstream Amsterdam ( paul.houx@downstream.com )
+ *
+ * There are several amendments to the used specification, which we will gradually implement to
+ * make the code compatible with the latest browsers.
+ */
+
+#include <ds/ui/sprite/sprite.h>
+#include <ds/util/float_util.h>
+
+namespace ds::ui {
+
+template <typename T>
+using SpriteFn = std::function<T(const Sprite*)>;
+using SizeFn   = SpriteFn<float>;
+using SpanFn   = SpriteFn<const Range<size_t>&>;
+
+class Grid : public Sprite {
+  public:
+	struct Track;
+
+	using AdditionalSpaceFn		  = std::function<float(const std::vector<Track>&, const Sprite*)>;
+	using TrackGrowthConstraintFn = std::function<float(Track&)>;
+	using TracksForGrowthFn		  = std::function<std::vector<Track*>(const std::vector<Track>&, const Sprite*)>;
+	using TracksForGrowthBeyondConstraintFn = std::function<std::vector<Track*>(const std::vector<Track*>&)>;
+	using BreadthFn							= std::function<float(const Track&)>;
+	using AccumulatorFn						= std::function<float&(Track&)>;
+
+	Grid(SpriteEngine& engine);
+
+	// Accepts CSS-style definition, e.g. "100px 1fr 20%".
+	void setColumns(const std::string& def);
+	// Accepts CSS-style definition, e.g. "100px 1fr 20%".
+	void setRows(const std::string& def);
+
+	// Accepts CSS-style definition, e.g. "10px".
+	void setColumnGap(const std::string& def);
+	// Accepts CSS-style definition, e.g. "10px".
+	void setRowGap(const std::string& def);
+	// Accepts CSS-style definition, e.g. "10px".
+	void setGap(const std::string& def);
+
+	//
+	ci::Rectf calcArea(const Range<size_t>& column, const Range<size_t>& row) const;
+	//
+	ci::Rectf calcArea(const Sprite* item) const {
+		const auto& col = item->getColumnSpan();
+		const auto& row = item->getRowSpan();
+		return calcArea(col, row);
+	}
+
+	//
+	float calcWidth() const;
+	//
+	float calcHeight() const;
+	//
+	float calcColumnPos(size_t index) const {
+		return calcPos(index, mColumns, mColumnGap.asUser(this, Value::HORIZONTAL));
+	}
+	//
+	float calcRowPos(size_t index) const { return calcPos(index, mRows, mRowGap.asUser(this, Value::VERTICAL)); }
+
+	static Range<size_t> parseSpan(const char** sInOut);
+
+	void drawLocalClient() override;
+
+	void drawPostLocalClient() override;
+
+	void addChild(Sprite& newChild) override;
+
+	void setLayoutUpdatedFunction(const std::function<void()>& layoutUpdatedFunction) {
+		mLayoutUpdatedFunction = layoutUpdatedFunction;
+	}
+	void onLayoutUpdate() const {
+		if (mLayoutUpdatedFunction) {
+			mLayoutUpdatedFunction();
+		}
+	}
+
+	void setSizeAll(float width, float height, float depth) override {
+		mNeedsLayout = true;
+		Sprite::setSizeAll(width, height, depth);
+	}
+
+	bool setAvailableSize(const ci::vec2& size) override;
+
+  private:
+	// Returns whether the \a area overlaps the \a span.
+	bool areaOverlapsItem(const ci::Rectf& area, const Sprite* item) const;
+	// Returns whether the \a area overlaps any of the \a spans.
+	bool areaOverlapsItems(const ci::Rectf& area, const std::vector<Sprite*>& items) const;
+	// Calculates the position of the grid line with the specified \a index.
+	static float calcPos(size_t index, const std::vector<Track>& tracks, float gap);
+	// Calculates the position of the grid line with the specified \a index.
+	static float calcPos(size_t index, const std::vector<Track*>& tracks, float gap);
+	// Returns the number of gaps.
+	static int countGaps(size_t index, const std::vector<Track>& tracks);
+	// Returns the number of gaps.
+	static int countGaps(size_t index, const std::vector<Track*>& tracks);
+	// Performs the layout algorithm.
+	void runLayout();
+	//! This is the core grid track sizing algorithm. It is run for grid columns and grid rows.
+	void computeUsedBreadthOfGridTracks(Value::Direction direction, std::vector<Track>& tracks, const SpanFn& spanFn,
+										const SizeFn& minFn, const SizeFn& maxFn);
+	static void resolveContentBasedTrackSizingFunctions(std::vector<Track>& tracks, const std::vector<Sprite*>& items,
+														const SpanFn& spanFn, const SizeFn& minFn, const SizeFn& maxFn);
+	static void
+	resolveContentBasedTrackSizingFunctionsForItems(std::vector<Track>& tracks, // Set of tracks that need to be sized.
+													const std::vector<Sprite*>&				 items,			 //
+													const AdditionalSpaceFn&				 spaceFn,		 //
+													const TrackGrowthConstraintFn&			 constraintFn,	 //
+													const TracksForGrowthFn&				 tracksFn,		 //
+													const TracksForGrowthBeyondConstraintFn& tracksBeyondFn, //
+													const AccumulatorFn&					 accumulatorFn);
+	static void	 distributeSpaceToTracks(std::vector<Track>& tracks, float spaceToDistribute,
+										 const TrackGrowthConstraintFn& constraintFn, std::vector<Track*> tracksFn,
+										 const std::vector<Track*>& tracksBeyond, const BreadthFn& currentBreadthFn);
+	static float calculateNormalizedFlexBreadth(const std::vector<Track*>& tracks, float spaceToFill, float gap);
+
+	static float calculateRemainingSpace(const std::vector<Track>& tracks, float spaceToFill, float gap);
+
+	// Returns a list of all items.
+	std::vector<Sprite*> allItems();
+	// Returns a list of all items that do not span a track with a flexible sizing function, sorted by span count.
+	// The \a spanFn is either `getColumnSpan` or `getRowSpan'.
+	std::vector<Sprite*> nonFlexibleItems(const std::vector<Track>& tracks, const SpanFn& spanFn);
+
+	static void parse(std::vector<Track>& tracks, const std::string& def);
+
+	std::vector<Track>	  mColumns;
+	std::vector<Track>	  mRows;
+	Value				  mColumnGap{0, Value::PIXELS};
+	Value				  mRowGap{0, Value::PIXELS};
+	std::function<void()> mLayoutUpdatedFunction;
+	mutable bool		  mInitialized{false};
+	mutable bool		  mNeedsLayout{true};
+};
+
+class SizingFn {
+  public:
+	enum Unit { UNDEFINED, FIXED, MIN_CONTENT, MAX_CONTENT };
+
+	SizingFn() = default;
+
+	explicit SizingFn(const std::string& str);
+	explicit SizingFn(const char** sInOut);
+
+	const Value& value() const { return mValue; }
+	Unit		 unit() const { return mUnit; }
+
+	bool isFixed() const { return mUnit == FIXED && mValue.isFixed(); }
+	bool isIntrinsic() const { return !isFixed(); }
+	bool isMinContent() const { return mUnit == MIN_CONTENT; }
+	bool isMaxContent() const { return mUnit == MAX_CONTENT; }
+	bool isFlex() const { return mUnit == FIXED && mValue.isFlex(); }
+
+	//! Returns whether the sizing function is defined.
+	operator bool() const { return mUnit != UNDEFINED; }
+
+  private:
+	void parse(const char** sInOut);
+
+	Unit  mUnit{UNDEFINED};
+	Value mValue;
+};
+
+struct Grid::Track {
+	enum Type { BREADTH, MIN_MAX, FIT_CONTENT };
+
+	Track() = default;
+	explicit Track(const std::string& str);
+	explicit Track(const char** sInOut);
+
+	/// Returns the flex factor (the value in front of 'fr'), or 0 if track is not flexible.
+	float flexValue() const { return isFlex() ? max.value().value() : 0; }
+
+	//! Returns whether this track uses the minmax sizing function.
+	bool isMinMax() const { return type == MIN_MAX; }
+	//! Returns whether this track is set to fit content.
+	bool isFitContent() const { return type == FIT_CONTENT; }
+	//! Returns whether this track is flexible.
+	bool isFlex() const { return min.isFlex(); }
+
+	//! Returns whether this track is not flexible but can still grow larger.
+	bool canGrow() const { return !isFlex() && !approxEqual(usedBreadth, maxBreadth); }
+
+	void parse(const char** sInOut);
+
+	// See: https://www.w3.org/TR/css-grid-1/#algo-init
+	void initialize(const Value::Dimensions& dimensions);
+
+	Type	 type{BREADTH}; //
+	SizingFn min;			//
+	SizingFn max;			//
+
+	float				 usedBreadth{0};									 // Used by the track sizing algorithm.
+	float				 maxBreadth{std::numeric_limits<float>::infinity()}; // Used by the track sizing algorithm.
+	float				 updatedTrackBreadth{0};							 // Used by the track sizing algorithm.
+	float				 updatedLimit{0};									 // Used by the track sizing algorithm.
+	float				 tempBreadth{0};									 // Used by the track sizing algorithm.
+	float				 normalizedFlexValue{0};							 // Used by the track sizing algorithm.
+	std::vector<Sprite*> spanGroupInWhichMaxBreadthWasMadeFinite;			 // Used by the track sizing algorithm.
+};
+
+} // namespace ds::ui

--- a/src/ds/ui/grid/grid.h
+++ b/src/ds/ui/grid/grid.h
@@ -75,6 +75,8 @@ class Grid : public Sprite {
 
 	void addChild(Sprite& newChild) override;
 
+	void updateLayout() const { mNeedsLayout = true; }
+
 	void setLayoutUpdatedFunction(const std::function<void()>& layoutUpdatedFunction) {
 		mLayoutUpdatedFunction = layoutUpdatedFunction;
 	}

--- a/src/ds/ui/grid/grid.h
+++ b/src/ds/ui/grid/grid.h
@@ -138,6 +138,7 @@ class Grid : public Sprite {
 
 	static void parse(std::vector<Track>& tracks, const std::string& def);
 
+	EventClient			  mEventClient;
 	std::vector<Track>	  mColumns;
 	std::vector<Track>	  mRows;
 	Value				  mColumnGap{0, Value::PIXELS};

--- a/src/ds/ui/grid/grid.h
+++ b/src/ds/ui/grid/grid.h
@@ -55,15 +55,17 @@ class Grid : public Sprite {
 	}
 
 	//
-	float calcWidth() const;
+	float calcWidth(bool excludeFlex = false) const;
 	//
-	float calcHeight() const;
+	float calcHeight(bool excludeFlex = false) const;
 	//
-	float calcColumnPos(size_t index) const {
-		return calcPos(index, mColumns, mColumnGap.asUser(this, Value::HORIZONTAL));
+	float calcColumnPos(size_t index, bool excludeFlex = false) const {
+		return calcPos(index, mColumns, mColumnGap.asUser(this, Value::HORIZONTAL), excludeFlex);
 	}
 	//
-	float calcRowPos(size_t index) const { return calcPos(index, mRows, mRowGap.asUser(this, Value::VERTICAL)); }
+	float calcRowPos(size_t index, bool excludeFlex = false) const {
+		return calcPos(index, mRows, mRowGap.asUser(this, Value::VERTICAL), excludeFlex);
+	}
 
 	static Range<size_t> parseSpan(const char** sInOut);
 
@@ -83,7 +85,7 @@ class Grid : public Sprite {
 	}
 
 	void setSizeAll(float width, float height, float depth) override {
-		mNeedsLayout = true;
+		mNeedsLayout |= !mChildren.empty();
 		Sprite::setSizeAll(width, height, depth);
 	}
 
@@ -95,9 +97,9 @@ class Grid : public Sprite {
 	// Returns whether the \a area overlaps any of the \a spans.
 	bool areaOverlapsItems(const ci::Rectf& area, const std::vector<Sprite*>& items) const;
 	// Calculates the position of the grid line with the specified \a index.
-	static float calcPos(size_t index, const std::vector<Track>& tracks, float gap);
+	static float calcPos(size_t index, const std::vector<Track>& tracks, float gap, bool excludeFlex = false);
 	// Calculates the position of the grid line with the specified \a index.
-	static float calcPos(size_t index, const std::vector<Track*>& tracks, float gap);
+	static float calcPos(size_t index, const std::vector<Track*>& tracks, float gap, bool excludeFlex = false);
 	// Returns the number of gaps.
 	static int countGaps(size_t index, const std::vector<Track>& tracks);
 	// Returns the number of gaps.

--- a/src/ds/ui/grid/grid.h
+++ b/src/ds/ui/grid/grid.h
@@ -91,6 +91,8 @@ class Grid : public Sprite {
 
 	bool setAvailableSize(const ci::vec2& size) override;
 
+	void fitInsideArea(const ci::Rectf& area) override;
+
   private:
 	// Returns whether the \a area overlaps the \a span.
 	bool areaOverlapsItem(const ci::Rectf& area, const Sprite* item) const;

--- a/src/ds/ui/grid/value.cpp
+++ b/src/ds/ui/grid/value.cpp
@@ -1,0 +1,89 @@
+#include "stdafx.h"
+
+#include "ds/ui/grid/value.h"
+#include "ds/ui/sprite/sprite.h"
+#include "ds/util/parse_util.h"
+
+namespace ds::ui {
+
+Value::Value(const std::string& str) {
+	const char* sInOut = str.c_str();
+	parse(&sInOut);
+}
+
+Value::Value(const char** sInOut) {
+	parse(sInOut);
+}
+
+float Value::asUser(const Dimensions& dimensions) const {
+	switch (mUnit) {
+	case PERCENTAGE:
+		return mValue * dimensions.percentOf / 100;
+	case VIEWPORT_WIDTH:
+		return mValue * dimensions.viewportSize.x / 100;
+	case VIEWPORT_HEIGHT:
+		return mValue * dimensions.viewportSize.y / 100;
+	case VIEWPORT_MIN:
+		return mValue * std::min(dimensions.viewportSize.x, dimensions.viewportSize.y) / 100;
+	case VIEWPORT_MAX:
+		return mValue * std::max(dimensions.viewportSize.x, dimensions.viewportSize.y) / 100;
+	case UNDEFINED:
+	case PIXELS:
+	case FLEX:
+		break;
+	}
+
+	return mValue;
+}
+
+float Value::asUser(const ui::Sprite* sprite, Direction direction) const {
+	assert(sprite && sprite->getParent());
+
+	Dimensions dim;
+	dim.percentOf	 = direction == HORIZONTAL ? sprite->getParent()->getWidth() : sprite->getParent()->getHeight();
+	dim.viewportSize = {sprite->getEngine().getWorldWidth(), sprite->getEngine().getWorldHeight()};
+	return asUser(dim);
+}
+
+void Value::parse(const char** sInOut) {
+	const char* from = *sInOut;
+
+	skipSpace(sInOut);
+	if (strncmp(*sInOut, "auto", 4) == 0) {
+		*sInOut += 4;
+		mUnit = UNDEFINED;
+	} else {
+		mValue = parseFloat(sInOut);
+		if (mValue < 0) throw std::runtime_error("Value must be equal to or greater than 0");
+
+		if (!**sInOut || std::isspace(**sInOut)) {
+			DS_LOG_WARNING("No unit given, pixels assumed: " << std::string(from, *sInOut - from).c_str());
+			mUnit = PIXELS;
+		}
+
+		else if (**sInOut == '%') {
+			*sInOut += 1;
+			mUnit = PERCENTAGE;
+		} else if (strncmp(*sInOut, "px", 2) == 0) {
+			*sInOut += 2;
+			mUnit = PIXELS;
+		} else if (strncmp(*sInOut, "fr", 2) == 0) {
+			*sInOut += 2;
+			mUnit = FLEX;
+		} else if (strncmp(*sInOut, "vw", 2) == 0) {
+			*sInOut += 2;
+			mUnit = VIEWPORT_WIDTH;
+		} else if (strncmp(*sInOut, "vh", 2) == 0) {
+			*sInOut += 2;
+			mUnit = VIEWPORT_HEIGHT;
+		} else if (strncmp(*sInOut, "vmin", 4) == 0) {
+			*sInOut += 4;
+			mUnit = VIEWPORT_MIN;
+		} else if (strncmp(*sInOut, "vmax", 4) == 0) {
+			*sInOut += 4;
+			mUnit = VIEWPORT_MAX;
+		}
+	}
+}
+
+} // namespace ds::ui

--- a/src/ds/ui/grid/value.cpp
+++ b/src/ds/ui/grid/value.cpp
@@ -40,7 +40,7 @@ float Value::asUser(const ui::Sprite* sprite, Direction direction) const {
 	assert(sprite && sprite->getParent());
 
 	Dimensions dim;
-	dim.percentOf	 = direction == HORIZONTAL ? sprite->getParent()->getWidth() : sprite->getParent()->getHeight();
+	dim.percentOf	 = direction == HORIZONTAL ? sprite->getWidth() : sprite->getHeight();
 	dim.viewportSize = {sprite->getEngine().getWorldWidth(), sprite->getEngine().getWorldHeight()};
 	return asUser(dim);
 }

--- a/src/ds/ui/grid/value.h
+++ b/src/ds/ui/grid/value.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <string>
+
+namespace ds::ui {
+
+// Forward declarations.
+class Sprite;
+
+//! Value/Unit pair for CSS grid layout. A similar class is also defined in Cinder, but it lacks some features that we
+//! are specifically interested in.
+class Value {
+  public:
+	enum Unit {
+		UNDEFINED,
+		PIXELS,
+		PERCENTAGE,
+		VIEWPORT_WIDTH,
+		VIEWPORT_HEIGHT,
+		VIEWPORT_MIN,
+		VIEWPORT_MAX,
+		FLEX
+	}; // Percentage is relative to parent size.
+	enum Direction { HORIZONTAL, VERTICAL };
+
+	struct Dimensions {
+		float	 percentOf;
+		ci::vec2 viewportSize;
+	};
+
+	Value() = default;
+	Value(float value, Unit unit)
+	  : mUnit(unit)
+	  , mValue(value) {}
+
+	explicit Value(const std::string& str);
+	explicit Value(const char** sInOut);
+
+	[[nodiscard]] float value() const { return mValue; }
+	[[nodiscard]] Unit	unit() const { return mUnit; }
+
+	[[nodiscard]] float asUser(const Dimensions& dimensions) const;
+	[[nodiscard]] float asUser(const ds::ui::Sprite* sprite, Direction direction) const;
+
+	[[nodiscard]] bool isDefined() const { return mUnit != UNDEFINED; }
+	[[nodiscard]] bool isFlex() const { return mUnit == FLEX; }
+	[[nodiscard]] bool isFixed() const { return !(mUnit == UNDEFINED || mUnit == FLEX); }
+
+	/// Makes it easier to use, see: GridSprite::sumFlex().
+	explicit operator float() const { return mValue; }
+
+	//! Returns whether the value is defined.
+	operator bool() const { return !(mUnit == UNDEFINED); }
+
+  private:
+	void parse(const char** sInOut);
+
+	Unit  mUnit{UNDEFINED};								   //
+	float mValue{std::numeric_limits<float>::quiet_NaN()}; //
+};
+
+} // namespace ds::ui

--- a/src/ds/ui/grid/value.h
+++ b/src/ds/ui/grid/value.h
@@ -46,6 +46,11 @@ class Value {
 	[[nodiscard]] bool isFlex() const { return mUnit == FLEX; }
 	[[nodiscard]] bool isFixed() const { return !(mUnit == UNDEFINED || mUnit == FLEX); }
 
+	void set(float value, Unit unit) {
+		mValue = value;
+		mUnit  = unit;
+	}
+
 	/// Makes it easier to use, see: GridSprite::sumFlex().
 	explicit operator float() const { return mValue; }
 

--- a/src/ds/ui/layout/layout_sprite.cpp
+++ b/src/ds/ui/layout/layout_sprite.cpp
@@ -6,6 +6,7 @@
 #include <ds/debug/logger.h>
 #include <ds/ui/sprite/sprite_engine.h>
 #include <ds/ui/sprite/text.h>
+#include <ds/util/float_util.h>
 #include <ds/util/string_util.h>
 
 #include <yoga/YGNode.h>
@@ -211,6 +212,15 @@ void LayoutSprite::runFlowLayout(const bool vertical, const bool wrap /* = false
 	}
 	setSize(layoutWidth, layoutHeight);
 
+	// Keep track of max width and height, useful if running this layout inside a grid.
+	if (vertical) {
+		mMinWidth = mMaxWidth = Value(maxWidth, Value::PIXELS);
+		mMinHeight = mMaxHeight = Value(totalSize, Value::PIXELS);
+	} else {
+		mMinWidth = mMaxWidth = Value(totalSize, Value::PIXELS);
+		mMinHeight = mMaxHeight = Value(maxHeight, Value::PIXELS);
+	}
+
 	// figure out what's left over and how to use it properly
 	float leftOver	 = 0.0f;
 	float perStretch = 0.0f;
@@ -414,6 +424,19 @@ void LayoutSprite::runFlexLayout(bool calculate) {
 		// node->setDirty(false);
 		//}
 	}
+}
+
+bool LayoutSprite::setAvailableSize(const ci::vec2& size) {
+	const bool hasChanged =
+		!approxEqual(mWidth, size.x) || !approxEqual(mHeight, size.y) || mShrinkToChildren != kShrinkBoth;
+
+	mWidth			  = size.x;
+	mHeight			  = size.y;
+	mShrinkToChildren = kShrinkBoth; // We assume this is what you want when you're using a layout inside a grid.
+
+	runLayout();
+
+	return hasChanged;
 }
 
 void LayoutSprite::addChild(Sprite& child) {

--- a/src/ds/ui/layout/layout_sprite.h
+++ b/src/ds/ui/layout/layout_sprite.h
@@ -94,6 +94,9 @@ class LayoutSprite : public ds::ui::Sprite {
 	static std::string getLayoutTypeString(const ds::ui::LayoutSprite::LayoutType& propertyValue);
 	static std::string getShrinkToChildrenString(const ds::ui::LayoutSprite::ShrinkType& propertyValue);
 
+	/// If nested inside a grid layout, this will set the size of the layout sprite and run the layout algorithm.
+	bool setAvailableSize(const ci::vec2& size) override;
+
   protected:
 	/// See enum declaration for descriptions
 	/// virtual in case you want to override with your own layout jimmies.

--- a/src/ds/ui/sprite/fit.cpp
+++ b/src/ds/ui/sprite/fit.cpp
@@ -1,0 +1,128 @@
+#include "stdafx.h"
+
+#include "ds/ui/sprite/fit.h"
+#include "ds/util/parse_util.h"
+
+using namespace ci;
+
+namespace ds::ui {
+
+glm::mat3x2 Fit::calcTransform(const Rectf& outer, const Rectf& inner, bool normalized) const {
+	// See: https://svgwg.org/svg2-draft/coords.html#ComputingAViewportsTransform
+	glm::mat3x2 m32;
+
+	if (inner.getWidth() > 0 && inner.getHeight() > 0) {
+		if (mAlign == Align::NONE || mMeetOrSlice != MeetOrSlice::NONE) {
+			m32[0][0] = outer.getWidth() / inner.getWidth();   // scale-x
+			m32[1][1] = outer.getHeight() / inner.getHeight(); // scale-y
+		}
+		if (mMeetOrSlice == MeetOrSlice::MEET)						//
+			m32[0][0] = m32[1][1] = glm::min(m32[0][0], m32[1][1]); //
+		else if (mMeetOrSlice == MeetOrSlice::SLICE)				//
+			m32[0][0] = m32[1][1] = glm::max(m32[0][0], m32[1][1]); //
+		m32[2][0] = outer.x1 - (inner.x1 * m32[0][0]);				// translate-x
+		m32[2][1] = outer.y1 - (inner.y1 * m32[1][1]);				// translate-y
+
+		if (mAlign == Align::X_MID_Y_MIN || mAlign == Align::X_MID_Y_MID || mAlign == Align::X_MID_Y_MAX)
+			m32[2][0] += (outer.getWidth() - inner.getWidth() * m32[0][0]) * 0.5f;
+		else if (mAlign == Align::X_MAX_Y_MIN || mAlign == Align::X_MAX_Y_MID || mAlign == Align::X_MAX_Y_MAX)
+			m32[2][0] += outer.getWidth() - inner.getWidth() * m32[0][0];
+
+		if (mAlign == Align::X_MIN_Y_MID || mAlign == Align::X_MID_Y_MID || mAlign == Align::X_MAX_Y_MID)
+			m32[2][1] += (outer.getHeight() - inner.getHeight() * m32[1][1]) * 0.5f;
+		else if (mAlign == Align::X_MIN_Y_MAX || mAlign == Align::X_MID_Y_MAX || mAlign == Align::X_MAX_Y_MAX)
+			m32[2][1] += outer.getHeight() - inner.getHeight() * m32[1][1];
+	} else {
+		m32[2][0] = outer.x1;
+		m32[2][1] = outer.y1;
+	}
+
+	// Normalize.
+	if (normalized && outer.getWidth() > 0 && outer.getHeight() > 0) {
+		m32[0][0] = inner.getWidth() * m32[0][0] / outer.getWidth();
+		m32[1][1] = inner.getHeight() * m32[1][1] / outer.getHeight();
+		m32[2][0] /= outer.getWidth();
+		m32[2][1] /= outer.getHeight();
+	}
+
+	return m32;
+}
+
+mat3 Fit::calcTransform3x3(const Rectf& outer, const Rectf& inner, bool normalized) const {
+	const auto m32 = calcTransform(outer, inner, normalized);
+	return {m32[0][0], m32[0][1], 0.f, m32[1][0], m32[1][1], 0.f, m32[2][0], m32[2][1], 1.f};
+}
+
+mat4 Fit::calcTransform4x4(const Rectf& outer, const Rectf& inner, bool normalized) const {
+	const auto m32 = calcTransform(outer, inner, normalized);
+	return {m32[0][0], m32[0][1], 0.f,	0.f, m32[1][0], m32[1][1], 0.f, 0.f,
+			0.f,	   0.f,		  1.0f, 0.f, m32[2][0], m32[2][1], 0.f, 1.f};
+}
+
+void Fit::parse(const char** sInOut) {
+	skipSpace(sInOut);
+
+	if (!*sInOut) return;
+
+	if (isSimilar(*sInOut, "none", 4)) {
+		*sInOut += 4;
+		mAlign		 = Align::NONE;
+		mMeetOrSlice = MeetOrSlice::NONE;
+		return;
+	}
+
+	if (isSimilar(*sInOut, "xmin", 4)) {
+		*sInOut += 4;
+		if (!*sInOut) throw std::runtime_error("Fit::parse() - Unexpected end of line");
+		if (isSimilar(*sInOut, "ymin", 4)) {
+			*sInOut += 4;
+			mAlign = Align::X_MIN_Y_MIN;
+		} else if (isSimilar(*sInOut, "ymid", 4)) {
+			*sInOut += 4;
+			mAlign = Align::X_MIN_Y_MID;
+		} else if (isSimilar(*sInOut, "ymax", 4)) {
+			*sInOut += 4;
+			mAlign = Align::X_MIN_Y_MAX;
+		}
+	} else if (isSimilar(*sInOut, "xmid", 4)) {
+		*sInOut += 4;
+		if (!*sInOut) throw std::runtime_error("Fit::parse() - Unexpected end of line");
+		if (isSimilar(*sInOut, "ymin", 4)) {
+			*sInOut += 4;
+			mAlign = Align::X_MID_Y_MIN;
+		} else if (isSimilar(*sInOut, "ymid", 4)) {
+			*sInOut += 4;
+			mAlign = Align::X_MID_Y_MID;
+		} else if (isSimilar(*sInOut, "ymax", 4)) {
+			*sInOut += 4;
+			mAlign = Align::X_MID_Y_MAX;
+		}
+	} else if (isSimilar(*sInOut, "xmax", 4)) {
+		*sInOut += 4;
+		if (!*sInOut) throw std::runtime_error("Fit::parse() - Unexpected end of line");
+		if (isSimilar(*sInOut, "ymin", 4)) {
+			*sInOut += 4;
+			mAlign = Align::X_MAX_Y_MIN;
+		} else if (isSimilar(*sInOut, "ymid", 4)) {
+			*sInOut += 4;
+			mAlign = Align::X_MAX_Y_MID;
+		} else if (isSimilar(*sInOut, "ymax", 4)) {
+			*sInOut += 4;
+			mAlign = Align::X_MAX_Y_MAX;
+		}
+	}
+
+	skipSpace(sInOut);
+
+	if (!*sInOut) {
+		mMeetOrSlice = MeetOrSlice::NONE;
+	} else if (isSimilar(*sInOut, "meet", 4)) {
+		*sInOut += 4;
+		mMeetOrSlice = MeetOrSlice::MEET;
+	} else if (isSimilar(*sInOut, "slice", 5)) {
+		*sInOut += 5;
+		mMeetOrSlice = MeetOrSlice::SLICE;
+	}
+}
+
+} // namespace ds::ui

--- a/src/ds/ui/sprite/fit.h
+++ b/src/ds/ui/sprite/fit.h
@@ -1,0 +1,63 @@
+#pragma once
+#ifndef DS_UI_SPRITE_FIT_H_
+#define DS_UI_SPRITE_FIT_H_
+
+namespace ds::ui {
+
+//! A class to help calculate the transformation matrix to fit one rectangle into another.
+class Fit {
+  public:
+	enum class Align {
+		NONE,
+		X_MIN_Y_MIN,
+		X_MID_Y_MIN,
+		X_MAX_Y_MIN,
+		X_MIN_Y_MID,
+		X_MID_Y_MID,
+		X_MAX_Y_MID,
+		X_MIN_Y_MAX,
+		X_MID_Y_MAX,
+		X_MAX_Y_MAX
+	};
+	enum class MeetOrSlice { NONE, MEET, SLICE };
+
+	Fit() = default;
+	Fit(Align align, MeetOrSlice meetOrSlice = MeetOrSlice::NONE)
+	  : mAlign(align)
+	  , mMeetOrSlice(meetOrSlice) {}
+
+	explicit Fit(const std::string& css) {
+		const char* sInOut = css.c_str();
+		parse(&sInOut);
+	}
+	explicit Fit(const char** sInOut) { parse(sInOut); }
+
+	//! Returns whether the fit is set to none. If it is, no transformations will be necessary.
+	[[nodiscard]] bool isNone() const { return mAlign == Align::NONE; }
+
+	//! Calculate the transformation matrix to fit the inner rectangle into the outer rectangle. Optionally normalizes
+	//! the result to the range 0-1.
+	[[nodiscard]] glm::mat3x2 calcTransform(const ci::Rectf& outer, const ci::Rectf& inner,
+											bool normalized = false) const;
+	//! Calculate the transformation matrix to fit the inner rectangle into the outer rectangle. Optionally normalizes
+	//! the result to the range 0-1.
+	[[nodiscard]] glm::mat3 calcTransform3x3(const ci::Rectf& outer, const ci::Rectf& inner,
+											 bool normalized = false) const;
+	//! Calculate the transformation matrix to fit the inner rectangle into the outer rectangle. Optionally normalizes
+	//! the result to the range 0-1.
+	[[nodiscard]] glm::mat4 calcTransform4x4(const ci::Rectf& outer, const ci::Rectf& inner,
+											 bool normalized = false) const;
+
+	[[nodiscard]] Align		  align() const { return mAlign; }
+	[[nodiscard]] MeetOrSlice meetOrSlice() const { return mMeetOrSlice; }
+
+  private:
+	void parse(const char** sInOut);
+
+	Align		mAlign{Align::X_MIN_Y_MIN};
+	MeetOrSlice mMeetOrSlice{MeetOrSlice::NONE};
+};
+
+} // namespace ds::ui
+
+#endif // DS_UI_SPRITE_FIT_H_

--- a/src/ds/ui/sprite/image.cpp
+++ b/src/ds/ui/sprite/image.cpp
@@ -306,9 +306,10 @@ void Image::clearImage() {
 }
 
 bool Image::setAvailableSize(const vec2& size) {
-	const auto fit	  = mFit.calcTransform(Rectf{0, 0, size.x, size.y}, Rectf{0, 0, getWidth(), getHeight()});
-	const auto width  = fit[0][0] * getWidth();
-	const auto height = fit[1][1] * getHeight();
+	const auto bounds = getBounds();
+	const auto fit	  = mFit.calcTransform(Rectf{0, 0, size.x, size.y}, bounds);
+	const auto width  = fit[0][0] * bounds.getWidth();
+	const auto height = fit[1][1] * bounds.getHeight();
 
 	mMinWidth = mMaxWidth = css::Value(width, Value::PIXELS);
 	mMinHeight = mMaxHeight = css::Value(height, Value::PIXELS);
@@ -346,6 +347,13 @@ float Image::getHeightMax() const {
 		return mMaxWidth.asUser(this, Value::HORIZONTAL) * aspect;
 	}
 	return Sprite::getHeightMax();
+}
+
+void Image::fitInsideArea(const Rectf& area) {
+	const auto bounds = getBounds();
+	const auto fit	  = mFit.calcTransform(area, bounds, false);
+	setScale(fit[0][0], fit[1][1]);
+	setPosition(fit[2]);
 }
 
 void Image::setSize(float width, float height) {
@@ -401,6 +409,11 @@ void Image::circleCropAutoCenter() {
 void Image::disableCircleCropCentered() {
 	mCircleCropCentered = false;
 	setCircleCrop(false);
+}
+
+ci::Rectf Image::getBounds() const {
+	if (mCircleCropped) return {mShaderExtraData.x, mShaderExtraData.y, mShaderExtraData.z, mShaderExtraData.w};
+	return {0, 0, getWidth(), getHeight()};
 }
 
 void Image::setStatusCallback(const std::function<void(const Status&)>& fn) {

--- a/src/ds/ui/sprite/image.cpp
+++ b/src/ds/ui/sprite/image.cpp
@@ -284,8 +284,12 @@ void Image::drawLocalClient() {
 	if (!inBounds() || !isLoaded()) return;
 
 	if (mTextureRef) {
-
 		mTextureRef->bind();
+
+		// Adjust position if circle cropping is applied.
+		ci::gl::ScopedModelMatrix sm;
+		ci::gl::translate(-mShaderExtraData.x, -mShaderExtraData.y); // Compensate for cropping.
+
 		if (mRenderBatch) {
 			mRenderBatch->draw();
 		} else {
@@ -306,7 +310,7 @@ void Image::clearImage() {
 }
 
 bool Image::setAvailableSize(const vec2& size) {
-	const auto bounds = getBounds();
+	const auto bounds = Rectf{0, 0, getWidth(), getHeight()};
 	const auto fit	  = mFit.calcTransform(Rectf{0, 0, size.x, size.y}, bounds);
 	const auto width  = fit[0][0] * bounds.getWidth();
 	const auto height = fit[1][1] * bounds.getHeight();
@@ -350,7 +354,7 @@ float Image::getHeightMax() const {
 }
 
 void Image::fitInsideArea(const Rectf& area) {
-	const auto bounds = getBounds();
+	const auto bounds = Rectf{0, 0, getWidth(), getHeight()};
 	const auto fit	  = mFit.calcTransform(area, bounds, false);
 	setScale(fit[0][0], fit[1][1]);
 	setPosition(fit[2]);
@@ -397,8 +401,8 @@ void Image::cicleCropAutoCenter() {
 void Image::circleCropAutoCenter() {
 	mCircleCropCentered = true;
 	setCircleCrop(true);
-	const float scw = getWidth();
-	const float sch = getHeight();
+	const float scw = mWidth;  // We need to know the actual size of the image, not the cropped size.
+	const float sch = mHeight; // So, we can't use getWidth() and getHeight() here.
 	if (scw > sch) {
 		setCircleCropRect(ci::Rectf(scw / 2.0f - sch / 2.0f, 0.0f, scw / 2.0f + sch / 2.0f, sch));
 	} else {
@@ -409,11 +413,6 @@ void Image::circleCropAutoCenter() {
 void Image::disableCircleCropCentered() {
 	mCircleCropCentered = false;
 	setCircleCrop(false);
-}
-
-ci::Rectf Image::getBounds() const {
-	if (mCircleCropped) return {mShaderExtraData.x, mShaderExtraData.y, mShaderExtraData.z, mShaderExtraData.w};
-	return {0, 0, getWidth(), getHeight()};
 }
 
 void Image::setStatusCallback(const std::function<void(const Status&)>& fn) {

--- a/src/ds/ui/sprite/image.cpp
+++ b/src/ds/ui/sprite/image.cpp
@@ -306,26 +306,14 @@ void Image::clearImage() {
 }
 
 bool Image::setAvailableSize(const vec2& size) {
-	bool hasChanged = false;
+	const auto fit	  = mFit.calcTransform(Rectf{0, 0, size.x, size.y}, Rectf{0, 0, getWidth(), getHeight()});
+	const auto width  = fit[0][0] * getWidth();
+	const auto height = fit[1][1] * getHeight();
 
-	if (size.x > 0) {
-		const float aspect = getHeight() / getWidth();
-		const float height = size.x * aspect;
-		if (!mMinHeight.isDefined() || !approxEqual(mMinHeight.asUser(this, Value::VERTICAL), height)) {
-			mMinHeight = Value(height, Value::PIXELS);
-			hasChanged |= true;
-		}
-	}
-	if (size.y > 0) {
-		const float aspect = getWidth() / getHeight();
-		const float width  = size.y * aspect;
-		if (!mMinWidth.isDefined() || !approxEqual(mMinWidth.asUser(this, Value::HORIZONTAL), width)) {
-			mMinWidth = Value(width, Value::PIXELS);
-			hasChanged |= true;
-		}
-	}
+	mMinWidth = mMaxWidth = css::Value(width, Value::PIXELS);
+	mMinHeight = mMaxHeight = css::Value(height, Value::PIXELS);
 
-	return hasChanged;
+	return !approxEqual(width, getWidth()) || !approxEqual(height, getHeight());
 }
 
 float Image::getWidthMin() const {

--- a/src/ds/ui/sprite/image.cpp
+++ b/src/ds/ui/sprite/image.cpp
@@ -305,6 +305,61 @@ void Image::clearImage() {
 	imageChanged();
 }
 
+bool Image::setAvailableSize(const vec2& size) {
+	bool hasChanged = false;
+
+	if (size.x > 0) {
+		const float aspect = getHeight() / getWidth();
+		const float height = size.x * aspect;
+		if (!mMinHeight.isDefined() || !approxEqual(mMinHeight.asUser(this, Value::VERTICAL), height)) {
+			mMinHeight = Value(height, Value::PIXELS);
+			hasChanged |= true;
+		}
+	}
+	if (size.y > 0) {
+		const float aspect = getWidth() / getHeight();
+		const float width  = size.y * aspect;
+		if (!mMinWidth.isDefined() || !approxEqual(mMinWidth.asUser(this, Value::HORIZONTAL), width)) {
+			mMinWidth = Value(width, Value::PIXELS);
+			hasChanged |= true;
+		}
+	}
+
+	return hasChanged;
+}
+
+float Image::getWidthMin() const {
+	if (!mMinWidth.isDefined() && mMinHeight.isDefined()) {
+		const float aspect = getWidth() / getHeight();
+		return mMinHeight.asUser(this, Value::VERTICAL) * aspect;
+	}
+	return Sprite::getWidthMin();
+}
+
+float Image::getWidthMax() const {
+	if (!mMaxWidth.isDefined() && mMaxHeight.isDefined()) {
+		const float aspect = getWidth() / getHeight();
+		return mMaxHeight.asUser(this, Value::VERTICAL) * aspect;
+	}
+	return Sprite::getWidthMax();
+}
+
+float Image::getHeightMin() const {
+	if (!mMinHeight.isDefined() && mMinWidth.isDefined()) {
+		const float aspect = getHeight() / getWidth();
+		return mMinWidth.asUser(this, Value::HORIZONTAL) * aspect;
+	}
+	return Sprite::getHeightMin();
+}
+
+float Image::getHeightMax() const {
+	if (!mMaxHeight.isDefined() && mMaxWidth.isDefined()) {
+		const float aspect = getHeight() / getWidth();
+		return mMaxWidth.asUser(this, Value::HORIZONTAL) * aspect;
+	}
+	return Sprite::getHeightMax();
+}
+
 void Image::setSize(float width, float height) {
 	setSizeAll(width, height, mDepth);
 }

--- a/src/ds/ui/sprite/image.h
+++ b/src/ds/ui/sprite/image.h
@@ -123,8 +123,10 @@ class Image : public Sprite {
 	/// Turns off the above functionality
 	void disableCircleCropCentered();
 
-	/// Helper function to get the bounds of the image. Adjusted for circle cropping if that's enabled.
-	ci::Rectf getBounds() const;
+	/// Returns the width in pixels of the image. If circle cropping is applied, it will return the cropped width.
+	float getWidth() const override { return mCircleCropped ? mShaderExtraData.z - mShaderExtraData.x : mWidth; }
+	/// Returns the height in pixels of the image. If circle cropping is applied, it will return the cropped height.
+	float getHeight() const override { return mCircleCropped ? mShaderExtraData.w - mShaderExtraData.y : mHeight; }
 
 	struct Status {
 		static const int STATUS_EMPTY	= 0;

--- a/src/ds/ui/sprite/image.h
+++ b/src/ds/ui/sprite/image.h
@@ -94,6 +94,9 @@ class Image : public Sprite {
 	/// calculate minimum height based on the aspect ratio.
 	float getHeightMax() const override;
 
+	/// Since images can be cropped, we need to make sure any cropping is taken into account.
+	void fitInsideArea(const ci::Rectf& area) override;
+
 	/// \note calls Image::setSizeAll(...) internally.
 	/// \see Image::setSizeAll(...)
 	void setSize(float width, float height);
@@ -119,6 +122,9 @@ class Image : public Sprite {
 	void circleCropAutoCenter();
 	/// Turns off the above functionality
 	void disableCircleCropCentered();
+
+	/// Helper function to get the bounds of the image. Adjusted for circle cropping if that's enabled.
+	ci::Rectf getBounds() const;
 
 	struct Status {
 		static const int STATUS_EMPTY	= 0;

--- a/src/ds/ui/sprite/image.h
+++ b/src/ds/ui/sprite/image.h
@@ -77,6 +77,23 @@ class Image : public Sprite {
 	/// Clears the image from this sprite. Removes a reference in the image store if not cached
 	void clearImage();
 
+	/// Sets the available size for this sprite, allowing it to update its size range. This is used in layout
+	/// calculations. Returns whether anything changed.
+	bool setAvailableSize(const ci::vec2& size) override;
+
+	/// Returns the minimum width of the Image. If minimum width hasn't been set, but minimum height has, it will
+	/// calculate minimum width based on the aspect ratio.
+	float getWidthMin() const override;
+	/// Returns the maximum width of the Image. If maximum width hasn't been set, but maximum height has, it will
+	/// calculate maximum width based on the aspect ratio.
+	float getWidthMax() const override;
+	/// Returns the minimum height of the Image. If minimum height hasn't been set, but minimum width has, it will
+	/// calculate minimum height based on the aspect ratio.
+	float getHeightMin() const override;
+	/// Returns the maximum height of the Image. If maximum height hasn't been set, but maximum width has, it will
+	/// calculate minimum height based on the aspect ratio.
+	float getHeightMax() const override;
+
 	/// \note calls Image::setSizeAll(...) internally.
 	/// \see Image::setSizeAll(...)
 	void setSize(float width, float height);

--- a/src/ds/ui/sprite/sprite.cpp
+++ b/src/ds/ui/sprite/sprite.cpp
@@ -553,6 +553,9 @@ void Sprite::doSetScale(const ci::vec3& scale) {
 	markAsDirty(SCALE_DIRTY);
 	dimensionalStateChanged();
 	onScaleChanged();
+
+	// Notify listeners about size change.
+	mEngine.getNotifier().notify(SpriteDimensionsChangedEvent(this));
 }
 
 const ci::vec3& Sprite::getPosition() const {
@@ -857,6 +860,9 @@ void Sprite::setSizeAll(float width, float height, float depth) {
 	mNeedsBatchUpdate = true;
 	markAsDirty(SIZE_DIRTY);
 	dimensionalStateChanged();
+
+	// Notify listeners about size change.
+	mEngine.getNotifier().notify(SpriteDimensionsChangedEvent(this));
 }
 
 void Sprite::setSizeAll(const ci::vec3& size3d) {

--- a/src/ds/ui/sprite/sprite.cpp
+++ b/src/ds/ui/sprite/sprite.cpp
@@ -1183,6 +1183,14 @@ bool Sprite::hasMultiTouchConstraint(const BitMask& constraint) const {
 	return mMultiTouchConstraints & constraint;
 }
 
+void Sprite::setColumnSpan(const Range<size_t>& span) {
+	mGridColumnSpan = span;
+}
+
+void Sprite::setRowSpan(const Range<size_t>& span) {
+	mGridRowSpan = span;
+}
+
 void Sprite::swipe(const ci::vec3& swipeVector) {
 	if (mSwipeCallback) mSwipeCallback(this, swipeVector);
 }
@@ -1369,6 +1377,14 @@ bool Sprite::inBounds() const {
 
 bool Sprite::isLoaded() const {
 	return true;
+}
+
+void Sprite::fitInsideArea(const ci::Rectf& area) {
+	// Fit the sprite to the area.
+	const auto bounds = ci::Rectf{0, 0, getWidth(), getHeight()};
+	const auto fit	  = mFit.calcTransform(area, bounds, false);
+	setScale(fit[0][0], fit[1][1]);
+	setPosition(fit[2]);
 }
 
 float Sprite::getDepth() const {

--- a/src/ds/ui/sprite/sprite.cpp
+++ b/src/ds/ui/sprite/sprite.cpp
@@ -828,8 +828,8 @@ void Sprite::buildTransform() const {
 		mTransformation = glm::rotate(mTransformation, mDegree * math::DEGREE2RADIAN, mRotation);
 	}
 	mTransformation = glm::scale(mTransformation, glm::vec3(mScale.x, mScale.y, mScale.z));
-	mTransformation =
-		glm::translate(mTransformation, glm::vec3(-mCenter.x * mWidth, -mCenter.y * mHeight, -mCenter.z * mDepth));
+	mTransformation = glm::translate(mTransformation,
+									 glm::vec3(-mCenter.x * getWidth(), -mCenter.y * getHeight(), -mCenter.z * getDepth()));
 
 	mInverseTransform = glm::inverse(mTransformation);
 }

--- a/src/ds/ui/sprite/sprite.h
+++ b/src/ds/ui/sprite/sprite.h
@@ -1163,6 +1163,22 @@ namespace ui {
 		}
 	}
 
+	class SpriteDimensionsChangedEvent : public ds::RegisteredEvent<SpriteDimensionsChangedEvent> {
+		Sprite* mSprite;
+
+	  public:
+		SpriteDimensionsChangedEvent(Sprite* sprite)
+		  : mSprite(sprite) {}
+
+		Sprite*	 getParent() const { return mSprite->getParent(); }
+		Sprite*	 getSprite() const { return mSprite; }
+		ci::vec3 getSize() const { return mSprite->getSize(); }
+		ci::vec3 getScale() const { return mSprite->getScale(); }
+		float	 getScaleWidth() const { return mSprite->getScaleWidth(); }
+		float	 getScaleHeight() const { return mSprite->getScaleHeight(); }
+		float	 getScaleDepth() const { return mSprite->getScaleDepth(); }
+	};
+
 } // namespace ui
 } // namespace ds
 

--- a/src/ds/ui/sprite/text.cpp
+++ b/src/ds/ui/sprite/text.cpp
@@ -22,6 +22,7 @@
 #include "ds/debug/logger.h"
 #include "ds/ui/service/pango_font_service.h"
 #include "ds/ui/sprite/sprite_engine.h"
+#include "ds/util/float_util.h"
 #include "ds/util/string_util.h"
 #include <Poco/Stopwatch.h>
 
@@ -695,6 +696,30 @@ float Text::getBaseline() {
 	} else {
 		return 0.f;
 	}
+}
+
+bool Text::setAvailableSize(const ci::vec2& size) {
+	// Adjust resize limits.
+	setResizeLimit(size.x, size.y);
+
+	// Measure minimum required space.
+	bool hasChanged = false;
+	if (!mMinWidth.isDefined() || !approxEqual(mMinWidth.asUser(this, Value::HORIZONTAL), getWidth())) {
+		mMinWidth  = Value(getWidth(), Value::PIXELS);
+		hasChanged = true;
+	}
+	if (!mMinHeight.isDefined() || !approxEqual(mMinHeight.asUser(this, Value::VERTICAL), getHeight())) {
+		mMinHeight = Value(getHeight(), Value::PIXELS);
+		hasChanged = true;
+	}
+
+	// Notify layout if settings have changed.
+	return hasChanged;
+}
+
+void Text::fitInsideArea(const ci::Rectf& area) {
+	setResizeLimit(area.getWidth(), area.getHeight());
+	Sprite::fitInsideArea(area);
 }
 
 bool Text::getTextWrapped() {

--- a/src/ds/ui/sprite/text.cpp
+++ b/src/ds/ui/sprite/text.cpp
@@ -162,6 +162,7 @@ Text::Text(ds::ui::SpriteEngine& eng)
   , mNeedsTextRender(false)
   , mNeedsFontOptionUpdate(false)
   , mNeedsMarkupDetection(false)
+  , mNeedsMinMaxMeasuring(false)
   , mPixelWidth(-1)
   , mPixelHeight(-1)
   , mPixelOffsetX(0)
@@ -238,6 +239,7 @@ void Text::setText(std::string text) {
 		mNeedsTextRender			  = true;
 		mNeedsRefit					  = true;
 		mNeedsMaxResizeFontSizeUpdate = true;
+		mNeedsMinMaxMeasuring		  = true;
 
 		markAsDirty(TEXT_DIRTY);
 	}
@@ -313,10 +315,11 @@ Alignment::Enum Text::getAlignment() {
 
 void Text::setAlignment(Alignment::Enum alignment) {
 	if (mStyle.mAlignment != alignment) {
-		mStyle.mAlignment = alignment;
-		mNeedsMeasuring	  = true;
-		mNeedsTextRender  = true;
-		mNeedsRefit		  = true;
+		mStyle.mAlignment	  = alignment;
+		mNeedsMeasuring		  = true;
+		mNeedsTextRender	  = true;
+		mNeedsRefit			  = true;
+		mNeedsMinMaxMeasuring = true;
 		markAsDirty(FONT_DIRTY);
 	}
 }
@@ -327,10 +330,11 @@ double Text::getLeading() const {
 
 Text& Text::setLeading(const double leading) {
 	if (mStyle.mLeading != leading) {
-		mStyle.mLeading	 = leading;
-		mNeedsMeasuring	 = true;
-		mNeedsTextRender = true;
-		mNeedsRefit		 = true;
+		mStyle.mLeading		  = leading;
+		mNeedsMeasuring		  = true;
+		mNeedsTextRender	  = true;
+		mNeedsRefit			  = true;
+		mNeedsMinMaxMeasuring = true;
 		markAsDirty(FONT_DIRTY);
 	}
 	return *this;
@@ -346,6 +350,7 @@ Text& Text::setLetterSpacing(const double letterSpacing) {
 		mNeedsMeasuring		  = true;
 		mNeedsTextRender	  = true;
 		mNeedsRefit			  = true;
+		mNeedsMinMaxMeasuring = true;
 		markAsDirty(FONT_DIRTY);
 	}
 	return *this;
@@ -372,8 +377,8 @@ Text& Text::setResizeLimit(const float maxWidth, const float maxHeight) {
 		if (mResizeLimitHeight == 0.0f) {
 			mResizeLimitHeight = -1.0f;
 		}
-		mNeedsMeasuring = true;
-		mNeedsRefit		= true;
+		mNeedsMeasuring		  = true;
+		mNeedsRefit			  = true;
 		markAsDirty(LAYOUT_DIRTY);
 	}
 
@@ -381,19 +386,21 @@ Text& Text::setResizeLimit(const float maxWidth, const float maxHeight) {
 }
 
 Text& Text::setFitFontSizes(std::vector<double> font_sizes) {
-	mStyle.mFitSizes = font_sizes;
-	mNeedsRefit		 = true;
-	mNeedsMeasuring	 = true;
+	mStyle.mFitSizes	  = font_sizes;
+	mNeedsRefit			  = true;
+	mNeedsMeasuring		  = true;
+	mNeedsMinMaxMeasuring = true;
 	return *this;
 }
 
 Text& Text::setFitToResizeLimit(const bool fitToResize) {
 	if (mFitToResizeLimit != fitToResize) {
 
-		mNeedsFontSizeUpdate = true;
-		mNeedsMeasuring		 = true;
-		mFitToResizeLimit	 = fitToResize;
-		mNeedsRefit			 = true;
+		mNeedsFontSizeUpdate  = true;
+		mNeedsMeasuring		  = true;
+		mFitToResizeLimit	  = fitToResize;
+		mNeedsRefit			  = true;
+		mNeedsMinMaxMeasuring = true;
 
 		mNeedsMaxResizeFontSizeUpdate = true;
 		markAsDirty(LAYOUT_DIRTY);
@@ -427,9 +434,10 @@ void Text::setTextColor(const ci::Color& color) {
 
 void Text::setFontSize(double size) {
 	if (mStyle.mSize != size) {
-		mStyle.mSize		 = size;
-		mNeedsFontSizeUpdate = true;
-		mNeedsMeasuring		 = true;
+		mStyle.mSize		  = size;
+		mNeedsFontSizeUpdate  = true;
+		mNeedsMeasuring		  = true;
+		mNeedsMinMaxMeasuring = true;
 
 		markAsDirty(FONT_DIRTY);
 	}
@@ -440,6 +448,7 @@ void Text::setFitMaxFontSize(double fontSize) {
 		mStyle.mFitMaxTextSize = fontSize;
 		mNeedsMeasuring		   = true;
 		mNeedsRefit			   = true;
+		mNeedsMinMaxMeasuring  = true;
 	}
 }
 
@@ -448,6 +457,7 @@ void Text::setFitMinFontSize(double fontSize) {
 		mStyle.mFitMinTextSize = fontSize;
 		mNeedsMeasuring		   = true;
 		mNeedsRefit			   = true;
+		mNeedsMinMaxMeasuring  = true;
 	}
 }
 
@@ -471,6 +481,7 @@ Text& Text::setFont(const std::string& font) {
 		mNeedsMeasuring				  = true;
 		mNeedsRefit					  = true;
 		mNeedsMaxResizeFontSizeUpdate = true;
+		mNeedsMinMaxMeasuring		  = true;
 		markAsDirty(FONT_DIRTY);
 	}
 	return *this;
@@ -492,6 +503,34 @@ float Text::getHeight() const {
 		(const_cast<Text*>(this))->measurePangoText();
 	}
 	return mHeight;
+}
+
+float Text::getWidthMin() const {
+	if (mNeedsMinMaxMeasuring) {
+		(const_cast<Text*>(this))->measureMinMaxTextSize();		
+	}
+	return mMinWidth.asUser(this, css::Value::HORIZONTAL);
+}
+
+float Text::getWidthMax() const {
+	if (mNeedsMinMaxMeasuring) {
+		(const_cast<Text*>(this))->measureMinMaxTextSize();		
+	}
+	return mMaxWidth.asUser(this, css::Value::HORIZONTAL);
+}
+
+float Text::getHeightMin() const {
+	if (mNeedsMinMaxMeasuring) {
+		(const_cast<Text*>(this))->measureMinMaxTextSize();		
+	}
+	return mMinHeight.asUser(this, css::Value::VERTICAL);
+}
+
+float Text::getHeightMax() const {
+	if (mNeedsMinMaxMeasuring) {
+		(const_cast<Text*>(this))->measureMinMaxTextSize();		
+	}
+	return mMaxHeight.asUser(this, css::Value::VERTICAL);
 }
 
 void Text::setEllipsizeMode(EllipsizeMode theMode) {
@@ -702,18 +741,23 @@ bool Text::setAvailableSize(const ci::vec2& size) {
 	// Adjust resize limits.
 	setResizeLimit(size.x, size.y);
 
-	// Measure minimum required space.
-	bool hasChanged = false;
-	if (!mMinWidth.isDefined() || !approxEqual(mMinWidth.asUser(this, Value::HORIZONTAL), getWidth())) {
-		mMinWidth  = Value(getWidth(), Value::PIXELS);
-		hasChanged = true;
-	}
-	if (!mMinHeight.isDefined() || !approxEqual(mMinHeight.asUser(this, Value::VERTICAL), getHeight())) {
-		mMinHeight = Value(getHeight(), Value::PIXELS);
-		hasChanged = true;
+	if (mNeedsMeasuring) {
+		measurePangoText();
 	}
 
-	// Notify layout if settings have changed.
+	const auto w = getWidth();// mTrimWhiteSpace ? mPixelWidth - glm::max(mRenderOffset.x, 0.0f) : mWidth;
+	const auto h = getHeight();// mTrimWhiteSpace ? mPixelHeight - glm::max(mRenderOffset.y, 0.0f) : mHeight;
+
+	bool hasChanged = !approxEqual(w, mMinWidth.asUser(this, css::Value::HORIZONTAL));
+	hasChanged |= !approxEqual(w, mMaxWidth.asUser(this, css::Value::HORIZONTAL));
+	hasChanged |= !approxEqual(h, mMinHeight.asUser(this, css::Value::VERTICAL));
+	hasChanged |= !approxEqual(h, mMaxHeight.asUser(this, css::Value::VERTICAL));
+
+	mMinWidth.set(w, css::Value::Unit::PIXELS);
+	mMaxWidth.set(w, css::Value::Unit::PIXELS);
+	mMinHeight.set(h, css::Value::Unit::PIXELS);
+	mMaxHeight.set(h, css::Value::Unit::PIXELS);
+
 	return hasChanged;
 }
 
@@ -862,7 +906,7 @@ void Text::findFitFontSize() {
 
 			// inital height measurement
 			pango_layout_get_pixel_extents(mPangoLayout, &inkRect, &extentRect);
-			double h = std::max(extentRect.height, inkRect.height);
+			double h = mTrimWhiteSpace ? inkRect.height : std::max(extentRect.height, inkRect.height);
 
 			while (h < mResizeLimitHeight) {
 
@@ -873,7 +917,7 @@ void Text::findFitFontSize() {
 
 				// get the height
 				pango_layout_get_pixel_extents(mPangoLayout, &inkRect, &extentRect);
-				h = std::max(extentRect.height, inkRect.height);
+				h = mTrimWhiteSpace ? inkRect.height : std::max(extentRect.height, inkRect.height);
 
 				// check if we are over the limit now and out last increment was greater than 1.
 				// if both of those are true, we reset the increment to one, and try again from the last working
@@ -888,7 +932,7 @@ void Text::findFitFontSize() {
 
 					// remeasure the height
 					pango_layout_get_pixel_extents(mPangoLayout, &inkRect, &extentRect);
-					h = std::max(extentRect.height, inkRect.height);
+					h = mTrimWhiteSpace ? inkRect.height : std::max(extentRect.height, inkRect.height);
 
 					continue;
 				}
@@ -911,15 +955,15 @@ void Text::findFitFontSize() {
 				_setFontSize(fs);
 
 				pango_layout_get_pixel_extents(mPangoLayout, &inkRect, &extentRect);
-				double w = std::max(extentRect.width, inkRect.width);
+				double w = mTrimWhiteSpace ? inkRect.width : std::max(extentRect.width, inkRect.width);
 				while (w < mResizeLimitWidth) {
 
 					// set font
 					_setFontSize(fs + increment);
 
-					// get height
+					// get width
 					pango_layout_get_pixel_extents(mPangoLayout, &inkRect, &extentRect);
-					w = std::max(extentRect.width, inkRect.width);
+					w = mTrimWhiteSpace ? inkRect.width : std::max(extentRect.width, inkRect.width);
 
 
 					if (w >= mResizeLimitWidth && increment > 1) {
@@ -928,7 +972,7 @@ void Text::findFitFontSize() {
 						_setFontSize(fs);
 						// h = getHeight();
 						pango_layout_get_pixel_extents(mPangoLayout, &inkRect, &extentRect);
-						w = std::max(extentRect.width, inkRect.width);
+						w = mTrimWhiteSpace ? inkRect.width : std::max(extentRect.width, inkRect.width);
 						continue;
 					}
 					fs = fs + increment;
@@ -1497,6 +1541,57 @@ void Text::renderPangoText() {
 			cairo_surface_destroy(cairoSurface);
 		}
 	}
+}
+
+void Text::measureMinMaxTextSize() {
+	const auto resizeLimit = ci::vec2(getResizeLimitWidth(), getResizeLimitHeight());
+
+	auto style = mStyle;
+	std::sort(style.mFitSizes.begin(), style.mFitSizes.end());
+
+
+	// Use smallest font size.
+	if (!style.mFitSizes.empty()) {
+		setFitFontSizes({style.mFitSizes.front()});
+	} else {
+		setFitMinFontSize(style.mFitMinTextSize);
+		setFitMaxFontSize(style.mFitMinTextSize);
+	}
+
+	setResizeLimit(1, 0);
+	measurePangoText();
+	mMinWidth = css::Value(mPixelWidth, css::Value::PIXELS);
+
+	setResizeLimit(0, 1);
+	measurePangoText();
+	mMinHeight = css::Value(mPixelHeight, css::Value::PIXELS);
+
+	// Use largest font size.
+	if (!style.mFitSizes.empty()) {
+		setFitFontSizes({style.mFitSizes.back()});
+	} else {
+		setFitMinFontSize(style.mFitMaxTextSize);
+		setFitMaxFontSize(style.mFitMaxTextSize);
+	}
+	
+	setResizeLimit(1, 0);
+	measurePangoText();
+	mMaxHeight = css::Value(mPixelHeight, css::Value::PIXELS);
+	
+	setResizeLimit(0, 1);
+	measurePangoText();
+	mMaxWidth = css::Value(mPixelWidth, css::Value::PIXELS);
+
+	// Restore the original resize limits.
+	setResizeLimit(resizeLimit.x, resizeLimit.y);
+	if (!style.mFitSizes.empty()) {
+		setFitFontSizes(style.mFitSizes);
+	} else {
+		setFitMinFontSize(style.mFitMinTextSize);
+		setFitMaxFontSize(style.mFitMaxTextSize);
+	}
+
+	mNeedsMinMaxMeasuring = false;
 }
 
 void Text::writeAttributesTo(ds::DataBuffer& buf) {

--- a/src/ds/ui/sprite/text.h
+++ b/src/ds/ui/sprite/text.h
@@ -192,6 +192,11 @@ class Text : public ds::ui::Sprite {
 	/// Returns the actual render size of the text
 	ci::ivec2 getPixelSize() const { return {mPixelWidth, mPixelHeight}; }
 
+	float getWidthMin() const override;
+	float getWidthMax() const override;
+	float getHeightMin() const override;
+	float getHeightMax() const override;
+
 	/// Sets the available size for this sprite, allowing it to update its size range. This is used in layout
 	/// calculations. Returns whether anything changed.
 	bool setAvailableSize(const ci::vec2& size) override;
@@ -305,6 +310,9 @@ class Text : public ds::ui::Sprite {
 	/// Renders text into the texture.
 	void renderPangoText();
 
+	/// Measures min/max size of the text for layout purposes
+	void measureMinMaxTextSize();
+
 	// pango references;
 	PangoContext* mPangoContext;
 	PangoLayout*  mPangoLayout;
@@ -353,6 +361,7 @@ class Text : public ds::ui::Sprite {
 	bool mNeedsTextRender;
 	bool mNeedsFontOptionUpdate;
 	bool mNeedsMarkupDetection;
+	bool mNeedsMinMaxMeasuring;
 
 	/// simply stored to check for change across renders
 	int mPixelWidth;

--- a/src/ds/ui/sprite/text.h
+++ b/src/ds/ui/sprite/text.h
@@ -192,6 +192,13 @@ class Text : public ds::ui::Sprite {
 	/// Returns the actual render size of the text
 	ci::ivec2 getPixelSize() const { return {mPixelWidth, mPixelHeight}; }
 
+	/// Sets the available size for this sprite, allowing it to update its size range. This is used in layout
+	/// calculations. Returns whether anything changed.
+	bool setAvailableSize(const ci::vec2& size) override;
+
+	/// Used in Grid layouts, enables size-fitting and sets size and position of the Text.
+	void fitInsideArea(const ci::Rectf& area) override;
+
 	/// If ellipsize mode is none and there's a resize width > 0 and the text had to wrap at all, returns true.
 	/// otherwise false
 	bool getTextWrapped();

--- a/src/ds/util/float_util.h
+++ b/src/ds/util/float_util.h
@@ -1,0 +1,35 @@
+#pragma once
+#ifndef DS_UTIL_FLOATUTIL_H_
+#define DS_UTIL_FLOATUTIL_H_
+
+namespace ds {
+
+constexpr double EPSILON_VALUE = 4.37114e-05;
+
+inline bool approxZero(float n, float epsilon = float(EPSILON_VALUE)) {
+	return std::abs(n) < epsilon;
+}
+
+inline bool approxZero(double n, double epsilon = EPSILON_VALUE) {
+	return std::abs(n) < epsilon;
+}
+
+inline float roundToZero(float n, float epsilon = float(EPSILON_VALUE)) {
+	return approxZero(n, epsilon) ? 0.0f : n;
+}
+
+inline double roundToZero(double n, double epsilon = EPSILON_VALUE) {
+	return approxZero(n, epsilon) ? 0.0 : n;
+}
+
+inline bool approxEqual(float a, float b, float epsilon = float(EPSILON_VALUE)) {
+	return std::abs(b - a) < epsilon;
+}
+
+inline bool approxEqual(double a, double b, double epsilon = EPSILON_VALUE) {
+	return std::abs(b - a) < epsilon;
+}
+
+} // namespace ds
+
+#endif

--- a/src/ds/util/parse_util.h
+++ b/src/ds/util/parse_util.h
@@ -1,0 +1,82 @@
+#pragma once
+#ifndef DS_UTIL_PARSEUTIL_H_
+#define DS_UTIL_PARSEUTIL_H_
+
+#include <string>
+
+namespace ds {
+
+/// Returns whether \a c is a digit ASCII character.
+inline bool isDigit(char c) {
+	return (c >= '0' && c <= '9');
+}
+/// Returns whether \a c is a numeric ASCII character, including '.', '-', 'e', 'E', and '+'.
+inline bool isNumeric(char c) {
+	return (c >= '0' && c <= '9') || c == '.' || c == '-' || c == 'e' || c == 'E' || c == '+';
+}
+/// Skips any whitespace in the ASCII string.
+inline void skipSpace(const char** sInOut) {
+	while (**sInOut && isspace(**sInOut))
+		++(*sInOut);
+}
+/// Skips any whitespace or commas in the ASCII string.
+inline void skipSpaceOrComma(const char** sInOut) {
+	while (**sInOut && (isspace(**sInOut) || **sInOut == ','))
+		++(*sInOut);
+}
+/// Skips any whitespace or parenthesis in the ASCII string.
+inline void skipSpaceOrParenthesis(const char** sInOut) {
+	while (**sInOut && (isspace(**sInOut) || **sInOut == '(' || **sInOut == ')'))
+		++(*sInOut);
+}
+/// Skips all characters until the given character is found in the ASCII string.
+inline void skipUntil(const char** sInOut, char c) {
+	while (**sInOut && **sInOut != c)
+		++(*sInOut);
+}
+/// Returns the part before the first occurrence of the given character in the ASCII string.
+inline std::string fetchUntil(const char** sInOut, char c) {
+	const char* from = *sInOut;
+	skipUntil(sInOut, c);
+	return std::string(from, *sInOut - from);
+}
+/// Returns the first word in the ASCII string.
+inline std::string fetchWord(const char** sInOut) {
+	const char* from = *sInOut;
+	while (**sInOut && !isspace(**sInOut))
+		++(*sInOut);
+	return std::string(from, *sInOut - from);
+}
+/// Returns the double value at the beginning of the ASCII string.
+inline double parseDouble(const char** sInOut) {
+	return strtod(*sInOut, const_cast<char**>(sInOut));
+}
+/// Returns the float point value at the beginning of the ASCII string.
+inline float parseFloat(const char** sInOut) {
+	return strtof(*sInOut, const_cast<char**>(sInOut));
+}
+/// Returns the integer value at the beginning of the ASCII string.
+inline long int parseInt(const char** sInOut) {
+	return strtol(*sInOut, const_cast<char**>(sInOut), 10);
+}
+/// Returns the integer value of the hexadecimal digits at the beginning of the ASCII string.
+inline long int parseHex(const char** sInOut) {
+		return strtol(*sInOut, const_cast<char**>(sInOut), 16);
+}
+/// Returns the integer value of the binary digits at the beginning of the ASCII string.
+inline long int parseBinary(const char** sInOut) {
+	return strtol(*sInOut, const_cast<char**>(sInOut), 2);
+}
+/// Returns whether the ASCII strings are equal, ignoring case.
+inline bool isSimilar(const std::string& a, const std::string& b) {
+	return a.size() == b.size() &&
+		   std::equal(a.begin(), a.end(), b.begin(), [](char a, char b) { return tolower(a) == tolower(b); });
+}
+/// Returns whether the ASCII strings are equal, ignoring case.
+inline bool isSimilar(const char* a, const char* b, size_t maxCount) {
+	return std::equal(a, a + maxCount, b, b + maxCount, [](char a, char b) { return tolower(a) == tolower(b); });
+}
+
+} // namespace ds
+
+#endif // DS_UTIL_PARSEUTIL_H_

--- a/vs2015/platform.vcxproj
+++ b/vs2015/platform.vcxproj
@@ -128,6 +128,8 @@
     <ClInclude Include="..\src\ds\ui\button\sprite_button.h" />
     <ClInclude Include="..\src\ds\ui\control\control_check_box.h" />
     <ClInclude Include="..\src\ds\ui\control\control_slider.h" />
+    <ClInclude Include="..\src\ds\ui\grid\grid.h" />
+    <ClInclude Include="..\src\ds\ui\grid\value.h" />
     <ClInclude Include="..\src\ds\ui\layout\layout_sprite.h" />
     <ClInclude Include="..\src\ds\ui\layout\perspective_layout.h" />
     <ClInclude Include="..\src\ds\ui\service\shader_string_repo.h" />
@@ -137,6 +139,7 @@
     <ClInclude Include="..\src\ds\ui\soft_keyboard\soft_keyboard_button.h" />
     <ClInclude Include="..\src\ds\ui\soft_keyboard\soft_keyboard_defs.h" />
     <ClInclude Include="..\src\ds\ui\soft_keyboard\soft_keyboard_settings.h" />
+    <ClInclude Include="..\src\ds\ui\sprite\fit.h" />
     <ClInclude Include="..\src\ds\ui\sprite\util\flexbox_parser.h" />
     <ClInclude Include="..\src\ds\ui\touch\touch_debug.h" />
     <ClInclude Include="..\src\ds\ui\touch\tuio_input.h" />
@@ -144,6 +147,7 @@
     <ClInclude Include="..\src\ds\util\ada\tools\fs.h" />
     <ClInclude Include="..\src\ds\util\ada\tools\list.h" />
     <ClInclude Include="..\src\ds\util\date_util.h" />
+    <ClInclude Include="..\src\ds\util\float_util.h" />
     <ClInclude Include="..\src\ds\util\glm_structured_binding.h" />
     <ClInclude Include="..\src\ds\util\markdown_to_pango.h" />
     <ClInclude Include="..\src\ds\util\sundown\autolink.h" />
@@ -307,6 +311,8 @@
     <ClCompile Include="..\src\ds\ui\button\sprite_button.cpp" />
     <ClCompile Include="..\src\ds\ui\control\control_check_box.cpp" />
     <ClCompile Include="..\src\ds\ui\control\control_slider.cpp" />
+    <ClCompile Include="..\src\ds\ui\grid\grid.cpp" />
+    <ClCompile Include="..\src\ds\ui\grid\value.cpp" />
     <ClCompile Include="..\src\ds\ui\layout\layout_sprite.cpp" />
     <ClCompile Include="..\src\ds\ui\layout\perspective_layout.cpp" />
     <ClCompile Include="..\src\ds\ui\service\shader_string_repo.cpp" />
@@ -315,6 +321,7 @@
     <ClCompile Include="..\src\ds\ui\soft_keyboard\soft_keyboard_builder.cpp" />
     <ClCompile Include="..\src\ds\ui\soft_keyboard\soft_keyboard_button.cpp" />
     <ClCompile Include="..\src\ds\ui\soft_keyboard\soft_keyboard_defs.cpp" />
+    <ClCompile Include="..\src\ds\ui\sprite\fit.cpp" />
     <ClCompile Include="..\src\ds\ui\sprite\util\flexbox_parser.cpp" />
     <ClCompile Include="..\src\ds\ui\touch\touch_debug.cpp" />
     <ClCompile Include="..\src\ds\ui\touch\tuio_input.cpp" />

--- a/vs2015/platform.vcxproj.filters
+++ b/vs2015/platform.vcxproj.filters
@@ -121,6 +121,9 @@
     <Filter Include="src\imgui_components">
       <UniqueIdentifier>{6e8dd3c8-2605-44f6-b63a-4d39d6e9cca2}</UniqueIdentifier>
     </Filter>
+    <Filter Include="src\ds\ui\grid">
+      <UniqueIdentifier>{ed058117-6d7c-45f5-8f11-cb859d03d47f}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\ds\data\resource.h">
@@ -705,6 +708,18 @@
     <ClInclude Include="..\src\imgui_components\TextAnsi.h">
       <Filter>src\imgui_components</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\ds\ui\grid\grid.h">
+      <Filter>src\ds\ui\grid</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\ds\util\float_util.h">
+      <Filter>src\ds\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\ds\ui\sprite\fit.h">
+      <Filter>src\ds\ui\sprite</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\ds\ui\grid\value.h">
+      <Filter>src\ds\ui\grid</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\ds\data\resource.cpp">
@@ -1156,6 +1171,15 @@
     </ClCompile>
     <ClCompile Include="..\src\imgui_components\TextAnsi.cpp">
       <Filter>src\imgui_components</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ds\ui\grid\grid.cpp">
+      <Filter>src\ds\ui\grid</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ds\ui\sprite\fit.cpp">
+      <Filter>src\ds\ui\sprite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\ds\ui\grid\value.cpp">
+      <Filter>src\ds\ui\grid</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
…described here: https://www.w3.org/TR/2013/WD-css3-grid-layout-20130402/#layout-algorithm

It's the result of weeks of work, squashed into a single commit for easier comparison. New properties and functions have been added to `ds::ui::Sprite` to make it work with grid layouts. Derived UI classes, like `Text`, `Image` and `LayoutSprite`, have been updated to work well when placed inside grid cells.

For now, we don't support named grid lines, so use numbers to specify in which column(s) or row(s) you want to place your sprites. Additionally, we don't support automatic placement of content, because the heuristics of a DS_Cinder app differ in many ways from web content.

Gaps are supported, as are intrinsics and most of the functions (e.g. "minmax" or "repeat") available to create your grid. Value units like "px", "%", "vw" and "vmin" are supported, but type units like "em" are not.

We hope this is useful and a welcome addition to DS_Cinder.