### PR TITLE
Add redistributable v140 and install it alongside app & bridgesync

### DIFF
--- a/install/base_install.iss
+++ b/install/base_install.iss
@@ -77,7 +77,7 @@ Source: "/downsync/*"; DestDir: "{app}/downsync/"; Flags: recursesubdirs
 
 #ifdef USE_BRIDGESYNC
 Source: "/bridgesync/*"; DestDir: "{app}/bridgesync/"; Flags: recursesubdirs
-Source: "{#DS_PLATFORM}/install/msvcr140.dll"; DestDir: "{app}/bridgesync/"
+Source: "{#DS_PLATFORM}/install/msvcp140.dll"; DestDir: "{app}/bridgesync/"
 #endif
 
 #ifexist "README.md"
@@ -90,7 +90,7 @@ Source: "install/readme.txt"; DestDir: "{app}/release_notes.txt"; Flags: isreadm
 
 Source: "{#DS_PLATFORM}/install/msvcr100.dll"; DestDir: "{app}"
 Source: "{#DS_PLATFORM}/install/msvcr120.dll"; DestDir: "{app}"
-Source: "{#DS_PLATFORM}/install/msvcr140.dll"; DestDir: "{app}"
+Source: "{#DS_PLATFORM}/install/msvcp140.dll"; DestDir: "{app}"
 ;Source: "{#DS_PLATFORM}/.git/HEAD"; DestDir: "{app}/data"; DestName: "ds_cinder_commit.txt"
 
 #ifdef USE_GSTREAMER

--- a/install/base_install.iss
+++ b/install/base_install.iss
@@ -77,6 +77,7 @@ Source: "/downsync/*"; DestDir: "{app}/downsync/"; Flags: recursesubdirs
 
 #ifdef USE_BRIDGESYNC
 Source: "/bridgesync/*"; DestDir: "{app}/bridgesync/"; Flags: recursesubdirs
+Source: "{#DS_PLATFORM}/install/msvcr140.dll"; DestDir: "{app}/bridgesync/"
 #endif
 
 #ifexist "README.md"
@@ -89,6 +90,7 @@ Source: "install/readme.txt"; DestDir: "{app}/release_notes.txt"; Flags: isreadm
 
 Source: "{#DS_PLATFORM}/install/msvcr100.dll"; DestDir: "{app}"
 Source: "{#DS_PLATFORM}/install/msvcr120.dll"; DestDir: "{app}"
+Source: "{#DS_PLATFORM}/install/msvcr140.dll"; DestDir: "{app}"
 ;Source: "{#DS_PLATFORM}/.git/HEAD"; DestDir: "{app}/data"; DestName: "ds_cinder_commit.txt"
 
 #ifdef USE_GSTREAMER

--- a/install/msvcp140.dll
+++ b/install/msvcp140.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4c2229bdc2a2a630acdc095b4d86008e5c3e3bc7773174354f3da4f5beb9cde
+size 575056


### PR DESCRIPTION
This should remove the need for installing the redist package for each production machine and fixes the bridgesync crash seen in production