### PR TITLE
Eb/update platform

### DIFF
--- a/vs2015/PropertySheets/Platform64.props
+++ b/vs2015/PropertySheets/Platform64.props
@@ -5,7 +5,7 @@
   <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>_WIN32_WINNT=0x0602;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WIN32_WINNT=0x0A00;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include;..\src;$(DS_PLATFORM_093)\Cinder\include;$(BOOST_PATH);$(DS_PLATFORM_093)\Cinder\blocks\OSC\src;$(DS_PLATFORM_093)\Cinder\blocks\TUIO\src;$(DS_PLATFORM_093)\lib\poco\include;$(DS_PLATFORM_093)\src;$(DS_PLATFORM_093)\src\gtk;$(DS_PLATFORM_093)\src\gtk\cairo;$(DS_PLATFORM_093)\src\gtk\pango-1.0;$(DS_PLATFORM_093)\src\gtk\glib-2.0;$(DS_PLATFORM_093)\lib\snappy;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>

--- a/vs2015/PropertySheets/Platform64_d.props
+++ b/vs2015/PropertySheets/Platform64_d.props
@@ -5,7 +5,7 @@
   <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>_WIN32_WINNT=0x0602;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WIN32_WINNT=0x0A00;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\include;..\src;$(DS_PLATFORM_093)\Cinder\include;$(BOOST_PATH);$(DS_PLATFORM_093)\Cinder\blocks\OSC\src;$(DS_PLATFORM_093)\Cinder\blocks\TUIO\src;$(DS_PLATFORM_093)\lib\poco\include;$(DS_PLATFORM_093)\src;$(DS_PLATFORM_093)\src\gtk;$(DS_PLATFORM_093)\src\gtk\cairo;$(DS_PLATFORM_093)\src\gtk\pango-1.0;$(DS_PLATFORM_093)\src\gtk\glib-2.0;$(DS_PLATFORM_093)\lib\snappy;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>


### PR DESCRIPTION
I have no idea if this is a good idea or not, but something I ran across when messing with the Microsoft Surface Dial for project Monolith was that the microsoft tools wouldn't work when the platform tools preprocessor definitions enforced the win32 to be for windows 8.

Maybe it will break everything? 

https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170