### PR TITLE
This adds a `media_player_keep_if_same` setting to ds::ui::MediaPlayer…

### DIFF
--- a/projects/viewers/src/ds/ui/media/media_player.cpp
+++ b/projects/viewers/src/ds/ui/media/media_player.cpp
@@ -10,6 +10,7 @@
 #include <ds/ui/sprite/sprite_engine.h>
 #include <ds/ui/util/ui_utils.h>
 #include <ds/util/string_util.h>
+#include <ds/util/float_util.h>
 
 #include <ds/data/resource.h>
 
@@ -243,7 +244,14 @@ void MediaPlayer::loadMedia(const std::string& mediaPath, const bool initializeI
 void MediaPlayer::loadMedia(const ds::Resource& reccy, const bool initializeImmediately) {
 	if (mInitialized) {
 		// If the resource is the same, don't do anything.
-		if (mMediaViewerSettings.mKeepIfSame && reccy.getAbsoluteFilePath() == mResource.getAbsoluteFilePath()) return;
+		if (mMediaViewerSettings.mKeepIfSame && reccy.getAbsoluteFilePath() == mResource.getAbsoluteFilePath()) {
+			// ci::Rectf does not support operator==(const ci::Rectf&), so we'll have to do it the hard way.
+			bool cropIsSame = approxEqual(reccy.getCrop().x1, mResource.getCrop().x1);
+			cropIsSame &= approxEqual(reccy.getCrop().x2, mResource.getCrop().x2);
+			cropIsSame &= approxEqual(reccy.getCrop().y1, mResource.getCrop().y1);
+			cropIsSame &= approxEqual(reccy.getCrop().y2, mResource.getCrop().y2);
+			if (cropIsSame) return;
+		}
 		// If the resource is different, uninitialize and then set the new resource.
 		uninitialize();
 	}

--- a/projects/viewers/src/ds/ui/media/media_player.cpp
+++ b/projects/viewers/src/ds/ui/media/media_player.cpp
@@ -186,6 +186,14 @@ auto INIT = []() {
 				mvs.mVideoNVDecode = ds::parseBoolean(theValue);
 				mediaPlayer.setSettings(mvs);
 			});
+
+		e.registerSpritePropertySetter<ds::ui::MediaPlayer>(
+			"media_player_keep_if_same",
+			[](ds::ui::MediaPlayer& mediaPlayer, const std::string& theValue, const std::string& fileReferrer) {
+				auto& mvs		   = mediaPlayer.getSettings();
+				mvs.mKeepIfSame = ds::parseBoolean(theValue);
+				mediaPlayer.setSettings(mvs);
+			});
 	});
 	return true;
 }();
@@ -233,7 +241,12 @@ void MediaPlayer::loadMedia(const std::string& mediaPath, const bool initializeI
 }
 
 void MediaPlayer::loadMedia(const ds::Resource& reccy, const bool initializeImmediately) {
-	if (mInitialized) uninitialize();
+	if (mInitialized) {
+		// If the resource is the same, don't do anything.
+		if (mMediaViewerSettings.mKeepIfSame && reccy.getAbsoluteFilePath() == mResource.getAbsoluteFilePath()) return;
+		// If the resource is different, uninitialize and then set the new resource.
+		uninitialize();
+	}
 
 	mResource = reccy;
 

--- a/projects/viewers/src/ds/ui/media/media_viewer_settings.h
+++ b/projects/viewers/src/ds/ui/media/media_viewer_settings.h
@@ -46,7 +46,8 @@ struct MediaViewerSettings {
 	  , mVideoNVDecode(false)
 	  , mPanoramicVideoInteractive(true)
 	  , mVideoStreamingLatency(0.2)
-	  , mVideoSplitAlpha(false) {}
+	  , mVideoSplitAlpha(false)
+	  , mKeepIfSame(false) {}
 
 	//--------------------Overall Settings -----------------------------------------//
 	/// The size to be calculated to fit inside when initially loading content
@@ -164,6 +165,9 @@ struct MediaViewerSettings {
 
 	/// render video as if lower half is the alpha channel
 	bool mVideoSplitAlpha;
+
+	/// don't unload the media if the same resource is set again
+	bool mKeepIfSame;
 };
 
 } // namespace ds::ui


### PR DESCRIPTION
…allowing you to keep the current resource when loading the same media.

This is useful if you have a sequence of templates, each using the same background media. The background media would continue to show uninterrupted.