### PR TITLE
NVIDIA Path Rendering as a separate project

### DIFF
--- a/projects/nvpath/PropertySheets/NvPath64.props
+++ b/projects/nvpath/PropertySheets/NvPath64.props
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DS_PLATFORM_093)\projects\nvpath\src</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);nvpath.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);$(DS_PLATFORM_093)\projects\nvpath\lib64</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>

--- a/projects/nvpath/PropertySheets/NvPath64_d.props
+++ b/projects/nvpath/PropertySheets/NvPath64_d.props
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DS_PLATFORM_093)\projects\nvpath\src</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>%(AdditionalDependencies);nvpath_d.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);$(DS_PLATFORM_093)\projects\nvpath\lib64</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>

--- a/projects/nvpath/nvpath.vcxproj
+++ b/projects/nvpath/nvpath.vcxproj
@@ -1,0 +1,314 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="DummyWeb_Debug|x64">
+      <Configuration>DummyWeb_Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="DummyWeb_Release_Debug_Info|x64">
+      <Configuration>DummyWeb_Release_Debug_Info</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release_Debug_Info|x64">
+      <Configuration>Release_Debug_Info</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="DummyWeb_Release|x64">
+      <Configuration>DummyWeb_Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\stdafx.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="src\nvpath\NvPath.cpp" />
+    <ClCompile Include="src\nvpath\NvPathSvg.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\stdafx.h" />
+    <ClInclude Include="src\cy\cyCore.h" />
+    <ClInclude Include="src\cy\cyPolynomial.h" />
+    <ClInclude Include="src\nvpath\NvPath.h" />
+    <ClInclude Include="src\nvpath\NvPathSvg.h" />
+    <ClInclude Include="src\nvpath\NvPathUtil.h" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{FA76A6D1-7D68-4871-A791-7CBA0E98A93E}</ProjectGuid>
+    <RootNamespace>BasicTweenApp</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Release|x64'" Label="Configuration">
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Debug|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Release_Debug_Info|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Release_Debug_Info|x64'">
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(DS_PLATFORM_093)\vs2015\PropertySheets\Platform64.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(DS_PLATFORM_093)\vs2015\PropertySheets\Platform64.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release_Debug_Info|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(DS_PLATFORM_093)\vs2015\PropertySheets\Platform64.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Release_Debug_Info|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(DS_PLATFORM_093)\vs2015\PropertySheets\Platform64.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(DS_PLATFORM_093)\vs2015\PropertySheets\Platform64_d.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(DS_PLATFORM_093)\vs2015\PropertySheets\Platform64_d.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">lib64\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Debug|x64'">lib64\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">lib64\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Release|x64'">lib64\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release_Debug_Info|x64'">lib64\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Release_Debug_Info|x64'">lib64\</OutDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Debug|x64'">true</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Release|x64'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release_Debug_Info|x64'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Release_Debug_Info|x64'">false</LinkIncremental>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectName)_d</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Debug|x64'">$(ProjectName)_d</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Release|x64'">$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release_Debug_Info|x64'">$(ProjectName)</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Release_Debug_Info|x64'">$(ProjectName)</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;lib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;NOMINMAX;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
+      <AdditionalOptions>/Zm256 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>$(DS_PLATFORM_093)\Cinder\include;..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>cinder_d.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+      <IgnoreSpecificDefaultLibraries>LIBCMT</IgnoreSpecificDefaultLibraries>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;lib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;NOMINMAX;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
+      <MinimalRebuild>false</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <ForcedIncludeFiles>
+      </ForcedIncludeFiles>
+      <AdditionalOptions>/Zm256 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>$(DS_PLATFORM_093)\Cinder\include;..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>cinder.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;lib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/Zm256 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>cinder.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateMapFile>false</GenerateMapFile>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>
+      </EnableCOMDATFolding>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;lib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/Zm256 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>cinder.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateMapFile>false</GenerateMapFile>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>
+      </EnableCOMDATFolding>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_Debug_Info|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;lib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/Zm256 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>cinder.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateMapFile>false</GenerateMapFile>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>
+      </EnableCOMDATFolding>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DummyWeb_Release_Debug_Info|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;lib</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions);NOMINMAX</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/Zm256 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <ProjectReference>
+      <LinkLibraryDependencies>true</LinkLibraryDependencies>
+    </ProjectReference>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalDependencies>cinder.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateMapFile>false</GenerateMapFile>
+      <SubSystem>Windows</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>
+      </EnableCOMDATFolding>
+      <RandomizedBaseAddress>false</RandomizedBaseAddress>
+      <DataExecutionPrevention>
+      </DataExecutionPrevention>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/projects/nvpath/nvpath.vcxproj.filters
+++ b/projects/nvpath/nvpath.vcxproj.filters
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="src">
+      <UniqueIdentifier>{2b08b134-7635-4eab-8a25-0c1580e926be}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\nvpath">
+      <UniqueIdentifier>{c65bbd42-9cc4-424a-b958-e76a8163b170}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="src\cy">
+      <UniqueIdentifier>{63e3086e-b4ba-4616-b7c2-dbe4d8c25668}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\stdafx.cpp" />
+    <ClCompile Include="src\nvpath\NvPath.cpp">
+      <Filter>src\nvpath</Filter>
+    </ClCompile>
+    <ClCompile Include="src\nvpath\NvPathSvg.cpp">
+      <Filter>src\nvpath</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\src\stdafx.h" />
+    <ClInclude Include="src\nvpath\NvPath.h">
+      <Filter>src\nvpath</Filter>
+    </ClInclude>
+    <ClInclude Include="src\nvpath\NvPathSvg.h">
+      <Filter>src\nvpath</Filter>
+    </ClInclude>
+    <ClInclude Include="src\nvpath\NvPathUtil.h">
+      <Filter>src\nvpath</Filter>
+    </ClInclude>
+    <ClInclude Include="src\cy\cyCore.h">
+      <Filter>src\cy</Filter>
+    </ClInclude>
+    <ClInclude Include="src\cy\cyPolynomial.h">
+      <Filter>src\cy</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/projects/nvpath/src/cy/LICENSE.txt
+++ b/projects/nvpath/src/cy/LICENSE.txt
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2016, Cem Yuksel <cem@cemyuksel.com>
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/projects/nvpath/src/cy/cyCore.h
+++ b/projects/nvpath/src/cy/cyCore.h
@@ -1,0 +1,389 @@
+// cyCodeBase by Cem Yuksel
+// [www.cemyuksel.com]
+//-------------------------------------------------------------------------------
+//! \file   cyCore.h 
+//! \author Cem Yuksel
+//! 
+//! \brief  Core functions and macros
+//! 
+//! Core functions and macros for math and other common operations
+//! 
+//-------------------------------------------------------------------------------
+//
+// Copyright (c) 2016, Cem Yuksel <cem@cemyuksel.com>
+// All rights reserved.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy 
+// of this software and associated documentation files (the "Software"), to deal 
+// in the Software without restriction, including without limitation the rights 
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+// copies of the Software, and to permit persons to whom the Software is 
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+// SOFTWARE.
+// 
+//-------------------------------------------------------------------------------
+
+#ifndef _CY_CORE_H_INCLUDED_
+#define _CY_CORE_H_INCLUDED_
+
+//-------------------------------------------------------------------------------
+
+#ifndef _CY_CORE_MEMCPY_LIMIT
+#define _CY_CORE_MEMCPY_LIMIT 256
+#endif
+
+//-------------------------------------------------------------------------------
+
+#include <cstdlib>
+#include <cstring>
+#include <cstdint>
+#include <cassert>
+#include <cmath>
+#include <type_traits>
+#include <limits>
+
+#if !defined(CY_NO_INTRIN_H) && !defined(CY_NO_EMMINTRIN_H) && !defined(CY_NO_IMMINTRIN_H)
+# include <immintrin.h>
+#endif
+
+//-------------------------------------------------------------------------------
+namespace cy {
+//-------------------------------------------------------------------------------
+//////////////////////////////////////////////////////////////////////////
+// Compiler compatibility
+//////////////////////////////////////////////////////////////////////////
+
+#if defined(__INTEL_COMPILER)
+# define _CY_COMPILER_INTEL __INTEL_COMPILER
+# define _CY_COMPILER_VER_MEETS(msc,gcc,clang,intel) _CY_COMPILER_INTEL >= intel
+# define _CY_COMPILER_VER_BELOW(msc,gcc,clang,intel) _CY_COMPILER_INTEL <  intel
+#elif defined(__clang__)
+# define _CY_COMPILER_CLANG (__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__)
+# define _CY_COMPILER_VER_MEETS(msc,gcc,clang,intel) _CY_COMPILER_CLANG >= clang
+# define _CY_COMPILER_VER_BELOW(msc,gcc,clang,intel) _CY_COMPILER_CLANG <  clang
+#elif defined(_MSC_VER)
+# define _CY_COMPILER_MSC _MSC_VER
+# define _CY_COMPILER_VER_MEETS(msc,gcc,clang,intel) _CY_COMPILER_MSC >= msc
+# define _CY_COMPILER_VER_BELOW(msc,gcc,clang,intel) _CY_COMPILER_MSC <  msc
+#elif __GNUC__
+# define _CY_COMPILER_GCC (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+# define _CY_COMPILER_VER_MEETS(msc,gcc,clang,intel) _CY_COMPILER_GCC >= gcc
+# define _CY_COMPILER_VER_BELOW(msc,gcc,clang,intel) _CY_COMPILER_GCC <  gcc
+#else
+# define _CY_COMPILER_UNKNOWN
+# define _CY_COMPILER_VER_MEETS(msc,gcc,clang,intel) false
+# define _CY_COMPILER_VER_BELOW(msc,gcc,clang,intel) false
+#endif
+
+// constexpr
+#ifndef __cpp_constexpr
+# if _CY_COMPILER_VER_MEETS(1900,40600,30100,1310)
+#  define __cpp_constexpr
+# else
+#  define constexpr
+# endif
+#endif
+
+// nullptr
+#if _CY_COMPILER_VER_BELOW(1600,40600,20900,1210)
+class _cy_nullptr_t {
+public:
+  template<class T> operator T*() const { return 0; }
+  template<class C, class T> operator T C::*() const { return 0; }
+private:
+  void operator & () const {}
+};
+static _cy_nullptr_t nullptr;
+#endif
+
+// template aliases
+#define _CY_TEMPLATE_ALIAS_UNPACK(...) __VA_ARGS__
+#if _CY_COMPILER_VER_BELOW(1800,40700,30000,1210)
+# define _CY_TEMPLATE_ALIAS(template_name,template_equivalent) class template_name : public _CY_TEMPLATE_ALIAS_UNPACK template_equivalent {}
+#else
+# define _CY_TEMPLATE_ALIAS(template_name,template_equivalent) using template_name = _CY_TEMPLATE_ALIAS_UNPACK template_equivalent
+#endif
+
+// std::is_trivially_copyable
+#if _CY_COMPILER_VER_MEETS(1700,50000,30400,1300)
+# define _cy_std_is_trivially_copyable 1
+#endif
+
+// restrict
+#if defined(__INTEL_COMPILER)
+//# define restrict restrict
+#elif defined(__clang__)
+# define restrict __restrict__
+#elif defined(_MSC_VER)
+# define restrict __restrict
+#elif __GNUC__
+# define restrict __restrict__
+#else
+# define restrict
+#endif
+
+// alignment
+#if _CY_COMPILER_VER_BELOW(1900,40800,30000,1500)
+# if defined(_MSC_VER)
+#  define alignas(alignment_size) __declspec(align(alignment_size))
+# else
+#  define alignas(alignment_size) __attribute__((aligned(alignment_size)))
+# endif
+#endif
+
+// final, override
+#if _CY_COMPILER_VER_BELOW(1700,40700,20900,1210)
+# define override
+# if defined(_MSC_VER)
+#  define final sealed
+# else
+#  define final
+# endif
+#endif
+
+// static_assert
+#if _CY_COMPILER_VER_BELOW(1900,60000,20500,1800)
+# define static_assert(condition,message) assert(condition && message)
+#endif
+
+// unrestricted unions
+#ifndef __cpp_unrestricted_unions
+# if _CY_COMPILER_VER_MEETS(1900,40600,30000,1400)
+#  define __cpp_unrestricted_unions
+# endif
+#endif
+
+// nodiscard
+//#if _CY_COMPILER_VER_MEETS(1901,40800,30000,1500)
+#if (__cplusplus>=201703L) || (defined(_MSVC_LANG) && _MSVC_LANG>=201703L)
+# define CY_NODISCARD [[nodiscard]]
+#else
+# define CY_NODISCARD
+#endif
+
+// default and deleted class member functions
+#if _CY_COMPILER_VER_MEETS(1800,40400,30000,1200)
+# define CY_CLASS_FUNCTION_DEFAULT = default;
+# define CY_CLASS_FUNCTION_DELETE  = delete;
+#else
+# define CY_CLASS_FUNCTION_DEFAULT {}
+# define CY_CLASS_FUNCTION_DELETE  { static_assert(false,"Calling deleted method."); }
+#endif
+
+// switch statements where default cannot be reached
+#if defined(__INTEL_COMPILER) || defined(__clang__) || defined(__GNUC__)
+# define nodefault default: __builtin_unreachable()
+#elif defined(_MSC_VER)
+# define nodefault default: __assume(0)
+#else
+# define nodefault default: 
+#endif
+
+//////////////////////////////////////////////////////////////////////////
+// Auto Vectorization
+//////////////////////////////////////////////////////////////////////////
+
+#ifdef _MSC_VER
+# if _MSC_VER >= 1700
+#  define _CY_IVDEP __pragma(loop(ivdep))
+# endif
+#elif defined __GNUC__
+# if _CY_GCC_VER >= 40900
+#  define _CY_IVDEP _Pragma("GCC ivdep");
+# endif
+#elif defined __clang__
+# if _CY_CLANG_VER >= 30500
+#  define _CY_IVDEP _Pragma("clang loop vectorize(enable) interleave(enable)");
+# endif
+#else
+//# define _CY_IVDEP _Pragma("ivdep");
+# define _CY_IVDEP
+#endif
+
+#ifndef _CY_IVDEP
+# define _CY_IVDEP
+#endif
+
+#define _CY_IVDEP_FOR _CY_IVDEP for
+
+//////////////////////////////////////////////////////////////////////////
+// Disabling MSVC's non-standard depreciation warnings
+//////////////////////////////////////////////////////////////////////////
+
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
+# define _CY_CRT_SECURE_NO_WARNINGS     __pragma( warning(push) ) __pragma( warning(disable:4996) )
+# define _CY_CRT_SECURE_RESUME_WARNINGS __pragma( warning(pop)  )
+#else
+# define _CY_CRT_SECURE_NO_WARNINGS
+# define _CY_CRT_SECURE_RESUME_WARNINGS
+#endif
+
+//////////////////////////////////////////////////////////////////////////
+// Math functions
+//////////////////////////////////////////////////////////////////////////
+
+//!@name Common math function templates
+
+template <typename T> CY_NODISCARD inline T Max      ( T v1, T v2 ) { return v1 >= v2 ? v1 : v2; }
+template <typename T> CY_NODISCARD inline T Min      ( T v1, T v2 ) { return v1 <= v2 ? v1 : v2; }
+template <typename T> CY_NODISCARD inline T Max      ( T v1, T v2, T v3 ) { return Max( Max(v1,v2), v3 ); }
+template <typename T> CY_NODISCARD inline T Min      ( T v1, T v2, T v3 ) { return Min( Min(v1,v2), v3 ); }
+template <typename T> CY_NODISCARD inline T Max      ( T v1, T v2, T v3, T const v4 ) { return Max( Max(v1,v2), Max(v3,v4) ); }
+template <typename T> CY_NODISCARD inline T Min      ( T v1, T v2, T v3, T const v4 ) { return Min( Min(v1,v2), Min(v3,v4) ); }
+template <typename T> CY_NODISCARD inline T Clamp    ( T v, T minVal=T(0), T maxVal=T(1) ) { return Min(maxVal,Max(minVal,v)); }
+
+template <typename T> CY_NODISCARD inline T ACosSafe ( T v ) { return (T) std::acos(Clamp(v,T(-1),T(1))); }
+template <typename T> CY_NODISCARD inline T ASinSafe ( T v ) { return (T) std::asin(Clamp(v,T(-1),T(1))); }
+template <typename T> CY_NODISCARD inline T Sqrt     ( T v ) { return (T) std::sqrt(v); }
+template <typename T> CY_NODISCARD inline T SqrtSafe ( T v ) { return (T) std::sqrt(Max(v,T(0))); }
+
+#ifdef _INCLUDED_IMM
+template<> CY_NODISCARD inline float  Sqrt    <float> ( float  v ) { return _mm_cvtss_f32(_mm_sqrt_ss(_mm_set_ps1(v))); }
+template<> CY_NODISCARD inline float  SqrtSafe<float> ( float  v ) { return _mm_cvtss_f32(_mm_sqrt_ss(_mm_set_ps1(Max(v,0.0f)))); }
+template<> CY_NODISCARD inline double Sqrt    <double>( double v ) { __m128d t=_mm_set1_pd(v);          return _mm_cvtsd_f64(_mm_sqrt_sd(t,t)); }
+template<> CY_NODISCARD inline double SqrtSafe<double>( double v ) { __m128d t=_mm_set1_pd(Max(v,0.0)); return _mm_cvtsd_f64(_mm_sqrt_sd(t,t)); }
+#endif
+
+template<typename T> constexpr inline T Pi() { return T(3.141592653589793238462643383279502884197169); }
+
+template <typename T> CY_NODISCARD inline bool IsFinite( T v ) { return std::numeric_limits<T>::is_integer || std::isfinite(v); }
+
+//////////////////////////////////////////////////////////////////////////
+// Memory Operations
+//////////////////////////////////////////////////////////////////////////
+
+template <typename T>
+inline void MemCopy( T * restrict dest, T const * restrict src, size_t count )
+{
+#ifdef _cy_std_is_trivially_copyable
+	if ( std::is_trivially_copyable<T>() ) {
+		memcpy( dest, src, (count)*sizeof(T) );
+	} else 
+#endif
+		for ( size_t i=0; i<count; ++i ) dest[i] = src[i];
+}
+
+template <typename T, typename S>
+inline void MemConvert( T * restrict dest, S const * restrict src, size_t count )
+{
+	for ( size_t i=0; i<count; ++i ) dest[i] = reinterpret_cast<T>(src[i]);
+}
+
+template <typename T>
+inline void MemClear( T * dest, size_t count )
+{
+	memset( dest, 0, count*sizeof(T) );
+}
+
+template <typename T> inline void SwapBytes( T &v1, T &v2 ) { char t[sizeof(T)]; memcpy(&t,&v1,sizeof(T)); memcpy(&v1,&v2,sizeof(T)); memcpy(&v2,&t,sizeof(T)); }
+template <typename T> inline void Swap     ( T &v1, T &v2 ) { if ( std::is_trivially_copyable<T>::value ) { T t=v1; v1=v2; v2=t; } else SwapBytes(v1,v2); }
+
+/////////////////////////////////////////////////////////////////////////////////
+// Sorting functions
+/////////////////////////////////////////////////////////////////////////////////
+
+template <bool ascending, typename T>
+inline void Sort2( T &r0, T &r1, T const &v0, T const &v1 )
+{
+	if ( ascending ) {
+		r0 = Min( v0, v1 );
+		r1 = Max( v0, v1 );
+	} else {
+		r0 = Max( v0, v1 );
+		r1 = Min( v0, v1 );
+	}
+}
+
+template <bool ascending, typename T>
+inline void Sort2( T r[2], T const v[2] )
+{
+	r[1-ascending] = Min( v[0], v[1] );
+	r[  ascending] = Max( v[0], v[1] );
+}
+
+template <bool ascending, typename T>
+void Sort3( T &r0, T &r1, T &r2, T const &v0, T const &v1, T const &v2 )
+{
+	T n01   = Min( v0,  v1    );
+	T x01   = Max( v0,  v1    );
+	T n2x01 = Min( v2,  x01   );
+	r1      = Max( n01, n2x01 );
+	if ( ascending ) {
+		r0  = Min( n2x01, n01 );
+		r2  = Max( x01,   v2  );
+	} else {
+		r0  = Max( x01,   v2  );
+		r2  = Min( n2x01, n01 );
+	}
+}
+
+template <bool ascending, typename T>
+void Sort3( T r[3], T const v[3] )
+{
+	T n01   = Min( v[0], v[1] );
+	T x01   = Max( v[0], v[1] );
+	T n2x01 = Min( v[2], x01  );
+	T r0    = Min( n2x01, n01 );
+	T r1    = Max( n01, n2x01 );
+	T r2    = Max( x01,  v[2] );
+	if ( ascending ) { r[0]=r0; r[1]=r1; r[2]=r2; }
+	else             { r[0]=r2; r[1]=r1; r[2]=r0; }
+}
+
+template <bool ascending, typename T>
+inline void Sort4( T &r0, T &r1, T &r2, T &r3, T const &v0, T const &v1, T const &v2, T const &v3 )
+{
+	T n01  = Min( v0,  v1  );
+	T x01  = Max( v0,  v1  );
+	T n23  = Min( v2,  v3  );
+	T x23  = Max( v2,  v3  );
+	T x02  = Max( n23, n01 );
+	T n13  = Min( x01, x23 );
+	if ( ascending ) {
+		r0 = Min( n01, n23 );
+		r1 = Min( x02, n13 );
+		r2 = Max( n13, x02 );
+		r3 = Max( x23, x01 );
+	} else {
+		r0 = Max( x23, x01 );
+		r1 = Max( n13, x02 );
+		r2 = Min( x02, n13 );
+		r3 = Min( n01, n23 );
+	}
+}
+
+template <bool ascending, typename T>
+inline void Sort4( T r[4], T const v[4] )
+{
+	T n01 = Min( v[0], v[1] );
+	T x01 = Max( v[0], v[1] );
+	T n23 = Min( v[2], v[3] );
+	T x23 = Max( v[2], v[3] );
+	T x02 = Max( n23, n01 );
+	T n13 = Min( x01, x23 );
+	T r0  = Min( n01, n23 );
+	T r1  = Min( x02, n13 );
+	T r2  = Max( n13, x02 );
+	T r3  = Max( x23, x01 );
+	if ( ascending ) { r[0]=r0; r[1]=r1; r[2]=r2; r[3]=r3; }
+	else             { r[0]=r3; r[1]=r2; r[2]=r1; r[3]=r0; }
+}
+
+//////////////////////////////////////////////////////////////////////////
+
+//-------------------------------------------------------------------------------
+} // namespace cy
+//-------------------------------------------------------------------------------
+
+#endif
+

--- a/projects/nvpath/src/cy/cyPolynomial.h
+++ b/projects/nvpath/src/cy/cyPolynomial.h
@@ -1,0 +1,1513 @@
+// cyCodeBase by Cem Yuksel
+// [www.cemyuksel.com]
+//-------------------------------------------------------------------------------
+//! \file   cyPolynomial.h 
+//! \author Cem Yuksel
+//! 
+//! \brief  Polynomial operations and solver class and functions.
+//!
+//! This file includes the implementation of the numerical polynomial solver
+//! described in
+//! 
+//! Cem Yuksel. 2022. High-Performance Polynomial Root Finding for Graphics.
+//! Proc. ACM Comput. Graph. Interact. Tech. 5, 3, Article 7 (July 2022), 15 pages.
+//! 
+//! http://www.cemyuksel.com/?x=polynomials
+//! 
+//! The polynomial functions take an array of polynomial coefficients in the
+//! order of increasing degrees.
+//! 
+//-------------------------------------------------------------------------------
+//
+// Copyright (c) 2022, Cem Yuksel <cem@cemyuksel.com>
+// All rights reserved.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy 
+// of this software and associated documentation files (the "Software"), to deal 
+// in the Software without restriction, including without limitation the rights 
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+// copies of the Software, and to permit persons to whom the Software is 
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all 
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+// SOFTWARE.
+// 
+//-------------------------------------------------------------------------------
+
+#ifndef _CY_POLYNOMIAL_H_INCLUDED_
+#define _CY_POLYNOMIAL_H_INCLUDED_
+
+//-------------------------------------------------------------------------------
+
+#include "cyCore.h"
+
+//-------------------------------------------------------------------------------
+namespace cy {
+//-------------------------------------------------------------------------------
+/////////////////////////////////////////////////////////////////////////////////
+//
+//! @name General Polynomial Functions
+//!
+//! These functions can be used for evaluating polynomials and their derivatives,
+//! computing their derivatives, deflating them, and inflating them.
+//! 
+/////////////////////////////////////////////////////////////////////////////////
+//-------------------------------------------------------------------------------
+
+//! Evaluates the given polynomial of degree `N` at `x`.
+//! 
+//! The coefficients in the `coef` array must be in the order of increasing degrees.
+template <int N, typename ftype>
+inline ftype PolynomialEval( ftype const coef[N+1], ftype x ) { ftype r = coef[N]; for ( int i=N-1; i>=0; --i ) r = r*x + coef[i]; return r; }
+
+//-------------------------------------------------------------------------------
+
+//! Evaluates the given polynomial and its derivative at `x`.
+//! 
+//! This function does not require computing the derivative of the polynomial,
+//! but it is slower than evaluating the polynomial and its precomputed derivative separately.
+//! Therefore, it is not recommended when the polynomial and it derivative are computed repeatedly.
+//! The coefficients in the `coef` array must be in the order of increasing degrees.
+template <int N, typename ftype>
+inline ftype PolynomialEvalWithDeriv( ftype &derivativeValue, ftype const coef[N+1], ftype x )
+{
+	if constexpr ( N < 1 ) { derivativeValue = 0; return coef[0]; }
+	else {
+		ftype  p = coef[N]*x + coef[N-1];
+		ftype dp = coef[N];
+		for ( int i=N-2; i>=0; --i ) {
+			dp = dp*x + p;
+			p  =  p*x + coef[i];
+		}
+		derivativeValue = dp;
+		return p;
+	}
+}
+
+//-------------------------------------------------------------------------------
+
+//! Computes the polynomial's derivative and sets the coefficients of the `deriv` array.
+//! 
+//! Note that a degree N polynomial's derivative is degree `N-1` and has `N` coefficients.
+//! The coefficients are in the order of increasing degrees.
+template <int N, typename ftype>
+inline void PolynomialDerivative( ftype deriv[N], ftype const coef[N+1] ) { deriv[0] = coef[1]; for ( int i=2; i<=N; ++i ) deriv[i-1] = i * coef[i]; }
+
+//-------------------------------------------------------------------------------
+
+//! Deflates the given polynomial using one of its known roots.
+//! 
+//! Stores the coefficients of the deflated polynomial in the `defPoly` array.
+//! Let f(x) represent the given polynomial.
+//! This computes the deflated polynomial g(x) of a lower degree such that
+//! 
+//! `f(x) = (x - root) * g(x)`.
+//! 
+//! The given root must be a valid root of the given polynomial.
+//! Note that the deflated polynomial has degree `N-1` with `N` coefficients.
+//! The coefficients are in the order of increasing degrees.
+template <int N, typename ftype> inline void PolynomialDeflate( ftype defPoly[N], ftype const coef[N+1], ftype root )
+{
+	defPoly[N-1] = coef[N];
+	for ( int i=N-1; i> 0; --i ) defPoly[i-1] = coef[i] + root*defPoly[i];
+}
+
+//-------------------------------------------------------------------------------
+
+//! Inflates the given polynomial using the given root.
+//! 
+//! Stores the coefficients of the inflated polynomial in the `infPoly` array.
+//! Let f(x) represent the given polynomial.
+//! This computes the inflated polynomial g(x) of a higher degree such that
+//! 
+//! `g(x) = (x - root) * f(x)`.
+//! 
+//! Note that the inflated polynomial has degree `N+1` with `N+2` coefficients.
+//! The coefficients are in the order of increasing degrees.
+template <int N, typename ftype> inline void PolynomialInflate( ftype infPoly[N+2], ftype const coef[N+1], ftype root )
+{
+	infPoly[N+1] = coef[N];
+	for ( int i=N-1; i>=0; --i ) infPoly[i+1] = coef[i] - root*infPoly[i+1];
+	infPoly[0] = -root*coef[0];
+}
+
+//-------------------------------------------------------------------------------
+/////////////////////////////////////////////////////////////////////////////////
+//!@{
+//! 
+//! @name Polynomial Root Finding Functions
+//!
+//! These functions find polynomial roots.
+//! They can be limited to a finite bounds between `xMin` and `xMax`.
+//! Functions for degree 3 and higher polynomials use numerical root finding.
+//! By default, they use Newton iterations defined in `RootFinderNewton` as their
+//! numerical root finding method, but they can also be used with a custom class
+//! that provides the same interface.
+//! 
+//! The given `xError` parameter is passed on to the numerical root finder.
+//! The default value is 0, which aims to find the root up to numerical precision.
+//! This might be too slow. Therefore, for a high-performance implementation,
+//! it is recommended to use a non-zero error threshold for `xError`.
+//! 
+//! If `boundError` is false (the default value), `RootFinderNewton` does not
+//! guarantee satisfying the error bound `xError`, but it almost always does.
+//! Keeping `boundError` false is recommended for improved performance.
+//! 
+/////////////////////////////////////////////////////////////////////////////////
+//-------------------------------------------------------------------------------
+
+template <typename ftype> constexpr ftype  PolynomialDefaultError        () { return ftype(0); }
+template <>               constexpr float  PolynomialDefaultError<float >() { return 6e-4f; }
+template <>               constexpr double PolynomialDefaultError<double>() { return 6e-7; }
+
+//-------------------------------------------------------------------------------
+
+class RootFinderNewton;
+
+#define _CY_POLY_TEMPLATE_N  template <int N, typename ftype, bool boundError=false, typename RootFinder=RootFinderNewton> CY_NODISCARD inline
+#define _CY_POLY_TEMPLATE_R  template <       typename ftype, bool boundError=false, typename RootFinder=RootFinderNewton> CY_NODISCARD inline
+#define _CY_POLY_TEMPLATE_A  template <       typename ftype                                                             > CY_NODISCARD inline
+#define _CY_POLY_TEMPLATE_D  template <       typename ftype                                                             >              inline
+
+#define _CY_POLY_TEMPLATE_NC template <int N, typename ftype, bool boundError=false, typename RootFinder=RootFinderNewton, typename RootCallback> inline
+#define _CY_POLY_TEMPLATE_RC template <       typename ftype, bool boundError=false, typename RootFinder=RootFinderNewton, typename RootCallback> inline
+#define _CY_POLY_TEMPLATE_AC template <       typename ftype,                                                              typename RootCallback> inline
+
+//-------------------------------------------------------------------------------
+
+//! Finds the roots of the given polynomial between `xMin` and `xMax` and returns the number of roots found.
+_CY_POLY_TEMPLATE_N int PolynomialRoots( ftype roots[N], ftype const coef[N+1], ftype xMin, ftype xMax, ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_R int CubicRoots     ( ftype roots[3], ftype const coef[4],   ftype xMin, ftype xMax, ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_A int QuadraticRoots ( ftype roots[2], ftype const coef[3],   ftype xMin, ftype xMax  );
+_CY_POLY_TEMPLATE_D int LinearRoot     ( ftype &root,    ftype const coef[2],   ftype xMin, ftype xMax  );
+
+//-------------------------------------------------------------------------------
+
+//! Finds the roots of the given polynomial and returns the number of roots found.
+_CY_POLY_TEMPLATE_N int PolynomialRoots   ( ftype roots[N], ftype const coef[N+1], ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_R int CubicRoots        ( ftype roots[3], ftype const coef[4],   ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_A int QuadraticRoots    ( ftype roots[2], ftype const coef[3] );
+_CY_POLY_TEMPLATE_D int LinearRoot        ( ftype &root,    ftype const coef[2] );
+
+//-------------------------------------------------------------------------------
+
+//! Finds the first root of the given polynomial between `xMin` and `xMax` and returns true if a root is found.
+_CY_POLY_TEMPLATE_N bool PolynomialFirstRoot( ftype &root, ftype const coef[N+1], ftype xMin, ftype xMax, ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_R bool CubicFirstRoot     ( ftype &root, ftype const coef[4],   ftype xMin, ftype xMax, ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_A bool QuadraticFirstRoot ( ftype &root, ftype const coef[3],   ftype xMin, ftype xMax );
+
+//-------------------------------------------------------------------------------
+
+//! Finds the first root of the given polynomial and returns true if a root is found.
+_CY_POLY_TEMPLATE_N bool PolynomialFirstRoot( ftype &root, ftype const coef[N+1], ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_R bool CubicFirstRoot     ( ftype &root, ftype const coef[4],   ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_A bool QuadraticFirstRoot ( ftype &root, ftype const coef[3] );
+
+//-------------------------------------------------------------------------------
+
+//! Returns true if the given polynomial has a root between `xMin` and `xMax`.
+_CY_POLY_TEMPLATE_N bool PolynomialHasRoot( ftype const coef[N+1], ftype xMin, ftype xMax, ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_A bool CubicHasRoot     ( ftype const coef[4],   ftype xMin, ftype xMax );
+_CY_POLY_TEMPLATE_A bool QuadraticHasRoot ( ftype const coef[3],   ftype xMin, ftype xMax );
+
+//-------------------------------------------------------------------------------
+
+//! Returns true if the given polynomial has a root.
+_CY_POLY_TEMPLATE_N bool PolynomialHasRoot( ftype const coef[N+1], ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_A bool CubicHasRoot     ( ftype const coef[4] ) { return true; }
+_CY_POLY_TEMPLATE_A bool QuadraticHasRoot ( ftype const coef[3] ) { return coef[1]*coef[1] - ftype(4)*coef[0]*coef[2] >= 0; }
+
+//-------------------------------------------------------------------------------
+
+//! Calls the given `callback` function for each root of the given polynomial between `xMin` and `xMax` in increasing order.
+//! The `callback` function should have the following form:
+//! 
+//! `bool RootCallback( ftype root );`
+//!
+//! If the `callback` function returns true, root finding is terminated without finding any additional roots.
+//! If the `callback` function returns false, root finding continues.
+//! Returns true if root finding is terminated by the `callback` function. Otherwise, returns false.
+_CY_POLY_TEMPLATE_NC bool PolynomialForEachRoot( RootCallback callback, ftype const coef[N+1], ftype xMin, ftype xMax, ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_RC bool CubicForEachRoot     ( RootCallback callback, ftype const coef[4],   ftype xMin, ftype xMax, ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_AC bool QuadraticForEachRoot ( RootCallback callback, ftype const coef[3],   ftype xMin, ftype xMax );
+
+//-------------------------------------------------------------------------------
+
+//! Calls the given `callback` function for each root of the given polynomial in increasing order.
+//! The `callback` function should have the following form:
+//! 
+//! `bool RootCallback( ftype root );`
+//!
+//! If the `callback` function returns true, root finding is terminated without finding any additional roots.
+//! If the `callback` function returns false, root finding continues.
+//! Returns true if root finding is terminated by the `callback` function. Otherwise, returns false.
+_CY_POLY_TEMPLATE_NC bool PolynomialForEachRoot( RootCallback callback, ftype const coef[N+1], ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_RC bool CubicForEachRoot     ( RootCallback callback, ftype const coef[4],   ftype xError=PolynomialDefaultError<ftype>() );
+_CY_POLY_TEMPLATE_AC bool QuadraticForEachRoot ( RootCallback callback, ftype const coef[3] );
+
+//-------------------------------------------------------------------------------
+//!@}
+//-------------------------------------------------------------------------------
+
+#define _CY_POLY_TEMPLATE_B  template <bool boundError=false> CY_NODISCARD
+#define _CY_POLY_TEMPLATE_BC template <bool boundError=false, typename RootCallback>
+
+//-------------------------------------------------------------------------------
+/////////////////////////////////////////////////////////////////////////////////
+//!
+//! A general-purpose polynomial class.
+//!
+//! This class can be used for easily generating and manipulating polynomials.
+//! It also offers interfaces to the polynomial evaluation and root finding functions.
+//! 
+/////////////////////////////////////////////////////////////////////////////////
+template < typename ftype, int N>
+class Polynomial
+{
+public:
+	ftype coef[N+1];	//!< The coefficients of the polynomial.
+
+	CY_NODISCARD ftype const & operator [] ( int   i ) const { return coef[i]; }	//!< Access to the coefficients of the polynomial
+	CY_NODISCARD ftype       & operator [] ( int   i )       { return coef[i]; }	//!< Access to the coefficients of the polynomial
+	CY_NODISCARD ftype         operator () ( ftype x ) const { return Eval(x); }	//!< Evaluates the polynomial at the given `x` value.
+
+	CY_NODISCARD ftype Eval         (               ftype x ) const { return PolynomialEval         <N,ftype>(        coef, x ); }	//!< Evaluates the polynomial at `x`.
+	CY_NODISCARD ftype EvalWithDeriv( ftype &deriv, ftype x ) const { return PolynomialEvalWithDeriv<N,ftype>( deriv, coef, x ); }	//!< Evaluates the polynomial and its derivative at `x`.
+
+	CY_NODISCARD Polynomial<ftype,N> operator + ( Polynomial<ftype,N> const &p ) const { Polynomial<ftype,N> r; for ( int i=0; i<=N; ++i ) r[i] = coef[i] + p[i]; return r; }	//!< Adds two polynomials.
+	CY_NODISCARD Polynomial<ftype,N> operator - ( Polynomial<ftype,N> const &p ) const { Polynomial<ftype,N> r; for ( int i=0; i<=N; ++i ) r[i] = coef[i] - p[i]; return r; }	//!< Subtracts two polynomials.
+	CY_NODISCARD Polynomial<ftype,N> operator * ( ftype s )                      const { Polynomial<ftype,N> r; for ( int i=0; i<=N; ++i ) r[i] = coef[i] * s;    return r; }	//!< Multiplies the polynomial with a scalar.
+	void operator += ( Polynomial<ftype,N> const &p ) { for ( int i=0; i<=N; ++i ) coef[i] += p[i]; }	//!< Adds another polynomial to this one.
+	void operator -= ( Polynomial<ftype,N> const &p ) { for ( int i=0; i<=N; ++i ) coef[i] -= p[i]; }	//!< Subtracts another polynomial from this one.
+	void operator *= ( ftype s )                      { for ( int i=0; i<=N; ++i ) coef[i] *= s; }		//!< Multiplies this polynomial with a scalar.
+
+	//! Multiplies two polynomials and returns the resulting polynomial.
+	template <int M> Polynomial<ftype,N+M> operator * ( Polynomial<ftype,M> const &p ) const
+	{
+		Polynomial<ftype,N+M> r;
+		for ( int i=0; i<=N+M; ++i ) r[i] = ftype(0);
+		for ( int i=0; i<=N; ++i ) {
+			for ( int j=0; j<=M; ++j ) {
+				r[i+j] += coef[i] * p[j];
+			}
+		}
+		return r;
+	}
+
+	//! Multiplies the polynomial with itself and returns the resulting polynomial.
+	CY_NODISCARD Polynomial<ftype,2*N> Squared() const
+	{
+		Polynomial<ftype,2*N> r;
+		for ( int i=0; i<=2*N; ++i ) r[i] = ftype(0);
+		for ( int i=0; i<=N; ++i ) {
+			r[2*i] += coef[i] * coef[i];
+			for ( int j=i+1; j<=N; ++j ) {
+				r[i+j] += 2 * coef[i] * coef[j];
+			}
+		}
+		return r;
+	}
+
+	CY_NODISCARD Polynomial<ftype,N-1> Derivative()          const { Polynomial<ftype,N-1> d; PolynomialDerivative<N,ftype>(d.coef,coef     ); return d; }	//!< Returns the derivative of the polynomial.
+	CY_NODISCARD Polynomial<ftype,N-1> Deflate( ftype root ) const { Polynomial<ftype,N-1> p; PolynomialDeflate   <N,ftype>(p.coef,coef,root); return p; }	//!< Returns the deflation of the polynomial with the given root.
+	CY_NODISCARD Polynomial<ftype,N+1> Inflate( ftype root ) const { Polynomial<ftype,N+1> p; PolynomialInflate   <N,ftype>(p.coef,coef,root); return p; }	//!< Returns the inflated polynomial using the given root.
+
+	_CY_POLY_TEMPLATE_B  int  Roots      ( ftype roots[N], ftype xError=DefaultError() ) const { return PolynomialRoots      <N,ftype,boundError>(roots,coef,xError); }	//!< Finds all roots of the polynomial and returns the number of roots found.
+	_CY_POLY_TEMPLATE_B  bool FirstRoot  ( ftype &root,    ftype xError=DefaultError() ) const { return PolynomialFirstRoot  <N,ftype,boundError>(root, coef,xError); }	//!< Finds the first root of the polynomial and returns true if a root is found.
+	_CY_POLY_TEMPLATE_B  bool HasRoot    (                 ftype xError=DefaultError() ) const { return PolynomialHasRoot    <N,ftype,boundError>(      coef,xError); }	//!< Returns true if the polynomial has a root.
+	_CY_POLY_TEMPLATE_BC void ForEachRoot( RootCallback c, ftype xError=DefaultError() ) const { return PolynomialForEachRoot<N,ftype,boundError>(c,    coef,xError); }	//!< Calls the given callback function for each root of the polynomial.
+
+	_CY_POLY_TEMPLATE_B  int  Roots      ( ftype roots[N], ftype xMin, ftype xMax, ftype xError=DefaultError() ) const { return PolynomialRoots      <N,ftype,boundError>(roots,coef,xMin,xMax,xError); }	//!< Finds all roots of the polynomial between `xMin` and `xMax` and returns the number of roots found.
+	_CY_POLY_TEMPLATE_B  bool FirstRoot  ( ftype &root,    ftype xMin, ftype xMax, ftype xError=DefaultError() ) const { return PolynomialFirstRoot  <N,ftype,boundError>(root, coef,xMin,xMax,xError); }	//!< Finds the first root of the polynomial between `xMin` and `xMax` and returns true if a root is found.
+	_CY_POLY_TEMPLATE_B  bool HasRoot    (                 ftype xMin, ftype xMax, ftype xError=DefaultError() ) const { return PolynomialHasRoot    <N,ftype,boundError>(      coef,xMin,xMax,xError); }	//!< Returns true if the polynomial has a root between `xMin` and `xMax`.
+	_CY_POLY_TEMPLATE_BC void ForEachRoot( RootCallback c, ftype xMin, ftype xMax, ftype xError=DefaultError() ) const { return PolynomialForEachRoot<N,ftype,boundError>(c,    coef,xMin,xMax,xError); }	//!< Calls the given callback function for each root of the polynomial between `xMin` and `xMax`.
+
+	CY_NODISCARD bool IsFinite() const { for ( int i=0; i<=N; ++i ) if ( ! cy::IsFinite(coef[i]) ) return false; return true; }	//!< Returns true if all coefficients are finite real numbers.
+
+protected:
+	static constexpr ftype DefaultError() { return PolynomialDefaultError<ftype>(); }	//!< Returns the default error threshold for numerical root finding.
+};
+
+//-------------------------------------------------------------------------------
+/////////////////////////////////////////////////////////////////////////////////
+//! @name Support Functions (Internal)
+/////////////////////////////////////////////////////////////////////////////////
+//-------------------------------------------------------------------------------
+
+template <typename T, typename S> inline T    MultSign       ( T v, S sign ) { return v * (sign<0 ? T(-1) : T(1)); }	//!< Multiplies the given value with the given sign
+template <typename T, typename S> inline bool IsDifferentSign( T a, S b )    { return a<0 != b<0; }						//!< Returns true if the sign bits are different
+
+//-------------------------------------------------------------------------------
+/////////////////////////////////////////////////////////////////////////////////
+//! @name RootFinderNewton
+/////////////////////////////////////////////////////////////////////////////////
+//-------------------------------------------------------------------------------
+
+//! Numerical root finder using safe Newton iterations.
+//!
+//! This is the default numerical root finder used by the polynomial root finding functions.
+//! The methods of this class are called after a single root is isolated within a closed
+//! (finite) or open (infinite) interval.
+//! It performs a combination of Newton iterations and bisection to ensure convergence
+//! and achieve high-performance.
+class RootFinderNewton
+{
+public:
+	template <int N, typename ftype, bool boundError=false> static inline ftype FindClosed ( ftype const coef[N+1], ftype const deriv[N], ftype x0, ftype x1, ftype y0, ftype y1, ftype xError );	//!< @private Finds the single root within a closed interval between `x0` and `x1`.
+	template <int N, typename ftype, bool boundError=false> static inline ftype FindOpen   ( ftype const coef[N+1], ftype const deriv[N],                                         ftype xError );	//!< @private Finds the single root in an infinite interval.
+	template <int N, typename ftype, bool boundError=false> static inline ftype FindOpenMin( ftype const coef[N+1], ftype const deriv[N],           ftype x1,           ftype y1, ftype xError );	//!< @private Finds the single root from negative infinity to the given x bound `x1`.
+	template <int N, typename ftype, bool boundError=false> static inline ftype FindOpenMax( ftype const coef[N+1], ftype const deriv[N], ftype x0,           ftype y0,           ftype xError );	//!< @private Finds the single root from the given x bound `x0` to positive infinity.
+protected:
+	template <int N, typename ftype, bool boundError, bool openMin>
+	static inline ftype FindOpen( ftype const coef[N+1], ftype const deriv[N], ftype xs, ftype ys, ftype xr, ftype xError );	//!< @private The implementation of FindOpenMin and FindOpenMax
+};
+
+//-------------------------------------------------------------------------------
+
+//! Finds the single root within a closed interval between `x0` and `x1`.
+//!
+//! It combines Newton iterations with bisection to ensure convergence.
+//! It takes a polynomial's coefficients `coef` and its derivative's coefficients `deriv` along with the x bounds `x0` and `x1`
+//! and the values of the polynomial `y0` and `y1` computed at `x0` and `x1` respectively.
+//! It almost always satisfies the given error bound `xError` but this is not guaranteed unless `boundError` is set to `true`.
+//! If `boundError` is `true`, it performs additional operations to bound the error.
+template <int N, typename ftype, bool boundError>
+inline ftype RootFinderNewton::FindClosed( ftype const coef[N+1], ftype const deriv[N], ftype x0, ftype x1, ftype y0, ftype y1, ftype xError )
+{
+	ftype ep2 = 2*xError;
+	ftype xr = (x0 + x1) / 2;	// mid point
+	if ( x1-x0 <= ep2 ) return xr;
+
+	if constexpr ( N <= 3 ) {
+		ftype xr0 = xr;
+		for ( int safetyCounter=0; safetyCounter<16; ++safetyCounter ) {
+			ftype xn = xr - PolynomialEval<N,ftype>( coef, xr ) / PolynomialEval<2,ftype>( deriv, xr );
+			xn = Clamp( xn, x0, x1 );
+			if ( std::abs(xr - xn) <= xError ) return xn;
+			xr = xn;
+		}
+		if ( ! IsFinite(xr) ) xr = xr0;
+	}
+
+	ftype yr = PolynomialEval<N,ftype>( coef, xr );
+	ftype xb0 = x0;
+	ftype xb1 = x1;
+
+	while ( true ) {
+		int side = IsDifferentSign( y0, yr );
+		if ( side ) xb1 = xr; else xb0 = xr;
+		ftype dy = PolynomialEval<N-1,ftype>( deriv, xr );
+		ftype dx = yr / dy;
+		ftype xn = xr - dx;
+		if ( xn > xb0 && xn < xb1 ) { // valid Newton step
+			ftype stepsize = std::abs(xr-xn);
+			xr = xn;
+			if ( stepsize > xError ) {
+				yr = PolynomialEval<N,ftype>( coef, xr );
+			} else {
+				if constexpr ( boundError ) {
+					ftype xs;
+					if ( xError == 0 ) {
+						xs = std::nextafter( side?xb1:xb0, side?xb0:xb1 );
+					} else {
+						xs = xn - MultSign( xError, side-1 );
+						if ( xs == xn ) xs = std::nextafter( side?xb1:xb0, side?xb0:xb1 );
+					}
+					ftype ys = PolynomialEval<N,ftype>( coef, xs );
+					int s = IsDifferentSign( y0, ys );
+					if ( side != s ) return xn;
+					xr = xs;
+					yr = ys;
+				} else break;
+			}
+		} else { // Newton step failed
+			xr = (xb0 + xb1) / 2;
+			if ( xr == xb0 || xr == xb1 || xb1 - xb0 <= ep2 ) {
+				if constexpr ( boundError ) {
+					if ( xError == 0 ) {
+						ftype xm = side ? xb0 : xb1;
+						ftype ym = PolynomialEval<N,ftype>( coef, xm );
+						if ( std::abs(ym) < std::abs(yr) ) xr = xm;
+					}
+				}
+				break;
+			}
+			yr = PolynomialEval<N,ftype>( coef, xr );
+		}
+	}
+	return xr;
+}
+
+//-------------------------------------------------------------------------------
+
+//! Finds the single root in an infinite interval.
+//!
+//! This is intended for root finding in an open interval for polynomials with odd degrees.
+//! Polynomials with odd degrees always have at least one real root.
+//! If that is the only root, this function can be used to find it.
+template <int N, typename ftype, bool boundError>
+inline ftype RootFinderNewton::FindOpen( ftype const coef[N+1], ftype const deriv[N], ftype xError )
+{
+	static_assert( (N & 1) == 1, "RootFinderNewton::FindOpen only works for polynomials with odd degrees.");
+	const ftype xr = 0;
+	const ftype yr = coef[0]; // PolynomialEval<N,ftype>( coef, xr );
+	if ( IsDifferentSign(coef[N],yr) ) {
+		return FindOpenMax<N,ftype,boundError>( coef, deriv, xr, yr, xError );
+	} else {
+		return FindOpenMin<N,ftype,boundError>( coef, deriv, xr, yr, xError );
+	}
+}
+
+//-------------------------------------------------------------------------------
+
+//! Finds the single root from negative infinity to the given x bound `x1`.
+template <int N, typename ftype, bool boundError>
+inline ftype RootFinderNewton::FindOpenMin( ftype const coef[N+1], ftype const deriv[N], ftype x1, ftype y1, ftype xError )
+{
+	return FindOpen<N,ftype,boundError,true>( coef, deriv, x1, y1, x1 - ftype(1), xError );
+}
+
+//-------------------------------------------------------------------------------
+
+//! Finds the single root from the given x bound `x0` to positive infinity.
+template <int N, typename ftype, bool boundError>
+inline ftype RootFinderNewton::FindOpenMax( ftype const coef[N+1], ftype const deriv[N], ftype x0, ftype y0, ftype xError )
+{
+	return FindOpen<N,ftype,boundError,false>( coef, deriv, x0, y0, x0 + ftype(1), xError );
+}
+
+//-------------------------------------------------------------------------------
+
+//! @private The implementation of FindOpenMin and FindOpenMax
+template <int N, typename ftype, bool boundError, bool openMin>
+inline ftype RootFinderNewton::FindOpen( ftype const coef[N+1], ftype const deriv[N], ftype xm, ftype ym, ftype xr, ftype xError )
+{
+	ftype delta = ftype(1);
+	ftype yr = PolynomialEval<N,ftype>( coef, xr );
+
+	bool otherside = IsDifferentSign( ym, yr );
+
+	while ( yr != 0 ) {
+		if ( otherside ) {
+			if constexpr ( openMin ) {
+				return FindClosed<N,ftype,boundError>( coef, deriv, xr, xm, yr, ym, xError );
+			} else {
+				return FindClosed<N,ftype,boundError>( coef, deriv, xm, xr, ym, yr, xError );
+			}
+		} else {
+		open_interval:
+			xm = xr;
+			ym = yr;
+			ftype dy = PolynomialEval<N-1,ftype>( deriv, xr );
+			ftype dx = yr / dy;
+			ftype xn = xr - dx;
+			ftype dif = openMin ? xr-xn : xn-xr;
+			if ( dif <= 0 && std::isfinite(xn) ) {	// valid Newton step
+				xr = xn;
+				if ( dif <= xError ) { // we might have converged
+					if ( xr == xm ) break;
+					ftype xs = xn - MultSign( xError, -ftype(openMin) );
+					ftype ys = PolynomialEval<N,ftype>( coef, xs );
+					bool s = IsDifferentSign( ym, ys );
+					if ( s ) break;
+					xr = xs;
+					yr = ys;
+					goto open_interval;
+				}
+			} else {	// Newton step failed
+				xr = openMin ? xr - delta : xr + delta;
+				delta *= 2;
+			}
+			yr = PolynomialEval<N,ftype>( coef, xr );
+			otherside = IsDifferentSign( ym, yr );
+		}
+	}
+	return xr;
+}
+
+//-------------------------------------------------------------------------------
+/////////////////////////////////////////////////////////////////////////////////
+// Implementations of the root finding functions declared above
+/////////////////////////////////////////////////////////////////////////////////
+//-------------------------------------------------------------------------------
+
+//-------------------------------------------------------------------------------
+// Linear
+//-------------------------------------------------------------------------------
+
+template <typename ftype>
+inline int LinearRoot( ftype &root, ftype const coef[2], ftype x0, ftype x1 )
+{
+	if ( coef[1] != ftype(0) ) {
+		ftype r = -coef[0]/coef[1];
+		root = r;
+		return ( r >= x0 && r <= x1 );
+	} else {
+		root = (x0 + x1) / 2;
+		return coef[0] == 0;
+	}
+}
+
+template <typename ftype>
+inline int LinearRoot( ftype &root, ftype const coef[2] ) { root = -coef[0]/coef[1]; return coef[1]!=0; }
+
+//-------------------------------------------------------------------------------
+// Quadratics
+//-------------------------------------------------------------------------------
+
+template <typename ftype>
+inline int QuadraticRoots( ftype roots[2], ftype const coef[3] )
+{
+	const ftype c = coef[0];
+	const ftype b = coef[1];
+	const ftype a = coef[2];
+	const ftype delta = b*b - 4*a*c;
+	if ( delta > 0 ) {
+		const ftype d = Sqrt(delta);
+		const ftype q = ftype(-0.5) * ( b + MultSign(d,b) );
+		const ftype rv0 = q / a;
+		const ftype rv1 = c / q;
+		roots[0] = Min( rv0, rv1 );
+		roots[1] = Max( rv0, rv1 );
+		return 2;
+	} else if ( delta < 0 ) return 0;
+	roots[0] = ftype(-0.5) * b / a;
+	return a != 0;
+}
+
+template <typename ftype>
+inline int QuadraticRoots( ftype roots[2], ftype const coef[3], ftype x0, ftype x1 )
+{
+	const ftype c = coef[0];
+	const ftype b = coef[1];
+	const ftype a = coef[2];
+	const ftype delta = b*b - 4*a*c;
+	if ( delta > 0 ) {
+		const ftype d = Sqrt(delta);
+		const ftype q = ftype(-0.5) * ( b + MultSign(d,b) );
+		const ftype rv0 = q / a;
+		const ftype rv1 = c / q;
+		const ftype r0 = Min( rv0, rv1 );
+		const ftype r1 = Max( rv0, rv1 );
+		int r0i = ( r0 >= x0 ) & ( r0 <= x1 );
+		int r1i = ( r1 >= x0 ) & ( r1 <= x1 );
+		roots[ 0 ] = r0;
+		roots[r0i] = r1;
+		return r0i + r1i;
+	} else if ( delta < 0 ) return 0;
+	const ftype r0 = ftype(-0.5) * b / a;
+	roots[0] = r0;
+	return ( r0 >= x0 ) & ( r0 <= x1 );
+}
+
+//-------------------------------------------------------------------------------
+#ifdef _INCLUDED_IMM
+
+template <typename RootCallback>
+inline int QuadraticRoots( float roots[2], float const *coef, RootCallback callback )
+{
+	//__m128 _0abc    = _mm_set_ps( 0.0f, coef[2], coef[1], coef[0] );
+	__m128 _0abc    = _mm_load_ps(coef);
+	__m128 _02a2b2c = _mm_add_ps( _0abc, _0abc );
+	__m128 _2a2c_bb = _mm_shuffle_ps( _0abc, _02a2b2c, _MM_SHUFFLE(2,0,1,1) );
+	__m128 _2c2a_bb = _mm_shuffle_ps( _0abc, _02a2b2c, _MM_SHUFFLE(0,2,1,1) );
+	__m128 _4ac_b2  = _mm_mul_ps( _2a2c_bb, _2c2a_bb );
+	__m128 _4ac     = _mm_shuffle_ps( _4ac_b2, _4ac_b2, _MM_SHUFFLE(2,2,2,2) );
+	if ( _mm_comigt_ss( _4ac_b2, _4ac ) ) {
+		__m128 delta  = _mm_sub_ps( _4ac_b2, _4ac );
+		__m128 sqrtd  = _mm_sqrt_ss(delta);
+		__m128 signb  = _mm_set_ps(-0.0f,-0.0f,-0.0f,-0.0f);
+		__m128 db     = _mm_xor_ps( sqrtd, _mm_and_ps( _2a2c_bb, signb ) );
+		__m128 b_db   = _mm_add_ss( _2a2c_bb, db );
+		__m128 _2q    = _mm_xor_ps( b_db, signb );
+		__m128 _2c_2q = _mm_shuffle_ps( _2q,   _02a2b2c, _MM_SHUFFLE(0,0,0,0) );
+		__m128 _2q_2a = _mm_shuffle_ps( _02a2b2c, _2q,   _MM_SHUFFLE(0,0,2,2) );
+		__m128 rv     = _mm_div_ps( _2c_2q, _2q_2a );
+		__m128 r0     = _mm_min_ps( rv, _mm_shuffle_ps( rv, rv, _MM_SHUFFLE(3,2,1,2) ) );
+		__m128 r      = _mm_max_ps( r0, _mm_shuffle_ps( r0, r0, _MM_SHUFFLE(3,2,2,0) ) );
+		return callback(r);
+	} else if ( _mm_comilt_ss( _4ac_b2, _4ac ) ) return 0;
+	__m128 r = _mm_div_ps( _2a2c_bb, _mm_shuffle_ps( _2a2c_bb, _2a2c_bb, _MM_SHUFFLE(1,0,3,3) ) );
+	return callback(r) * (coef[2]!=0);
+}
+
+
+template <>
+inline int QuadraticRoots<float>( float roots[2], float const *coef )
+{
+	return QuadraticRoots( roots, coef, [&](__m128 r){
+		roots[0] = _mm_cvtss_f32(r);
+		roots[1] = _mm_cvtss_f32( _mm_shuffle_ps(r,r,_MM_SHUFFLE(3,2,0,1)) );
+		return 2;
+	});
+}
+
+template <>
+inline int QuadraticRoots<float>( float roots[2], float const * coef, float x0, float x1 )
+{
+	return QuadraticRoots( roots, coef, [&](__m128 r){
+		__m128 range  = _mm_set_ps( x1, x1, x0, x0 );
+		__m128 minT   = _mm_cmpge_ps( r, range );
+		__m128 maxT   = _mm_cmple_ps( r, _mm_shuffle_ps( range, range, _MM_SHUFFLE(3,2,2,2) ) );
+		__m128 valid  = _mm_and_ps( minT, _mm_shuffle_ps( maxT, _mm_setzero_ps(), _MM_SHUFFLE(3,2,1,0) ) );
+		__m128 rr     = _mm_blendv_ps( _mm_shuffle_ps( r, r, _MM_SHUFFLE(3,2,0,1) ), r, valid );
+		roots[0] = _mm_cvtss_f32(rr);
+		roots[1] = _mm_cvtss_f32( _mm_shuffle_ps(rr,rr,_MM_SHUFFLE(3,2,0,1)) );
+		return _mm_popcnt_u32( _mm_movemask_ps(valid) );
+	});
+}
+
+#endif // _INCLUDED_IMM
+//-------------------------------------------------------------------------------
+
+template <typename ftype>
+inline bool QuadraticFirstRoot( ftype &root, ftype const coef[3], ftype x0, ftype x1 )
+{
+	const ftype c = coef[0];
+	const ftype b = coef[1];
+	const ftype a = coef[2];
+	const ftype delta = b*b - 4*a*c;
+	if ( delta >= 0 ) {
+		const ftype d = Sqrt(delta);
+		const ftype q = ftype(-0.5) * ( b + MultSign(d,b) );
+		const ftype rv0 = q / a;
+		const ftype rv1 = c / q;
+		const ftype r0 = Min( rv0, rv1 );
+		if ( r0 >= x0 ) {
+			root = r0;
+			return r0 <= x1;
+		} else {
+			const ftype r1 = Max( rv0, rv1 );
+			root = r1;
+			return ( r1 >= x0 ) & ( r1 <= x1 );
+		}
+	}
+	return false;
+}
+
+//-------------------------------------------------------------------------------
+
+template <typename ftype>
+inline bool QuadraticFirstRoot( ftype &root, ftype const coef[3] )
+{
+	const ftype c = coef[0];
+	const ftype b = coef[1];
+	const ftype a = coef[2];
+	const ftype delta = b*b - 4*a*c;
+	if ( delta >= 0 ) {
+		const ftype d = Sqrt(delta);
+		const ftype q = ftype(-0.5) * ( b + MultSign(d,b) );
+		const ftype rv0 = q / a;
+		const ftype rv1 = c / q;
+		root = Min( rv0, rv1 );
+		return true;
+	}
+	return false;
+}
+
+//-------------------------------------------------------------------------------
+
+template <typename ftype>
+inline bool QuadraticHasRoot( ftype const coef[3], ftype x0, ftype x1 )
+{
+	const ftype c = coef[0];
+	const ftype b = coef[1];
+	const ftype a = coef[2];
+	const ftype delta = b*b - 4*a*c;
+	if ( delta >= 0 ) {
+		const ftype d = Sqrt(delta);
+		const ftype q = ftype(-0.5) * ( b + MultSign(d,b) );
+		const ftype rv0 = q / a;
+		const ftype rv1 = c / q;
+		const ftype r0 = Min( rv0, rv1 );
+		const ftype r1 = Max( rv0, rv1 );
+		if ( r0 >= x0 && r0 <= x1 ) return true;
+		if ( r1 >= x0 && r1 <= x1 ) return true;
+	}
+	return false;
+}
+
+//-------------------------------------------------------------------------------
+
+template <typename ftype, typename RootCallback>
+inline bool QuadraticForEachRoot( RootCallback callback, ftype const coef[3], ftype x0, ftype x1 )
+{
+	const ftype c = coef[0];
+	const ftype b = coef[1];
+	const ftype a = coef[2];
+	const ftype delta = b*b - 4*a*c;
+	if ( delta >= 0 ) {
+		const ftype d = Sqrt(delta);
+		const ftype q = ftype(-0.5) * ( b + MultSign(d,b) );
+		const ftype rv0 = q / a;
+		const ftype rv1 = c / q;
+		const ftype r0 = Min( rv0, rv1 );
+		const ftype r1 = Max( rv0, rv1 );
+		if ( r0 >= x0 && r0 <= x1 ) if ( callback(r0) ) return true;
+		if ( r1 >= x0 && r1 <= x1 ) return callback(r1);
+	}
+	return false;
+}
+
+//-------------------------------------------------------------------------------
+
+template <typename ftype, typename RootCallback>
+inline bool QuadraticForEachRoot( RootCallback callback, ftype const coef[3] )
+{
+	const ftype c = coef[0];
+	const ftype b = coef[1];
+	const ftype a = coef[2];
+	const ftype delta = b*b - 4*a*c;
+	if ( delta >= 0 ) {
+		const ftype d = Sqrt(delta);
+		const ftype q = ftype(-0.5) * ( b + MultSign(d,b) );
+		const ftype rv0 = q / a;
+		const ftype rv1 = c / q;
+		const ftype r0 = Min( rv0, rv1 );
+		const ftype r1 = Max( rv0, rv1 );
+		if ( callback(r0) ) return true;
+		return callback(r1);
+	}
+	return false;
+}
+
+//-------------------------------------------------------------------------------
+// Cubics
+//-------------------------------------------------------------------------------
+
+template <typename ftype, bool boundError, typename RootFinder>
+inline int CubicRoots( ftype roots[3], ftype const coef[4], ftype x0, ftype x1, ftype xError )
+{
+	const ftype y0 = PolynomialEval<3,ftype>( coef, x0 );
+	const ftype y1 = PolynomialEval<3,ftype>( coef, x1 );
+
+	const ftype a   = coef[3]*3;
+	const ftype b_2 = coef[2];
+	const ftype c   = coef[1];
+
+	const ftype deriv[4] = { c, 2*b_2, a, 0 };
+
+	const ftype delta_4 = b_2*b_2 - a*c;
+
+	if ( delta_4 > 0 ) {
+		const ftype d_2 = Sqrt( delta_4 );
+		const ftype q = - ( b_2 + MultSign( d_2, b_2 ) );
+		ftype rv0 = q / a;
+		ftype rv1 = c / q;
+		const ftype xa = Min( rv0, rv1 );
+		const ftype xb = Max( rv0, rv1 );
+
+		if ( IsDifferentSign(y0,y1) ) {
+			if ( xa >= x1 || xb <= x0 || ( xa <= x0 && xb >= x1 ) ) {	// first, last, or middle interval only
+				roots[0] = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, x0, x1, y0, y1, xError );
+				return 1;
+			}
+		} else {
+			if ( ( xa >= x1 || xb <= x0 ) || ( xa <= x0 && xb >= x1 ) ) return 0;
+		}
+
+		int numRoots = 0;
+		if ( xa > x0 ) {
+			const ftype ya = PolynomialEval<3,ftype>( coef, xa );
+			if ( IsDifferentSign(y0,ya) ) {
+				roots[0] = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, x0, xa, y0, ya, xError );	// first interval
+				if constexpr ( !boundError ) {
+					if ( IsDifferentSign(ya,y1) || ( xb < x1 &&  IsDifferentSign( ya, PolynomialEval<3,ftype>(coef,xb) ) ) ) {
+						ftype defPoly[4];
+						PolynomialDeflate<3>( defPoly, coef, roots[0] );
+						return QuadraticRoots( roots+1, defPoly, xa, x1 ) + 1;
+					} else return 1;
+				} else numRoots++;
+			}
+			if ( xb < x1 ) {
+				const ftype yb = PolynomialEval<3,ftype>( coef, xb );
+				if ( IsDifferentSign(ya,yb) ) {
+					roots[ !boundError ? 0 : numRoots++ ] = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, xa, xb, ya, yb, xError );
+					if constexpr ( !boundError ) {
+						if ( IsDifferentSign(yb,y1) ) {
+							ftype defPoly[4];
+							PolynomialDeflate<3>( defPoly, coef, roots[0] );
+							return QuadraticRoots( roots+1, defPoly, xb, x1 ) + 1;
+						} else return 1;
+					}
+				}
+				if ( IsDifferentSign(yb,y1) ) {
+					roots[ !boundError ? 0 : numRoots++ ] = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, xb, x1, yb, y1, xError );	// last interval
+					if constexpr ( !boundError ) return 1;
+				}
+			} else {
+				if ( IsDifferentSign(ya,y1) ) {
+					roots[ !boundError ? 0 : numRoots++ ] = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, xa, x1, ya, y1, xError );
+					if ( !boundError ) return 1;
+				}
+			}
+		} else {
+			const ftype yb = PolynomialEval<3,ftype>( coef, xb );
+			if ( IsDifferentSign(y0,yb) ) {
+				roots[0] = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, x0, xb, y0, yb, xError );
+				if constexpr ( !boundError ) {
+					if ( IsDifferentSign(yb,y1) ) {
+						ftype defPoly[4];
+						PolynomialDeflate<3>( defPoly, coef, roots[0] );
+						return QuadraticRoots( roots+1, defPoly, xb, x1 ) + 1;
+					} else return 1;
+				}
+				else numRoots++;
+			}
+			if ( IsDifferentSign(yb,y1) ) {
+				roots[ !boundError ? 0 : numRoots++ ] = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, xb, x1, yb, y1, xError );	// last interval
+				if constexpr ( !boundError ) return 1;
+			}
+		}
+		return numRoots;
+
+	} else {
+		if ( IsDifferentSign(y0,y1) ) {
+			roots[0] = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, x0, x1, y0, y1, xError );
+			return 1;
+		}
+		return 0;
+	}
+}
+
+//-------------------------------------------------------------------------------
+
+template <typename ftype, bool boundError, typename RootFinder>
+inline int CubicRoots( ftype roots[3], ftype const coef[4], ftype xError )
+{
+	if ( coef[3] != 0 ) {
+		const ftype a   = coef[3]*3;
+		const ftype b_2 = coef[2];
+		const ftype c   = coef[1];
+
+		const ftype deriv[4] = { c, 2*b_2, a, 0 };
+
+		const ftype delta_4 = b_2*b_2 - a*c;
+
+		if ( delta_4 > 0 ) {
+			const ftype d_2 = Sqrt( delta_4 );
+			const ftype q = - ( b_2 + MultSign( d_2, b_2 ) );
+			const ftype rv0 = q / a;
+			const ftype rv1 = c / q;
+			const ftype xa = Min( rv0, rv1 );
+			const ftype xb = Max( rv0, rv1 );
+
+			const ftype ya = PolynomialEval<3,ftype>( coef, xa );
+			const ftype yb = PolynomialEval<3,ftype>( coef, xb );
+
+			if ( ! IsDifferentSign(coef[3],ya) ) {
+				roots[0] = RootFinder::template FindOpenMin<3,ftype,boundError>( coef, deriv, xa, ya, xError );
+				if constexpr ( !boundError ) {
+					if ( IsDifferentSign(ya,yb) ) {
+						ftype defPoly[4];
+						PolynomialDeflate<3>( defPoly, coef, roots[0] );
+						return QuadraticRoots( roots+1, defPoly ) + 1;
+					}
+				} else {
+					if ( IsDifferentSign(ya,yb) ) {
+						roots[1] = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, xa, xb, ya, yb, xError );
+						roots[2] = RootFinder::template FindOpenMax<3,ftype,boundError>( coef, deriv, xb, yb, xError );
+						return 3;
+					}
+				}
+			} else {
+				roots[0] = RootFinder::template FindOpenMax<3,ftype,boundError>( coef, deriv, xb, yb, xError );
+			}
+			return 1;
+
+		} else {
+			ftype x_inf = - b_2 / a;
+			ftype y_inf = PolynomialEval<3,ftype>( coef, x_inf );
+			if ( IsDifferentSign(coef[3],y_inf) ) {
+				roots[0] = RootFinder::template FindOpenMax<3,ftype,boundError>( coef, deriv, x_inf, y_inf, xError );
+			} else {
+				roots[0] = RootFinder::template FindOpenMin<3,ftype,boundError>( coef, deriv, x_inf, y_inf, xError );
+			}
+			return 1;
+		}
+	} else return QuadraticRoots<ftype>( roots, coef );
+}
+
+//-------------------------------------------------------------------------------
+
+template <typename ftype, bool boundError, typename RootFinder>
+inline bool CubicFirstRoot( ftype &root, ftype const coef[4], ftype x0, ftype x1, ftype xError )
+{
+	const ftype y0 = PolynomialEval<3,ftype>( coef, x0 );
+	const ftype y1 = PolynomialEval<3,ftype>( coef, x1 );
+
+	const ftype a   = coef[3]*3;
+	const ftype b_2 = coef[2];
+	const ftype c   = coef[1];
+
+	const ftype deriv[4] = { c, 2*b_2, a, 0 };
+
+	const ftype delta_4 = b_2*b_2 - a*c;
+
+	if ( delta_4 > 0 ) {
+		const ftype d_2 = Sqrt( delta_4 );
+		const ftype q = - ( b_2 + MultSign( d_2, b_2 ) );
+		const ftype rv0 = q / a;
+		const ftype rv1 = c / q;
+		const ftype xa = Min( rv0, rv1 );
+		const ftype xb = Max( rv0, rv1 );
+
+		if ( IsDifferentSign(y0,y1) ) {
+			if ( xa >= x1 || xb <= x0 || ( xa <= x0 && xb >= x1 ) ) {	// first, last, or middle interval only
+				root = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, x0, x1, y0, y1, xError );	// first/last interval
+				return true;
+			}
+		} else {
+			if ( ( xa >= x1 || xb <= x0 ) || ( xa <= x0 && xb >= x1 ) ) return false;
+		}
+
+		if ( xa > x0 ) {
+			const ftype ya = PolynomialEval<3,ftype>( coef, xa );
+			if ( IsDifferentSign(y0,ya) ) {
+				root = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, x0, xa, y0, ya, xError );	// first interval
+				return true;
+			}
+			if ( xb < x1 ) {
+				const ftype yb = PolynomialEval<3,ftype>( coef, xb );
+				if ( IsDifferentSign(ya,yb) ) {
+					root = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, xa, xb, ya, yb, xError );
+					return true;
+				}
+				if ( IsDifferentSign(yb,y1) ) {
+					root = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, xb, x1, yb, y1, xError );	// last interval
+					return true;
+				}
+			} else {
+				if ( IsDifferentSign(ya,y1) ) {
+					root = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, xa, x1, ya, y1, xError );
+					return true;
+				}
+			}
+		} else {
+			const ftype yb = PolynomialEval<3,ftype>( coef, xb );
+			if ( IsDifferentSign(y0,yb) ) {
+				root = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, x0, xb, y0, yb, xError );
+				return true;
+			}
+			if ( IsDifferentSign(yb,y1) ) {
+				root = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, xb, x1, yb, y1, xError );	// last interval
+				return true;
+			}
+		}
+
+	} else {
+		if ( IsDifferentSign(y0,y1) ) {
+			root = RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, x0, x1, y0, y1, xError );
+			return true;
+		}
+	}
+	return false;
+}
+
+//-------------------------------------------------------------------------------
+
+template <typename ftype, bool boundError, typename RootFinder>
+inline bool CubicFirstRoot( ftype &root, ftype const coef[4], ftype xError )
+{
+	if ( coef[3] != 0 ) {
+		const ftype a   = coef[3]*3;
+		const ftype b_2 = coef[2];
+		const ftype c   = coef[1];
+
+		const ftype deriv[4] = { c, 2*b_2, a, 0 };
+
+		const ftype delta_4 = b_2*b_2 - a*c;
+
+		if ( delta_4 > 0 ) {
+			const ftype d_2 = Sqrt( delta_4 );
+			const ftype q = - ( b_2 + MultSign( d_2, b_2 ) );
+			const ftype rv0 = q / a;
+			const ftype rv1 = c / q;
+			const ftype xa = Min( rv0, rv1 );
+			const ftype xb = Max( rv0, rv1 );
+
+			const ftype ya = PolynomialEval<3,ftype>( coef, xa );
+			if ( ! IsDifferentSign(coef[3],ya) ) {
+				root = RootFinder::template FindOpenMin<3,ftype,boundError>( coef, deriv, xa, ya, xError );
+			} else {
+				const ftype yb = PolynomialEval<3,ftype>( coef, xb );
+				root = RootFinder::template FindOpenMax<3,ftype,boundError>( coef, deriv, xb, yb, xError );
+			}
+
+		} else {
+			ftype x_inf = - b_2 / a;
+			ftype y_inf = PolynomialEval<3,ftype>( coef, x_inf );
+			if ( IsDifferentSign(coef[3],y_inf) ) {
+				root = RootFinder::template FindOpenMax<3,ftype,boundError>( coef, deriv, x_inf, y_inf, xError );
+			} else {
+				root = RootFinder::template FindOpenMin<3,ftype,boundError>( coef, deriv, x_inf, y_inf, xError );
+			}
+		}
+		return true;
+	} else return QuadraticFirstRoot<ftype>( root, coef );
+}
+
+//-------------------------------------------------------------------------------
+
+template <typename ftype>
+inline bool CubicHasRoot( ftype const coef[4], ftype x0, ftype x1 )
+{
+	const ftype y0 = PolynomialEval<3,ftype>( coef, x0 );
+	const ftype y1 = PolynomialEval<3,ftype>( coef, x1 );
+	if ( IsDifferentSign(y0,y1) ) return true;
+
+	const ftype a   = coef[3]*3;
+	const ftype b_2 = coef[2];
+	const ftype c   = coef[1];
+
+	const ftype delta_4 = b_2*b_2 - a*c;
+
+	if ( delta_4 > 0 ) {
+		const ftype d_2 = Sqrt( delta_4 );
+		const ftype q = - ( b_2 + MultSign( d_2, b_2 ) );
+		const ftype rv0 = q / a;
+		const ftype rv1 = c / q;
+		const ftype xa = Min( rv0, rv1 );
+		const ftype xb = Max( rv0, rv1 );
+
+		if ( ( xa >= x1 || xb <= x0 ) || ( xa <= x0 && xb >= x1 ) ) return false;
+
+		if ( xa > x0 ) {
+			const ftype ya = PolynomialEval<3,ftype>( coef, xa );
+			if ( IsDifferentSign(y0,ya) ) return true;
+			if ( xb < x1 ) {
+				const ftype yb = PolynomialEval<3,ftype>( coef, xb );
+				if ( IsDifferentSign(y0,yb) ) return true;
+			}
+		} else {
+			const ftype yb = PolynomialEval<3,ftype>( coef, xb );
+			if ( IsDifferentSign(y0,yb) ) return true;
+		}
+	}
+	return false;
+}
+
+//-------------------------------------------------------------------------------
+
+template <typename ftype, bool boundError, typename RootFinder, typename RootCallback>
+inline bool CubicForEachRoot( RootCallback callback, ftype const coef[4], ftype x0, ftype x1, ftype xError )
+{
+	const ftype y0 = PolynomialEval<3,ftype>( coef, x0 );
+	const ftype y1 = PolynomialEval<3,ftype>( coef, x1 );
+
+	const ftype a   = coef[3]*3;
+	const ftype b_2 = coef[2];
+	const ftype c   = coef[1];
+
+	const ftype deriv[4] = { c, 2*b_2, a, 0 };
+
+	const ftype delta_4 = b_2*b_2 - a*c;
+
+	if ( delta_4 > 0 ) {
+		const ftype d_2 = Sqrt( delta_4 );
+		const ftype t = - ( b_2 + MultSign( d_2, b_2 ) );
+		const ftype rv0 = t / a;
+		const ftype rv1 = c / t;
+		const ftype xa = Min( rv0, rv1 );
+		const ftype xb = Max( rv0, rv1 );
+
+		if ( xa >= x1 || xb <= x0 ) {
+			if ( IsDifferentSign(y0,y1) ) {
+				if ( callback( RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, x0, x1, y0, y1, xError ) ) ) return true;	// first/last interval
+			}
+		} else if ( xa <= x0 && xb >= x1 ) {
+			if ( IsDifferentSign(y0,y1) ) {
+				if ( callback( RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, x0, x1, y0, y1, xError ) ) ) return true;
+			}
+		} else if ( xa > x0 ) {
+			const ftype ya = PolynomialEval<3,ftype>( coef, xa );
+			if ( IsDifferentSign(y0,ya) ) {
+				if ( callback( RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, x0, xa, y0, ya, xError ) ) ) return true;	// first interval
+			}
+			if ( xb < x1 ) {
+				const ftype yb = PolynomialEval<3,ftype>( coef, xb );
+				if ( IsDifferentSign(ya,yb) ) {
+					if ( callback( RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, xa, xb, ya, yb, xError ) ) ) return true;
+				}
+				if ( IsDifferentSign(yb,y1) ) {
+					if ( callback( RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, xb, x1, yb, y1, xError ) ) ) return true;	// last interval
+				}
+			} else {
+				if ( IsDifferentSign(ya,y1) ) {
+					if ( callback( RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, xa, x1, ya, y1, xError ) ) ) return true;
+				}
+			}
+		} else {
+			const ftype yb = PolynomialEval<3,ftype>( coef, xb );
+			if ( IsDifferentSign(y0,yb) ) {
+				if ( callback( RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, x0, xb, y0, yb, xError ) ) ) return true;
+			}
+			if ( IsDifferentSign(yb,y1) ) {
+				if ( callback( RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, xb, x1, yb, y1, xError ) ) ) return true;	// last interval
+			}
+		}
+
+	} else {
+		if ( IsDifferentSign(y0,y1) ) {
+			if ( callback( RootFinder::template FindClosed<3,ftype,boundError>( coef, deriv, x0, x1, y0, y1, xError ) ) ) return true;
+		}
+	}
+	return false;
+}
+
+//-------------------------------------------------------------------------------
+
+template <typename ftype, bool boundError, typename RootFinder, typename RootCallback>
+inline bool CubicForEachRoot( RootCallback callback, ftype const coef[4], ftype xError )
+{
+	if ( coef[3] != 0 ) {
+		const ftype a   = coef[3]*3;
+		const ftype b_2 = coef[2];
+		const ftype c   = coef[1];
+
+		const ftype deriv[4] = { c, 2*b_2, a, 0 };
+
+		const ftype delta_4 = b_2*b_2 - a*c;
+
+		if ( delta_4 > 0 ) {
+			const ftype d_2 = Sqrt( delta_4 );
+			const ftype q = - ( b_2 + MultSign( d_2, b_2 ) );
+			const ftype rv0 = q / a;
+			const ftype rv1 = c / q;
+			const ftype xa = Min( rv0, rv1 );
+			const ftype xb = Max( rv0, rv1 );
+
+			const ftype ya = PolynomialEval<3,ftype>( coef, xa );
+			const ftype yb = PolynomialEval<3,ftype>( coef, xb );
+
+			if ( ! IsDifferentSign(coef[3],ya) ) {
+				ftype root;
+				root = RootFinder::template FindOpenMin<3,ftype,boundError>( coef, deriv, xa, ya, xError );
+				if ( callback(root) ) return true;
+				if constexpr ( !boundError ) {
+					if ( IsDifferentSign(ya,yb) ) {
+						ftype defPoly[4];
+						PolynomialDeflate<3>( defPoly, coef, root );
+						return QuadraticForEachRoot( callback, defPoly );
+					}
+				} else {
+					if ( IsDifferentSign(ya,yb) ) {
+						if ( callback( RootFinder::template FindClosed <3,ftype,boundError>( coef, deriv, xa, xb, ya, yb, xError ) ) ) return true;
+						if ( callback( RootFinder::template FindOpenMax<3,ftype,boundError>( coef, deriv, xb, yb,         xError ) ) ) return true;
+						return false;
+					}
+				}
+			} else {
+				if ( callback( RootFinder::template FindOpenMax<3,ftype,boundError>( coef, deriv, xb, yb, xError ) ) ) return true;
+			}
+
+		} else {
+			ftype x_inf = - b_2 / a;
+			ftype y_inf = PolynomialEval<3,ftype>( coef, x_inf );
+			if ( IsDifferentSign(coef[3],y_inf) ) {
+				if ( callback( RootFinder::template FindOpenMax<3,ftype,boundError>( coef, deriv, x_inf, y_inf, xError ) ) ) return true;
+			} else {
+				if ( callback( RootFinder::template FindOpenMin<3,ftype,boundError>( coef, deriv, x_inf, y_inf, xError ) ) ) return true;
+			}
+		}
+		return false;
+	} else return QuadraticForEachRoot<ftype>( callback, coef );
+}
+
+//-------------------------------------------------------------------------------
+// Higher Order Polynomials
+//-------------------------------------------------------------------------------
+
+template <int N, typename ftype, bool boundError, typename RootFinder>
+inline int PolynomialRoots( ftype roots[N], ftype const coef[N+1], ftype x0, ftype x1, ftype xError )
+{
+	if      constexpr ( N == 1 ) return LinearRoot     <    ftype                      >( *roots, coef, x0, x1 );
+	else if constexpr ( N == 2 ) return QuadraticRoots <    ftype                      >(  roots, coef, x0, x1 );
+	else if constexpr ( N == 3 ) return CubicRoots     <    ftype,boundError,RootFinder>(  roots, coef, x0, x1, xError );
+	else if     ( coef[N] == 0 ) return PolynomialRoots<N-1,ftype,boundError,RootFinder>(  roots, coef, x0, x1, xError );
+	else {
+		ftype y0 = PolynomialEval<N,ftype>( coef, x0 );
+		ftype deriv[N];
+		PolynomialDerivative<N,ftype>( deriv, coef );
+		ftype derivRoots[N-1];
+		int nd = PolynomialRoots<N-1,ftype,boundError,RootFinder>( derivRoots, deriv, x0, x1, xError );
+		ftype x[N+1] = { x0 };
+		ftype y[N+1] = { y0 };
+		for ( int i=0; i<nd; ++i ) { x[i+1] = derivRoots[i]; y[i+1] = PolynomialEval<N,ftype>( coef, derivRoots[i] ); }
+		x[nd+1] = x1;
+		y[nd+1] = PolynomialEval<N,ftype>( coef, x1 );
+		int nr = 0;
+		for ( int i=0; i<=nd; ++i ) {
+			if ( IsDifferentSign(y[i],y[i+1]) ) {
+				roots[nr++] = RootFinder::template FindClosed<N,ftype,boundError>( coef, deriv, x[i], x[i+1], y[i], y[i+1], xError );
+			}
+		}
+		return nr;
+	}
+}
+
+//-------------------------------------------------------------------------------
+
+template <int N, typename ftype, bool boundError, typename RootFinder>
+inline int PolynomialRoots( ftype roots[N], ftype const coef[N+1], ftype xError )
+{
+	if      constexpr ( N == 1 ) return LinearRoot     <    ftype                      >( *roots, coef );
+	else if constexpr ( N == 2 ) return QuadraticRoots <    ftype                      >(  roots, coef );
+	else if constexpr ( N == 3 ) return CubicRoots     <    ftype,boundError,RootFinder>(  roots, coef, xError );
+	else if     ( coef[N] == 0 ) return PolynomialRoots<N-1,ftype,boundError,RootFinder>(  roots, coef, xError );
+	else {
+		ftype deriv[N];
+		PolynomialDerivative<N,ftype>( deriv, coef );
+		ftype derivRoots[N-1];
+		int nd = PolynomialRoots<N-1,ftype,boundError,RootFinder>( derivRoots, deriv, xError );
+		if ( (N & 1) || ( (N & 1) == 0 && nd > 0 ) ) {
+			int nr = 0;
+			ftype xa = derivRoots[0];
+			ftype ya = PolynomialEval<N,ftype>( coef, xa );
+			if ( IsDifferentSign(coef[N],ya) != (N & 1) ) {
+				roots[0] = RootFinder::template FindOpenMin<N,ftype,boundError>( coef, deriv, xa, ya, xError );
+				nr = 1;
+			}
+			for ( int i=1; i<nd; ++i ) {
+				ftype xb = derivRoots[i];
+				ftype yb = PolynomialEval<N,ftype>( coef, xb );
+				if ( IsDifferentSign(ya,yb) ) {
+					roots[nr++] = RootFinder::template FindClosed<N,ftype,boundError>( coef, deriv, xa, xb, ya, yb, xError );
+				}
+				xa = xb;
+				ya = yb;
+			}
+			if ( IsDifferentSign(coef[N],ya) ) {
+				roots[nr++] = RootFinder::template FindOpenMax<N,ftype,boundError>( coef, deriv, xa, ya, xError );
+			}
+			return nr;
+		} else {
+			if constexpr ( N & 1 ) {
+				roots[0] = RootFinder::template FindOpen<N,ftype,boundError>( coef, deriv, xError );
+				return 1;
+			} else return 0;	// this should not happen
+		}
+	}
+}
+
+//-------------------------------------------------------------------------------
+
+template <int N, typename ftype, bool boundError, typename RootFinder>
+inline bool PolynomialFirstRoot( ftype &root, ftype const coef[N+1], ftype x0, ftype x1, ftype xError )
+{
+	if      constexpr ( N == 1 ) return LinearRoot         <    ftype                      >( root, coef, x0, x1 );
+	if      constexpr ( N == 2 ) return QuadraticFirstRoot <    ftype                      >( root, coef, x0, x1 );
+	else if constexpr ( N == 3 ) return CubicFirstRoot     <    ftype,boundError,RootFinder>( root, coef, x0, x1, xError );
+	else if     ( coef[N] == 0 ) return PolynomialFirstRoot<N-1,ftype,boundError,RootFinder>( root, coef, x0, x1, xError );
+	else {
+		ftype y0 = PolynomialEval<N,ftype>( coef, x0 );
+		ftype deriv[N];
+		PolynomialDerivative<N,ftype>( deriv, coef );
+		bool done = PolynomialForEachRoot<N-1,ftype,boundError,RootFinder>( [&]( ftype xa ) {
+			ftype ya = PolynomialEval<N,ftype>( coef, xa );
+			if ( IsDifferentSign(y0,ya) ) {
+				root = RootFinder::template FindClosed<N,ftype,boundError>( coef, deriv, x0, xa, y0, ya, xError );
+				return true;
+			}
+			x0 = xa;
+			y0 = ya;
+			return false;
+		}, deriv, x0, x1, xError );
+		if ( done ) return true;
+		else {
+			ftype y1 = PolynomialEval<N,ftype>( coef, x1 );
+			if ( IsDifferentSign(y0,y1) ) {
+				root = RootFinder::template FindClosed<N,ftype,boundError>( coef, deriv, x0, x1, y0, y1, xError );
+				return true;
+			} else return false;
+		}
+	}
+}
+
+//-------------------------------------------------------------------------------
+
+template <int N, typename ftype, bool boundError, typename RootFinder>
+inline bool PolynomialFirstRoot( ftype &root, ftype const coef[N+1], ftype xError )
+{
+	if      constexpr ( N == 1 ) return LinearRoot         <    ftype                      >( root, coef );
+	if      constexpr ( N == 2 ) return QuadraticFirstRoot <    ftype                      >( root, coef );
+	else if constexpr ( N == 3 ) return CubicFirstRoot     <    ftype,boundError,RootFinder>( root, coef, xError );
+	else if     ( coef[N] == 0 ) return PolynomialFirstRoot<N-1,ftype,boundError,RootFinder>( root, coef, xError );
+	else {
+		ftype x0 = -std::numeric_limits<ftype>::infinity();
+		ftype y0 = ( ((N&1)==0) ^ (coef[N]<0) ) ? std::numeric_limits<ftype>::infinity() : -std::numeric_limits<ftype>::infinity();
+		bool firstInterval = true;
+		ftype deriv[N];
+		PolynomialDerivative<N,ftype>( deriv, coef );
+		bool done = PolynomialForEachRoot<N-1,ftype,boundError,RootFinder>( [&]( ftype xa ) {
+			ftype ya = PolynomialEval<N,ftype>( coef, xa );
+			if ( IsDifferentSign(y0,ya) ) {
+				if ( firstInterval ) {
+					root = RootFinder::template FindOpenMin<N,ftype,boundError>( coef, deriv,     xa,     ya, xError );
+				} else {
+					root = RootFinder::template FindClosed <N,ftype,boundError>( coef, deriv, x0, xa, y0, ya, xError );
+				}
+				return true;
+			}
+			firstInterval = false;
+			x0 = xa;
+			y0 = ya;
+			return false;
+		}, deriv, xError );
+		if ( done ) return true;
+		else {
+			if constexpr ( (N&1)==1 ) {
+				if ( firstInterval ) {
+					root = RootFinder::template FindOpen   <N,ftype,boundError>( coef, deriv,         xError );
+				} else {
+					root = RootFinder::template FindOpenMax<N,ftype,boundError>( coef, deriv, x0, y0, xError );
+				}
+				return true;
+			} else return false;
+		}
+	}
+}
+
+//-------------------------------------------------------------------------------
+
+template <int N, typename ftype, bool boundError, typename RootFinder>
+inline bool PolynomialHasRoot( ftype const coef[N+1], ftype x0, ftype x1, ftype xError )
+{
+	if      constexpr ( N == 2 ) return QuadraticHasRoot <    ftype>                      ( coef, x0, x1 );
+	else if constexpr ( N == 3 ) return CubicHasRoot     <    ftype>                      ( coef, x0, x1 );
+	else if     ( coef[N] == 0 ) return PolynomialHasRoot<N-1,ftype,boundError,RootFinder>( coef, x0, x1, xError );
+	else {
+		ftype y0 = PolynomialEval<N,ftype>( coef, x0 );
+		ftype y1 = PolynomialEval<N,ftype>( coef, x1 );
+		if ( IsDifferentSign(y0,y1) ) return true;
+		bool foundRoot = false;
+		ftype deriv[N];
+		PolynomialDerivative<N,ftype>( deriv, coef );
+		return PolynomialForEachRoot<N-1,ftype,boundError,RootFinder>( [&]( ftype xa ) {
+			ftype ya = PolynomialEval<N,ftype>( coef, xa );
+			return ( IsDifferentSign(y0,ya) );
+		}, deriv, x0, x1, xError );
+	}
+}
+
+//-------------------------------------------------------------------------------
+
+template <int N, typename ftype, bool boundError, typename RootFinder>
+inline bool PolynomialHasRoot( ftype const coef[N+1], ftype xError )
+{
+	if      constexpr ( N == 2 ) return QuadraticHasRoot<     ftype                      >( coef );
+	else if constexpr ( N == 3 ) return CubicHasRoot    <     ftype                      >( coef );
+	else if     ( coef[N] == 0 ) return PolynomialHasRoot<N-1,ftype,boundError,RootFinder>( coef );
+	else if constexpr ( (N&1) == 1 ) return true;
+	else {
+		ftype y0 = ( coef[N]<0 ) ? -std::numeric_limits<ftype>::infinity() : std::numeric_limits<ftype>::infinity();
+		ftype deriv[N];
+		PolynomialDerivative<N,ftype>( deriv, coef );
+		return PolynomialForEachRoot<N-1,ftype,boundError,RootFinder>( [&]( ftype xa ) {
+			ftype ya = PolynomialEval<N,ftype>( coef, xa );
+			if ( IsDifferentSign(y0,ya) ) return true;
+			return false;
+		}, deriv, xError );
+	}
+}
+
+//-------------------------------------------------------------------------------
+
+template <int N, typename ftype, bool boundError, typename RootFinder, typename RootCallback>
+inline bool PolynomialForEachRoot( RootCallback callback, ftype const coef[N+1], ftype x0, ftype x1, ftype xError )
+{
+	if      constexpr ( N == 2 ) return QuadraticForEachRoot <    ftype,                      RootCallback>( callback, coef, x0, x1         );
+	else if constexpr ( N == 3 ) return CubicForEachRoot     <    ftype,boundError,RootFinder,RootCallback>( callback, coef, x0, x1, xError );
+	else if     ( coef[N] == 0 ) return PolynomialForEachRoot<N-1,ftype,boundError,RootFinder,RootCallback>( callback, coef, x0, x1, xError );
+	else {
+		ftype y0 = PolynomialEval<N,ftype>( coef, x0 );
+		ftype deriv[N];
+		PolynomialDerivative<N,ftype>( deriv, coef );
+		bool done = PolynomialForEachRoot<N-1,ftype,boundError,RootFinder>( [&]( ftype xa ) {
+			ftype ya = PolynomialEval<N,ftype>( coef, xa );
+			if ( IsDifferentSign(y0,ya) ) {
+				ftype root;
+				root = RootFinder::template FindClosed<N,ftype,boundError>( coef, deriv, x0, xa, y0, ya, xError );
+				if ( callback(root) ) return true;
+			}
+			x0 = xa;
+			y0 = ya;
+			return false;
+		}, deriv, x0, x1, xError );
+		if ( done ) return true;
+		else {
+			ftype y1 = PolynomialEval<N,ftype>( coef, x1 );
+			if ( IsDifferentSign(y0,y1) ) {
+				return callback( RootFinder::template FindClosed<N,ftype,boundError>( coef, deriv, x0, x1, y0, y1, xError ) );
+			}
+			return false;
+		}
+	}
+}
+
+//-------------------------------------------------------------------------------
+
+template <int N, typename ftype, bool boundError, typename RootFinder, typename RootCallback>
+inline bool PolynomialForEachRoot( RootCallback callback, ftype const coef[N+1], ftype xError )
+{
+	if      constexpr ( N == 2 ) return QuadraticForEachRoot <    ftype,                      RootCallback>( callback, coef         );
+	else if constexpr ( N == 3 ) return CubicForEachRoot     <    ftype,boundError,RootFinder,RootCallback>( callback, coef, xError );
+	else if     ( coef[N] == 0 ) return PolynomialForEachRoot<N-1,ftype,boundError,RootFinder,RootCallback>( callback, coef, xError );
+	else {
+		ftype x0 = -std::numeric_limits<ftype>::infinity();
+		ftype y0 = ( ((N&1)==0) ^ (coef[N]<0) ) ? std::numeric_limits<ftype>::infinity() : -std::numeric_limits<ftype>::infinity();
+		bool firstInterval = true;
+		ftype deriv[N];
+		PolynomialDerivative<N,ftype>( deriv, coef );
+		bool done = PolynomialForEachRoot<N-1,ftype,boundError,RootFinder>( [&]( ftype xa ) {
+			ftype ya = PolynomialEval<N,ftype>( coef, xa );
+			if ( IsDifferentSign(y0,ya) ) {
+				ftype root;
+				if ( firstInterval ) {
+					root = RootFinder::template FindOpenMin<N,ftype,boundError>( coef, deriv,     xa,     ya, xError );
+				} else {
+					root = RootFinder::template FindClosed <N,ftype,boundError>( coef, deriv, x0, xa, y0, ya, xError );
+				}
+				if ( callback(root) ) return true;
+			}
+			firstInterval = false;
+			x0 = xa;
+			y0 = ya;
+			return false;
+		}, deriv, xError );
+		if ( done ) return true;
+		else {
+			if ( IsDifferentSign(y0,coef[N]) ) {
+				ftype root;
+				if constexpr ( (N&1)==1 ) {
+					if ( firstInterval ) {
+						root = RootFinder::template FindOpen   <N,ftype,boundError>( coef, deriv,         xError );
+					} else {
+						root = RootFinder::template FindOpenMax<N,ftype,boundError>( coef, deriv, x0, y0, xError );
+					}
+				} else {
+					root = RootFinder::template FindOpenMax<N,ftype,boundError>( coef, deriv, x0, y0, xError );
+				}
+				return callback(root);
+			}
+			return false;
+		}
+	}
+}
+
+//-------------------------------------------------------------------------------
+} // namespace cy
+//-------------------------------------------------------------------------------
+
+
+//-------------------------------------------------------------------------------
+
+#endif

--- a/projects/nvpath/src/nvpath/NvPath.cpp
+++ b/projects/nvpath/src/nvpath/NvPath.cpp
@@ -1,0 +1,2706 @@
+/*
+Copyright (c) 2023, Paul Houx Creative Coding - All rights reserved.
+This code is intended for use with the Cinder C++ library: http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "stdafx.h"
+
+#pragma warning(push)
+#pragma warning(disable : 4715)
+#pragma warning(disable : 4996)
+
+#include "nvpath/NvPath.h"
+#include "nvpath/NvPathSvg.h"
+#include "nvpath/NvPathUtil.h"
+
+#include <cinder/Log.h>
+#include <cinder/Utilities.h>
+#include <cinder/gl/draw.h>
+#include <cinder/gl/scoped.h>
+
+#include <ds/util/float_util.h> // for approxEqual method.
+
+using namespace ci;
+
+namespace nvpath {
+
+bool hasNvPathRendering() {
+	assert(ci::gl::context()); // We must have an active OpenGL context first!
+	return bool(GLAD_GL_NV_path_rendering);
+}
+
+void reportNoNvPathRendering() {
+	static bool sReported = false;
+	if (!sReported) {
+		sReported = true;
+		CI_LOG_F("This GPU does not support the NVidia Path Rendering extension!");
+	}
+}
+
+bool isPreMultiplied() { // TODO: add this to Cinder.
+	const auto ctx = gl::context();
+	if (ctx) {
+		GLenum src, dst, srcAlpha, dstAlpha;
+		ctx->getBlendFuncSeparate(&src, &dst, &srcAlpha, &dstAlpha);
+		return src == GL_ONE &&
+			   dst == GL_ONE_MINUS_SRC_ALPHA; // && srcAlpha == GL_ONE && dstAlpha == GL_ONE_MINUS_SRC_ALPHA;
+	}
+	return false;
+}
+
+bool Paint::Stop::operator==(const Stop& other) const {
+	return ds::approxEqual(offset, other.offset) && color == other.color;
+}
+
+bool Paint::Stop::operator==(float value) const {
+	return ds::approxEqual(offset, value);
+}
+
+Paint Paint::color(const ColorA8u& color, const std::string& id) {
+	Paint result{COLOR, id};
+	result.setColor(color);
+	return result;
+}
+
+Paint Paint::linear(const std::string& id) {
+	return Paint{LINEAR_GRADIENT, id};
+}
+
+Paint Paint::radial(const std::string& id) {
+	return Paint{RADIAL_GRADIENT, id};
+}
+
+Paint::Paint()
+  : Paint(NONE) {}
+
+Paint::Paint(Type type, std::string id)
+  : mType(type)
+  , mId(std::move(id)) {
+	mStops.emplace_back(0.0f, ColorA8u::black());
+
+	// Defaults for radial gradients are different.
+	if (type == RADIAL_GRADIENT) {
+		mCoords0 = mCoords1 = vec2(0.5f, 0.5f);
+
+		mRadius0 = 0.5f;
+		mRadius1 = 0.0f;
+	}
+}
+
+Paint::Paint(const ColorA8u& color)
+  : Paint(COLOR) {
+	mStops.emplace_back(0.0f, color);
+}
+
+Paint::Paint(std::string url)
+  : mNeedsResolve(true)
+  , mId(std::move(url)) {
+	// None of the other data members are initialized, because this instance will be replaced later.
+}
+
+bool Paint::isTransparent() const {
+	for (const auto& [offset, color] : mStops)
+		if (color.a < 1) return true;
+
+	return false;
+}
+
+const ColorA8u& Paint::getColor() const {
+	static ColorA8u sBlack{0, 0, 0, 255};
+	static ColorA8u sTransparent{0, 0, 0, 0};
+
+	switch (mType) {
+	case NONE:
+		return sTransparent;
+	case COLOR:
+		return getColor(0);
+	default:
+		if (mFallback) return mFallback->getColor();
+		return sBlack;
+	}
+}
+
+void Paint::setColor(const ColorA8u& color) {
+	mStops = {{0, color}};
+}
+
+void Paint::set(float offset, const ColorA8u& color) {
+	// Allow duplicates, see: https://svgwg.org/svg2-draft/pservers.html#GradientStops
+	// "If two gradient stops have the same offset value, then the latter gradient stop controls the color value at
+	// the overlap point."
+	const auto t   = clamp(offset, 0.0f, 1.0f);
+	const auto itr = std::upper_bound(mStops.begin(), mStops.end(), t, [](float a, const Stop& b) {
+		return a < b.offset && !ds::approxEqual(a, b.offset);
+	});
+	mStops.insert(itr, Stop{offset, color});
+}
+
+ColorA8u Paint::at(float t, bool preMultiply) const {
+	ColorA8u result;
+
+	const auto& lo = floor(t);
+	const auto& hi = ceil(t);
+
+	// See: https://svgwg.org/svg2-draft/pservers.html#GradientStops
+	// "If two gradient stops have the same offset value, then the latter gradient stop controls the color value at
+	// the overlap point."
+	if (ds::approxEqual(lo.offset, hi.offset)) {
+		result = hi.color; // TODO: check specifiesColor?
+	} else {
+		const float f = clamp((t - lo.offset) / (hi.offset - lo.offset), 0.0f, 1.0f);
+		result		  = lo.color.lerp(uint8_t(f * 255.0f), hi.color); // TODO: check specifiesColor?
+	}
+
+	return preMultiply ? result.premultiplied() : result;
+}
+
+const Paint::Stop& Paint::floor(float t) const {
+	assert(!mStops.empty());
+
+	for (auto itr = mStops.rbegin(); itr != mStops.rend(); ++itr) {
+		if (itr->offset <= t) return *itr;
+	}
+
+	return mStops.front();
+}
+
+const Paint::Stop& Paint::ceil(float t) const {
+	assert(!mStops.empty());
+
+	for (auto itr = mStops.begin(); itr != mStops.end(); ++itr) {
+		if (itr->offset > t) return *itr;
+	}
+
+	return mStops.back();
+}
+
+std::unique_ptr<uint8_t[]> Paint::data(int32_t width, int32_t height, bool preMultiply, float from, float to) const {
+	auto result = std::make_unique<uint8_t[]>(size_t(width) * size_t(height) * sizeof(ColorA8u));
+
+	for (int x = 0; x < width; ++x) {
+		const float t = mix(from, to, float(x) / float(width - 1));
+
+		const auto c = at(t, preMultiply);
+		for (int y = 0; y < height; ++y) {
+			const int64_t i		  = (int64_t(x) + int64_t(y) * int64_t(width)) * sizeof(ColorA8u);
+			result[size_t(i) + 0] = uint8_t(c.r);
+			result[size_t(i) + 1] = uint8_t(c.g);
+			result[size_t(i) + 2] = uint8_t(c.b);
+			result[size_t(i) + 3] = uint8_t(c.a);
+		}
+	}
+
+	return result;
+}
+
+bool Paints::contains(const std::string& paintId) const {
+	return mPaints.count(paintId) != 0;
+}
+
+bool Paints::contains(const Paint& paint) const {
+	return mPaints.count(paint.getId()) != 0;
+}
+
+float Paints::index(const std::string& paintId) const {
+	const auto itr = mPaints.find(paintId);
+	if (itr == mPaints.end()) return 0.0f;
+	const auto index = std::distance(mPaints.begin(), itr);
+	const auto size	 = textureSize();
+	return (static_cast<float>(index) + 0.5f) / static_cast<float>(size);
+}
+
+float Paints::index(const Paint& paint) const {
+	return index(paint.getId());
+}
+
+float Paints::set(const Paint& paint) {
+	mDirty |= mPaints.count(paint.getId()) == 0 || mPaints[paint.getId()] != paint;
+	mPaints[paint.getId()] = paint;
+	const auto index	   = std::distance(mPaints.begin(), mPaints.find(paint.getId()));
+	const auto size		   = textureSize();
+	return (static_cast<float>(index) + 0.5f) / static_cast<float>(size);
+}
+
+void Paints::setSpreadMethod(SpreadMethod method) const {
+	if (mTexture) {
+		mTexture->setWrapS(method == SpreadMethod::REFLECT	? GL_MIRRORED_REPEAT
+						   : method == SpreadMethod::REPEAT ? GL_REPEAT
+															: GL_CLAMP_TO_EDGE);
+	}
+}
+
+Shader::Type Paints::prepareLinearGradient(const Paint& paint, float opacity, bool prepareShader) {
+	assert(paint.isLinearGradient());
+
+	const auto index = set(paint);
+	setSpreadMethod(paint.getSpreadMethod());
+
+	if (prepareShader) {
+		ScopedShader scpShader(Shader::Type::LINEAR_GRADIENT);
+		scpShader.setColor(paint.getColor());
+		scpShader.setCoords(paint.useObjectBoundingBox() ? GL_PATH_OBJECT_BOUNDING_BOX_NV : GL_OBJECT_LINEAR_NV,
+							paint.getTransform());
+		scpShader.uniform("index", index);
+		scpShader.uniform("gradTab", 0);
+		scpShader.uniform("gradStart", paint.getCoords0());
+		scpShader.uniform("gradEnd", paint.getCoords1());
+		scpShader.uniform("opacity", opacity);
+	}
+
+	return Shader::Type::LINEAR_GRADIENT;
+}
+
+Shader::Type Paints::prepareRadialGradient(const Paint& paint, float opacity, bool prepareShader) {
+	assert(paint.isRadialGradient());
+
+	const float index = set(paint);
+	setSpreadMethod(paint.getSpreadMethod());
+
+	if (prepareShader) {
+		ScopedShader scpShader(Shader::Type::RADIAL_GRADIENT);
+		scpShader.setColor(paint.getColor());
+		scpShader.setCoords(paint.useObjectBoundingBox() ? GL_PATH_OBJECT_BOUNDING_BOX_NV : GL_OBJECT_LINEAR_NV,
+							paint.getTransform());
+		scpShader.uniform("index", index);
+		scpShader.uniform("gradTab", 0);
+		scpShader.uniform("focalToCenter", paint.getCoords0() - paint.getCoords1());
+		scpShader.uniform("centerRadius", paint.getRadius0());
+		scpShader.uniform("focalRadius", paint.getRadius1());
+		scpShader.uniform("translationPoint", paint.getCoords1());
+		scpShader.uniform("opacity", opacity);
+	}
+
+	return Shader::Type::RADIAL_GRADIENT;
+}
+
+Shader::Type Paints::preparePaint(const Paint& paint, float opacity, bool prepareShader) {
+	if (paint.isLinearGradient()) return prepareLinearGradient(paint, opacity, prepareShader);
+	if (paint.isRadialGradient()) return prepareRadialGradient(paint, opacity, prepareShader);
+
+	if (prepareShader) {
+		ScopedShader scpShader(Shader::Type::SOLID_COLOR);
+		scpShader.setColor(paint.getColor());
+		scpShader.uniform("opacity", opacity);
+	}
+
+	return Shader::Type::SOLID_COLOR;
+}
+
+GLint Paints::textureSize() const {
+	const GLint size = glm::max(128, static_cast<GLint>(mPaints.size()));
+	return isPowerOf2(size) ? size : static_cast<GLint>(nextPowerOf2(size));
+}
+
+void Paints::bind(gl::Context* ctx, uint8_t textureUnit) {
+	assert(ctx);
+
+	mTextureUnit = textureUnit;
+
+	if (const auto size = textureSize(); mDirty || !mTexture || mCtx != ctx || mTexture->getHeight() < size) {
+		const auto data = std::make_unique<uint8_t[]>(128 * size * sizeof(ColorA8u));
+
+		auto ptr = data.get();
+		for (const auto& [id, paint] : mPaints) {
+			for (int x = 0; x < 128; ++x) {
+				const float t = static_cast<float>(x) / static_cast<float>(128 - 1);
+				const auto	c = paint.at(t, false);
+				*ptr++		  = static_cast<uint8_t>(c.r);
+				*ptr++		  = static_cast<uint8_t>(c.g);
+				*ptr++		  = static_cast<uint8_t>(c.b);
+				*ptr++		  = static_cast<uint8_t>(c.a);
+			}
+		}
+
+		static const gl::Texture2d::Format FORMAT =
+			gl::Texture2d::Format().wrapT(GL_REPEAT).internalFormat(GL_RGBA).target(GL_TEXTURE_2D).loadTopDown();
+
+		GLint wrapS = GL_CLAMP_TO_EDGE;
+		if (mTexture) {
+			gl::ScopedTextureBind tbs(mTexture);
+			glGetTexParameteriv(mTexture->getTarget(), GL_TEXTURE_WRAP_S, &wrapS);
+		}
+
+		mCtx	 = ctx;
+		mTexture = gl::Texture::create(128, size, FORMAT);
+		mTexture->update(data.get(), GL_RGBA, GL_UNSIGNED_BYTE, 0, 128, size);
+		mTexture->setWrapS(wrapS);
+		mDirty = false;
+	}
+
+	if (mTexture) mCtx->pushTextureBinding(mTexture->getTarget(), mTexture->getId(), mTextureUnit);
+}
+
+void Paints::unbind(const gl::Context* ctx) const {
+	assert(ctx == mCtx);
+
+	if (mTexture) mCtx->popTextureBinding(mTexture->getTarget(), mTextureUnit);
+}
+
+Path::~Path() {
+	if (mPathId > 0) glDeletePathsNV(mPathId, 1);
+}
+
+Path::Path(const Path& other) {
+	if (other.mPathId > 0) {
+		mPathId = glGenPathsNV(1);
+		glCopyPathNV(mPathId, other.mPathId);
+	}
+}
+
+Path::Path(Path&& other) noexcept {
+	if (mPathId > 0) glDeletePathsNV(mPathId, 1);
+	mPathId		  = other.mPathId;
+	other.mPathId = 0;
+}
+
+Path& Path::operator=(const Path& other) {
+	if (other.mPathId > 0 && this != &other) {
+		if (mPathId == 0) mPathId = glGenPathsNV(1);
+		glCopyPathNV(mPathId, other.mPathId);
+	}
+	return *this;
+}
+
+Path& Path::operator=(Path&& other) noexcept {
+	if (this != &other) {
+		if (mPathId > 0) glDeletePathsNV(mPathId, 1);
+		mPathId		  = other.mPathId;
+		other.mPathId = 0;
+	}
+	return *this;
+}
+
+Path::Path(const Path2d& path) {
+	if (hasNvPathRendering()) {
+		std::vector<GLubyte> commands;
+
+		commands.reserve(path.getNumSegments() + 1 /* implicit MOVE_TO at start */);
+		commands.push_back(GL_MOVE_TO_NV);
+
+		for (size_t i = 0; i < path.getNumSegments(); ++i)
+			commands.push_back(toPathCommand(path.getSegmentType(i)));
+
+		const auto& points = path.getPoints();
+
+		mPathId = glGenPathsNV(1);
+		glPathCommandsNV(mPathId, static_cast<GLsizei>(commands.size()), commands.data(),
+						 static_cast<GLsizei>(points.size() * 2 /* each vec2 contains 2 floats */), GL_FLOAT,
+						 points.data());
+		// if (const GLenum err = gl::getError(); err != GL_NO_ERROR) CI_LOG_E(ci::gl::getErrorString(err));
+	} else
+		reportNoNvPathRendering();
+}
+
+Path::Path(const Shape2d& shape) {
+	if (hasNvPathRendering()) {
+		std::vector<GLubyte> commands;
+		std::vector<vec2>	 coords;
+
+		const auto& contours = shape.getContours();
+		for (const auto& contour : contours) {
+			const auto& points = contour.getPoints();
+			coords.insert(coords.end(), points.begin(), points.end());
+
+			const auto numCommands = static_cast<GLsizei>(contour.getNumSegments());
+
+			commands.reserve(commands.size() + numCommands + 1 /* implicit MOVE_TO at start */);
+			commands.push_back(GL_MOVE_TO_NV);
+
+			for (GLsizei i = 0; i < numCommands; ++i)
+				commands.push_back(toPathCommand(contour.getSegmentType(i)));
+		}
+
+		mPathId = glGenPathsNV(1);
+		glPathCommandsNV(mPathId, static_cast<GLsizei>(commands.size()), commands.data(),
+						 static_cast<GLsizei>(coords.size() * 2 /* each vec2 contains 2 floats */), GL_FLOAT,
+						 coords.data());
+		// if (const GLenum err = gl::getError(); err != GL_NO_ERROR) CI_LOG_E(gl::getErrorString(err));
+	} else
+		reportNoNvPathRendering();
+}
+
+Path::Path(const PolyLine2& polyLine) {
+	if (hasNvPathRendering()) {
+		const auto& points = polyLine.getPoints();
+
+		std::vector<GLubyte> commands;
+
+		const auto numCommands = points.size() + static_cast<size_t>(polyLine.isClosed());
+		commands.reserve(numCommands);
+		commands.push_back(GL_MOVE_TO_NV);
+
+		for (size_t i = 0; i < numCommands; ++i)
+			commands.push_back(GL_LINE_TO_NV);
+
+		if (polyLine.isClosed()) commands.push_back(GL_CLOSE_PATH_NV);
+
+		mPathId = glGenPathsNV(1);
+		glPathCommandsNV(mPathId, static_cast<GLsizei>(commands.size()), commands.data(),
+						 static_cast<GLsizei>(points.size() * 2 /* each vec2 contains 2 floats */), GL_FLOAT,
+						 points.data());
+		// if (const GLenum err = gl::getError(); err != GL_NO_ERROR) CI_LOG_E(gl::getErrorString(err));
+	} else
+		reportNoNvPathRendering();
+}
+
+Path::Path(const std::string& path, PathFormat format) {
+	if (hasNvPathRendering()) {
+		mPathId = glGenPathsNV(1);
+		glPathStringNV(mPathId, static_cast<GLenum>(format), static_cast<GLsizei>(path.length()), path.c_str());
+		// if (const GLenum err = gl::getError(); err != GL_NO_ERROR) CI_LOG_E(gl::getErrorString(err));
+	} else
+		reportNoNvPathRendering();
+}
+
+Path::Path(const std::vector<GLubyte>& commands, const std::vector<vec2>& points) {
+	if (hasNvPathRendering()) {
+		mPathId = glGenPathsNV(1);
+		glPathCommandsNV(mPathId, static_cast<GLsizei>(commands.size()), commands.data(),
+						 static_cast<GLsizei>(points.size() * 2 /* each vec2 contains 2 floats */), GL_FLOAT,
+						 points.data());
+		// if (const GLenum err = gl::getError(); err != GL_NO_ERROR) CI_LOG_E(gl::getErrorString(err));
+	} else
+		reportNoNvPathRendering();
+}
+
+Path::Path(const std::vector<GLubyte>& commands, const std::vector<GLfloat>& points) {
+	if (hasNvPathRendering()) {
+		mPathId = glGenPathsNV(1);
+		glPathCommandsNV(mPathId, static_cast<GLsizei>(commands.size()), commands.data(),
+						 static_cast<GLsizei>(points.size()), GL_FLOAT, points.data());
+		// if (const GLenum err = gl::getError(); err != GL_NO_ERROR) CI_LOG_E(gl::getErrorString(err));
+	} else
+		reportNoNvPathRendering();
+}
+
+Path::Path(const PathHelper& commands)
+  : Path(commands.getCommands(), commands.getCoords()) {}
+
+bool Path::getPointAlongPath(float distance, vec2& point, vec2& tangent) const {
+	if (mPathId > 0) {
+		return glPointAlongPathNV(mPathId, 0, getNumSegments(), distance, &point.x, &point.y, &tangent.x, &tangent.y);
+	}
+	return false;
+}
+
+float Path::getLength() const {
+	float length{0};
+
+	if (mPathId > 0) length = glGetPathLengthNV(mPathId, 0, getNumSegments());
+
+	return length;
+}
+
+Rectf Path::getFillBounds() const {
+	Rectf bounds;
+
+	if (mPathId > 0) glGetPathParameterfvNV(mPathId, GL_PATH_FILL_BOUNDING_BOX_NV, reinterpret_cast<GLfloat*>(&bounds));
+
+	return bounds;
+}
+
+Rectf Path::getStrokeBounds() const {
+	Rectf bounds;
+
+	if (mPathId > 0)
+		glGetPathParameterfvNV(mPathId, GL_PATH_STROKE_BOUNDING_BOX_NV, reinterpret_cast<GLfloat*>(&bounds));
+
+	return bounds;
+}
+
+float Path::getClientLength() const {
+	float clientLength = 0;
+
+	if (mPathId > 0) glGetPathParameterfvNV(mPathId, GL_PATH_CLIENT_LENGTH_NV, &clientLength);
+
+	return clientLength;
+}
+
+void Path::setClientLength(float length) const {
+	if (mPathId > 0) gl::pathParameterfNV(mPathId, GL_PATH_CLIENT_LENGTH_NV, glm::max(0.0f, length));
+}
+
+int Path::getNumSegments() const {
+	int numSegments = 0;
+
+	if (mPathId > 0) glGetPathParameterivNV(mPathId, GL_PATH_COMMAND_COUNT_NV, &numSegments);
+
+	return numSegments;
+}
+
+void Path::resetDashPattern() const {
+	if (mPathId > 0) {
+		glPathDashArrayNV(mPathId, 0, nullptr);
+		gl::pathParameteriNV(mPathId, GL_PATH_DASH_CAPS_NV, static_cast<GLint>(CapsStyle::FLAT));
+		gl::pathParameteriNV(mPathId, GL_PATH_INITIAL_DASH_CAP_NV, static_cast<GLint>(CapsStyle::FLAT));
+		gl::pathParameteriNV(mPathId, GL_PATH_TERMINAL_DASH_CAP_NV, static_cast<GLint>(CapsStyle::FLAT));
+	}
+}
+
+void Path::setDashPattern(const std::vector<float>& pattern) const {
+	if (mPathId > 0) {
+		glPathDashArrayNV(mPathId, static_cast<GLsizei>(pattern.size()), pattern.data());
+	}
+}
+
+void Path::setDashOffset(float offset, PathStyle style) const {
+	if (mPathId > 0) {
+		gl::pathParameterfNV(mPathId, GL_PATH_DASH_OFFSET_NV, offset);
+		gl::pathParameteriNV(mPathId, GL_PATH_DASH_OFFSET_RESET_NV, static_cast<GLint>(style));
+	}
+}
+
+void Path::setDashCaps(CapsStyle caps) const {
+	setDashCaps(caps, caps);
+}
+
+void Path::setDashCaps(CapsStyle initialCap, CapsStyle terminalCap) const {
+	if (mPathId > 0) {
+		gl::pathParameteriNV(mPathId, GL_PATH_INITIAL_DASH_CAP_NV, static_cast<GLint>(initialCap));
+		gl::pathParameteriNV(mPathId, GL_PATH_TERMINAL_DASH_CAP_NV, static_cast<GLint>(terminalCap));
+	}
+}
+
+void Path::setEndCaps(CapsStyle caps) const {
+	setEndCaps(caps, caps);
+}
+
+void Path::setEndCaps(CapsStyle initialCap, CapsStyle terminalCap) const {
+	if (mPathId > 0) {
+		gl::pathParameteriNV(mPathId, GL_PATH_INITIAL_END_CAP_NV, static_cast<GLint>(initialCap));
+		gl::pathParameteriNV(mPathId, GL_PATH_TERMINAL_END_CAP_NV, static_cast<GLint>(terminalCap));
+	}
+}
+
+void Path::setJoinStyle(JoinStyle joins) const {
+	if (mPathId > 0) {
+		gl::pathParameteriNV(mPathId, GL_PATH_JOIN_STYLE_NV, static_cast<GLint>(joins));
+	}
+}
+
+void Path::setStrokeWidth(float width) const {
+	if (mPathId > 0) {
+		gl::pathParameterfNV(mPathId, GL_PATH_STROKE_WIDTH_NV, static_cast<GLfloat>(width));
+	}
+}
+
+void Path::setMiterLimit(float limit) const {
+	if (mPathId > 0) {
+		gl::pathParameterfNV(mPathId, GL_PATH_MITER_LIMIT_NV, static_cast<GLfloat>(limit));
+	}
+}
+
+void Path::setStroke(CapsStyle caps, JoinStyle join, float strokeWidth) const {
+	if (mPathId > 0) {
+		gl::pathParameterfNV(mPathId, GL_PATH_STROKE_WIDTH_NV, strokeWidth);
+		gl::pathParameteriNV(mPathId, GL_PATH_END_CAPS_NV, static_cast<GLint>(caps));
+		gl::pathParameteriNV(mPathId, GL_PATH_JOIN_STYLE_NV, static_cast<GLint>(join));
+	}
+}
+
+void Path::stencilStroke(GLuint stencilMask) const {
+	if (mPathId > 0) {
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilStrokePathNV(mPathId, 0x1, stencilMask);
+	}
+}
+
+void Path::stencilFill(GLuint stencilMask, GLenum fillMode) const {
+	if (mPathId > 0) {
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilFillPathNV(mPathId, fillMode, stencilMask);
+	}
+}
+
+void Path::stencilStrokeInstanced(const std::vector<glm::mat3x2>& transforms, GLuint stencilMask) const {
+	if (mPathId > 0) {
+		if (sPaths.size() < transforms.size()) sPaths.resize(transforms.size(), 0);
+		stencilStrokeInstanced(sPaths, transforms, stencilMask);
+	}
+}
+
+void Path::stencilStrokeInstanced(const std::vector<GLuint>& paths, const std::vector<glm::mat3x2>& transforms,
+								  GLuint stencilMask) const {
+	if (mPathId > 0) {
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilStrokePathInstancedNV(static_cast<GLsizei>(transforms.size()), GL_UNSIGNED_INT, paths.data(), mPathId,
+									   0x1, stencilMask, GL_AFFINE_2D_NV,
+									   reinterpret_cast<const GLfloat*>(transforms.data()));
+	}
+}
+
+void Path::stencilFillInstanced(const std::vector<glm::mat3x2>& transforms, GLuint stencilMask, GLenum fillMode) const {
+	if (mPathId > 0) {
+		if (sPaths.size() < transforms.size()) sPaths.resize(transforms.size(), 0);
+		stencilFillInstanced(sPaths, transforms, stencilMask, fillMode);
+	}
+}
+
+void Path::stencilFillInstanced(const std::vector<GLuint>& paths, const std::vector<glm::mat3x2>& transforms,
+								GLuint stencilMask, GLenum fillMode) const {
+	if (mPathId > 0) {
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilFillPathInstancedNV(static_cast<GLsizei>(transforms.size()), GL_UNSIGNED_INT, paths.data(), mPathId,
+									 fillMode, stencilMask, GL_AFFINE_2D_NV,
+									 reinterpret_cast<const GLfloat*>(transforms.data()));
+	}
+}
+
+void Path::clearStroke(GLuint stencilMask) const {
+	if (mPathId > 0) {
+		if (!sClipPaths.empty()) {
+			CI_LOG_E("Clip-paths are currently not supported for clearStroke().");
+			return;
+		}
+
+		gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+		gl::stencilFunc(GL_NOTEQUAL, 0, stencilMask);
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+
+		ScopedColorMask scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glCoverStrokePathNV(mPathId, GL_CONVEX_HULL_NV);
+	}
+}
+
+void Path::clearFill(GLuint stencilMask) const {
+	if (mPathId > 0) {
+		if (!sClipPaths.empty()) {
+			CI_LOG_E("Clip-paths are currently not supported for clearFill().");
+			return;
+		}
+
+		gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+		gl::stencilFunc(GL_NOTEQUAL, 0, stencilMask);
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+
+		ScopedColorMask scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glCoverFillPathNV(mPathId, GL_CONVEX_HULL_NV);
+	}
+}
+
+void Path::coverStroke(const ColorA& color, bool clearStencil) const {
+	if (mPathId > 0) {
+		if (!sClipPaths.empty()) {
+			CI_LOG_E("Clip-paths are currently not supported for coverStroke().");
+			return;
+		}
+
+		ScopedShader scpShader(color);
+
+		gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+		gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+		gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glCoverStrokePathNV(mPathId, GL_CONVEX_HULL_NV);
+	}
+}
+
+void Path::coverFill(const ColorA& color, float opacity, bool clearStencil) const {
+	if (mPathId > 0) {
+		if (!sClipPaths.empty()) {
+			CI_LOG_E("Clip-paths are currently not supported for coverFill().");
+			return;
+		}
+
+		ScopedShader scpShader(color, opacity);
+
+		gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+		gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+		gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glCoverFillPathNV(mPathId, GL_BOUNDING_BOX_NV);
+	}
+}
+
+void Path::coverFill(const Paint& paint, float opacity, bool clearStencil) const {
+	if (mPathId > 0 && !paint.isNone()) {
+		if (!sClipPaths.empty()) {
+			CI_LOG_E("Clip-paths are currently not supported for coverFill().");
+			return;
+		}
+
+		auto& paints = getPaints();
+
+		ScopedShader scpShader(paints.preparePaint(paint, opacity));
+		ScopedPaints scpGradients(paints);
+
+		gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+		gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+		gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glCoverFillPathNV(mPathId, GL_BOUNDING_BOX_NV);
+	}
+}
+
+void Path::coverFill(const Paint& paint, const gl::Texture2dRef& texture, float opacity, bool clearStencil) const {
+	if (mPathId > 0 && !paint.isNone()) {
+		if (!sClipPaths.empty()) {
+			CI_LOG_E("Clip-paths are currently not supported for coverFill().");
+			return;
+		}
+
+		auto& paints = getPaints();
+
+		ScopedShader scpShader(paints.preparePaint(paint, opacity));
+
+		gl::ScopedTextureBind scpTexture(texture, 0);
+
+		gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+		gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+		gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glCoverFillPathNV(mPathId, GL_BOUNDING_BOX_NV);
+	}
+}
+
+void Path::coverFill(const ColorA& color, const Rectf& bounds, bool clearStencil) const {
+	if (mPathId > 0) {
+		if (!sClipPaths.empty()) {
+			CI_LOG_E("Clip-paths are currently not supported for coverFill().");
+			return;
+		}
+
+		ScopedShader scpShader(color);
+
+		gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+		gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+		gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		gl::drawSolidRect(bounds);
+	}
+}
+
+void Path::coverFill(const gl::Texture2dRef& texture, const Rectf& bounds, bool clearStencil) const {
+	if (mPathId > 0) {
+		if (!sClipPaths.empty()) {
+			CI_LOG_E("Clip-paths are currently not supported for coverFill().");
+			return;
+		}
+
+		gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+		gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+		gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		draw(texture, bounds);
+	}
+}
+
+void Path::stroke(const ColorA& color, float opacity, bool clearStencil) const {
+	if (mPathId > 0) {
+		GLuint clipMask	 = 0x80 >> sClipPaths.size();
+		GLuint coverMask = clipMask - 1;
+		GLuint bitMask	 = coverMask << 1 | 0x01;
+
+		ScopedStencilMask scpStencilMask(coverMask | clipMask); // Don't write to previous clip bits.
+		gl::ScopedState	  scpStencil(GL_STENCIL_TEST, GL_TRUE);
+
+		if (!sClipPaths.empty()) {
+			// Render clipped path.
+			gl::stencilFunc(GL_LESS, GLint(~bitMask & 0xFF), 0xFF); // Only render if all clip bits are set.
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+		} else {
+			gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+			gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+		}
+
+		ScopedShader scpShader(color, opacity);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilThenCoverStrokePathNV(mPathId, GL_COUNT_UP_NV, coverMask & 0xFF, GL_CONVEX_HULL_NV);
+
+		if (!sClipPaths.empty()) {
+			// Remove path from stencil buffer.
+			ScopedColorMask scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+			gl::stencilFunc(GL_ALWAYS, GLint(clipMask), coverMask);
+
+			glCoverStrokePathNV(mPathId, GL_CONVEX_HULL_NV);
+		}
+	}
+}
+
+void Path::stroke(const Paint& paint, float opacity, bool clearStencil) const {
+	if (mPathId > 0 && !paint.isNone()) {
+		GLuint clipMask	 = 0x80 >> sClipPaths.size();
+		GLuint coverMask = clipMask - 1;
+		GLuint bitMask	 = coverMask << 1 | 0x01;
+
+		ScopedStencilMask scpStencilMask(coverMask | clipMask); // Don't write to previous clip bits.
+		gl::ScopedState	  scpStencil(GL_STENCIL_TEST, GL_TRUE);
+
+		if (!sClipPaths.empty()) {
+			// Render clipped path.
+			gl::stencilFunc(GL_LESS, GLint(~bitMask & 0xFF), 0xFF); // Only render if all clip bits are set.
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+		} else {
+			gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+			gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+		}
+
+		auto& paints = getPaints();
+
+		ScopedShader scpShader(paints.preparePaint(paint, opacity));
+		ScopedPaints scpGradients(paints);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilThenCoverStrokePathNV(mPathId, GL_COUNT_UP_NV, coverMask & 0xFF, GL_CONVEX_HULL_NV);
+
+		if (!sClipPaths.empty()) {
+			// Remove path from stencil buffer.
+			ScopedColorMask scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+			gl::stencilFunc(GL_ALWAYS, GLint(clipMask), coverMask);
+
+			glCoverStrokePathNV(mPathId, GL_CONVEX_HULL_NV);
+		}
+	}
+}
+
+void Path::strokeInstanced(const std::vector<glm::mat3x2>& transforms, const ColorA& color, bool clearStencil) const {
+	if (mPathId > 0) {
+		if (sPaths.size() < transforms.size()) sPaths.resize(transforms.size(), 0);
+		strokeInstanced(sPaths, transforms, color, clearStencil);
+	}
+}
+
+void Path::strokeInstanced(const std::vector<glm::mat4x3>& transforms, const ColorA& color, bool clearStencil) const {
+	if (mPathId > 0) {
+		if (sPaths.size() < transforms.size()) sPaths.resize(transforms.size(), 0);
+		strokeInstanced(sPaths, transforms, color, clearStencil);
+	}
+}
+
+void Path::strokeInstanced(const std::vector<GLuint>& paths, const std::vector<glm::mat3x2>& transforms,
+						   const ColorA& color, bool clearStencil) const {
+	if (mPathId > 0) {
+		if (!sClipPaths.empty()) {
+			CI_LOG_E("Clip-paths are currently not supported for instanced rendering.");
+			return;
+		}
+
+		ScopedShader scpShader(color);
+
+		gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+		gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+		gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilThenCoverStrokePathInstancedNV(static_cast<GLsizei>(transforms.size()), GL_UNSIGNED_INT, paths.data(),
+												mPathId, GL_COUNT_UP_NV, 0xFF, GL_CONVEX_HULL_NV, GL_AFFINE_2D_NV,
+												reinterpret_cast<const GLfloat*>(transforms.data()));
+	}
+}
+
+void Path::strokeInstanced(const std::vector<GLuint>& paths, const std::vector<glm::mat4x3>& transforms,
+						   const ColorA& color, bool clearStencil) const {
+	if (mPathId > 0) {
+		if (!sClipPaths.empty()) {
+			CI_LOG_E("Clip-paths are currently not supported for instanced rendering.");
+			return;
+		}
+
+		ScopedShader scpShader(color);
+
+		gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+		gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+		gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilThenCoverStrokePathInstancedNV(static_cast<GLsizei>(transforms.size()), GL_UNSIGNED_INT, paths.data(),
+												mPathId, GL_COUNT_UP_NV, 0xFF, GL_CONVEX_HULL_NV, GL_AFFINE_3D_NV,
+												reinterpret_cast<const GLfloat*>(transforms.data()));
+	}
+}
+
+void Path::fill(const ColorA& color, float opacity, bool clearStencil) const {
+	if (mPathId > 0) {
+		GLuint clipMask	 = 0x80 >> sClipPaths.size();
+		GLuint coverMask = clipMask - 1;
+		GLuint bitMask	 = coverMask << 1 | 0x01;
+
+		ScopedStencilMask scpStencilMask(coverMask | clipMask); // Don't write to previous clip bits.
+		gl::ScopedState	  scpStencil(GL_STENCIL_TEST, GL_TRUE);
+
+		if (!sClipPaths.empty()) {
+			// Render clipped path.
+			gl::stencilFunc(GL_LESS, GLint(~bitMask & 0xFF), 0xFF); // Only render if all clip bits are set.
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+		} else {
+			gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+			gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+		}
+
+		ScopedShader scpShader(color, opacity);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilThenCoverFillPathNV(mPathId, GL_COUNT_UP_NV, coverMask & 0xFF, GL_CONVEX_HULL_NV);
+
+		if (!sClipPaths.empty()) {
+			// Remove path from stencil buffer.
+			ScopedColorMask scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+			gl::stencilFunc(GL_ALWAYS, GLint(clipMask), coverMask);
+
+			glCoverFillPathNV(mPathId, GL_CONVEX_HULL_NV);
+		}
+	}
+}
+
+void Path::fill(const Paint& paint, float opacity, bool clearStencil) const {
+	if (mPathId > 0 && !paint.isNone()) {
+		GLuint clipMask	 = 0x80 >> sClipPaths.size();
+		GLuint coverMask = clipMask - 1;
+		GLuint bitMask	 = coverMask << 1 | 0x01;
+
+		ScopedStencilMask scpStencilMask(coverMask | clipMask); // Don't write to previous clip bits.
+		gl::ScopedState	  scpStencil(GL_STENCIL_TEST, GL_TRUE);
+
+		if (!sClipPaths.empty()) {
+			// Render clipped path.
+			gl::stencilFunc(GL_LESS, GLint(~bitMask & 0xFF), 0xFF); // Only render if all clip bits are set.
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+		} else {
+			gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+			gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+		}
+
+		auto&		 paints = getPaints();
+		ScopedShader scpShader(paints.preparePaint(paint, opacity));
+		ScopedPaints scpGradients(paints);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilThenCoverFillPathNV(mPathId, GL_COUNT_UP_NV, coverMask & 0xFF, GL_CONVEX_HULL_NV);
+
+		if (!sClipPaths.empty()) {
+			// Remove path from stencil buffer.
+			ScopedColorMask scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+			gl::stencilFunc(GL_ALWAYS, GLint(clipMask), coverMask);
+
+			glCoverFillPathNV(mPathId, GL_CONVEX_HULL_NV);
+		}
+	}
+}
+
+void Path::fill(const Paint& paint, const gl::TextureRef& texture, float opacity, bool clearStencil) const {
+	if (mPathId > 0 && !paint.isNone()) {
+		GLuint clipMask	 = 0x80 >> sClipPaths.size();
+		GLuint coverMask = clipMask - 1;
+		GLuint bitMask	 = coverMask << 1 | 0x01;
+
+		ScopedStencilMask scpStencilMask(coverMask | clipMask); // Don't write to previous clip bits.
+		gl::ScopedState	  scpStencil(GL_STENCIL_TEST, GL_TRUE);
+
+		if (!sClipPaths.empty()) {
+			// Render clipped path.
+			gl::stencilFunc(GL_LESS, GLint(~bitMask & 0xFF), 0xFF); // Only render if all clip bits are set.
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+		} else {
+			gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+			gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+		}
+
+		auto&		 paints = getPaints();
+		ScopedShader scpShader(paints.preparePaint(paint, opacity));
+
+		gl::ScopedTextureBind scpTexture(texture, 0);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilThenCoverFillPathNV(mPathId, GL_COUNT_UP_NV, coverMask & 0xFF, GL_CONVEX_HULL_NV);
+
+		if (!sClipPaths.empty()) {
+			// Remove path from stencil buffer.
+			ScopedColorMask scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+			gl::stencilFunc(GL_ALWAYS, GLint(clipMask), coverMask);
+
+			glCoverFillPathNV(mPathId, GL_CONVEX_HULL_NV);
+		}
+	}
+}
+
+void Path::fill(const gl::TextureRef& texture, const Rectf& bounds, float opacity, bool clearStencil) const {
+	if (mPathId > 0) {
+		const auto pathBounds	 = getFillBounds();
+		const auto textureBounds = Rectf(texture->getBounds());
+		const auto fit			 = bounds.getCenteredFit(textureBounds, true).scaled(1.0f / textureBounds.getSize());
+
+		auto normalized =
+			Rectf(pathBounds.getUpperLeft() - bounds.getUpperLeft(), pathBounds.getLowerRight() - bounds.getUpperLeft())
+				.scaled(fit.getSize() / bounds.getSize());
+		normalized.offset(fit.getUpperLeft());
+
+		const auto flip				  = texture->isTopDown();
+		const auto upperLeftTexCoord  = vec2{normalized.x1, flip ? normalized.y2 : normalized.y1};
+		const auto lowerRightTexCoord = vec2{normalized.x2, flip ? normalized.y1 : normalized.y2};
+		fill(texture, upperLeftTexCoord, lowerRightTexCoord, opacity, clearStencil);
+	}
+}
+
+void Path::fill(const gl::TextureRef& texture, const vec2& upperLeftTexCoord, const vec2& lowerRightTexCoord,
+				float opacity, bool clearStencil) const {
+	if (mPathId > 0) {
+		GLuint clipMask	 = 0x80 >> sClipPaths.size();
+		GLuint coverMask = clipMask - 1;
+		GLuint bitMask	 = coverMask << 1 | 0x01;
+
+		ScopedStencilMask scpStencilMask(coverMask | clipMask); // Don't write to previous clip bits.
+		gl::ScopedState	  scpStencil(GL_STENCIL_TEST, GL_TRUE);
+
+		if (!sClipPaths.empty()) {
+			// Render clipped path.
+			gl::stencilFunc(GL_LESS, GLint(~bitMask & 0xFF), 0xFF); // Only render if all clip bits are set.
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+		} else {
+			gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+			gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+		}
+
+		gl::ScopedTextureBind scpTex(texture, 0);
+
+		ScopedShader scpShader(Shader::Type::IMAGE);
+		scpShader.setColor(ColorA::white());
+		scpShader.uniform("image", 0);
+		scpShader.uniform("opacity", opacity);
+
+		const vec2 s{lowerRightTexCoord.x - upperLeftTexCoord.x, lowerRightTexCoord.y - upperLeftTexCoord.y};
+		const mat3 m{1.0f / s.x, 0, 0, 0, 1.0f / s.y, 0, -upperLeftTexCoord.x, -upperLeftTexCoord.y, 1};
+		scpShader.setCoords(GL_PATH_OBJECT_BOUNDING_BOX_NV, m);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilThenCoverFillPathNV(mPathId, GL_COUNT_UP_NV, coverMask & 0xFF, GL_CONVEX_HULL_NV);
+
+		if (!sClipPaths.empty()) {
+			// Remove path from stencil buffer.
+			ScopedColorMask scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+			gl::stencilFunc(GL_ALWAYS, GLint(clipMask), coverMask);
+
+			glCoverFillPathNV(mPathId, GL_CONVEX_HULL_NV);
+		}
+	}
+}
+
+void Path::fillInstanced(const std::vector<glm::mat3x2>& transforms, const ColorA& color, bool clearStencil) const {
+	if (mPathId > 0) {
+		if (sPaths.size() < transforms.size()) sPaths.resize(transforms.size(), 0);
+		fillInstanced(sPaths, transforms, color, clearStencil);
+	}
+}
+
+void Path::fillInstanced(const std::vector<glm::mat4x3>& transforms, const ColorA& color, bool clearStencil) const {
+	if (mPathId > 0) {
+		if (sPaths.size() < transforms.size()) sPaths.resize(transforms.size(), 0);
+		fillInstanced(sPaths, transforms, color, clearStencil);
+	}
+}
+
+void Path::fillInstanced(const std::vector<GLuint>& paths, const std::vector<glm::mat3x2>& transforms,
+						 const ColorA& color, bool clearStencil) const {
+	if (mPathId > 0) {
+		if (!sClipPaths.empty()) {
+			CI_LOG_E("Clip-paths are currently not supported for instanced rendering.");
+			return;
+		}
+
+		ScopedShader scpShader(color);
+
+		gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+		gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+		gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilThenCoverFillPathInstancedNV(static_cast<GLsizei>(transforms.size()), GL_UNSIGNED_INT, paths.data(),
+											  mPathId, GL_COUNT_UP_NV, 0xFF, GL_CONVEX_HULL_NV, GL_AFFINE_2D_NV,
+											  reinterpret_cast<const GLfloat*>(transforms.data()));
+	}
+}
+
+void Path::fillInstanced(const std::vector<GLuint>& paths, const std::vector<glm::mat4x3>& transforms,
+						 const ColorA& color, bool clearStencil) const {
+	if (mPathId > 0) {
+		if (!sClipPaths.empty()) {
+			CI_LOG_E("Clip-paths are currently not supported for instanced rendering.");
+			return;
+		}
+
+		ScopedShader scpShader(color);
+
+		gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+		gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+		gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP);
+
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glStencilThenCoverFillPathInstancedNV(static_cast<GLsizei>(transforms.size()), GL_UNSIGNED_INT, paths.data(),
+											  mPathId, GL_COUNT_UP_NV, 0xFF, GL_CONVEX_HULL_NV, GL_AFFINE_3D_NV,
+											  reinterpret_cast<const GLfloat*>(transforms.data()));
+	}
+}
+
+void Path::pushClipPath(const Path& mask, bool showMask) {
+	if (mask.mPathId > 0) {
+		if (sClipPaths.size() < 6) {
+			GLuint clipMask	 = 0x80 >> sClipPaths.size();
+			GLuint coverMask = clipMask - 1;
+
+			// Render shape to stencil buffer to use it as a clip-path.
+			ScopedShader	  scpShader(Color(1, 1, 0));
+			ScopedColorMask	  scpColorMask(showMask, showMask, showMask,
+										   showMask);				// Don't write to color buffer, unless requested.
+			ScopedStencilMask scpStencilMask(coverMask | clipMask); // Don't write to previous clip bits.
+
+			gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
+			gl::stencilFunc(GL_NOTEQUAL, GLint(clipMask), coverMask);
+
+			glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+			glStencilFillPathNV(mask.mPathId, GL_COUNT_UP_NV,
+								coverMask & 0xFF); // Write path to LSB portion.
+
+			glCoverFillPathNV(mask.mPathId, GL_CONVEX_HULL_NV); // Convert LSB portion to clip bit.
+
+			sClipPaths.push_back(mask.mPathId);
+		} else {
+			CI_LOG_E("Maximum number of clip-paths reached.");
+			sClipPaths.push_back(0);
+		}
+	} else {
+		sClipPaths.push_back(0);
+	}
+}
+
+void Path::popClipPath() {
+	if (!sClipPaths.empty()) {
+		GLuint pathId = sClipPaths.back();
+		if (pathId > 0) {
+			GLuint clipMask	 = 0x80 >> (sClipPaths.size() - 1);
+			GLuint coverMask = clipMask - 1;
+
+			// Render shape to stencil buffer to use clear the clip-path.
+			ScopedColorMask	  scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+			ScopedStencilMask scpStencilMask(coverMask | clipMask); // Don't write to previous clip bits.
+
+			gl::ScopedState scpStencil(GL_STENCIL_TEST, GL_TRUE);
+			gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+			gl::stencilFunc(GL_ALWAYS, GLint(clipMask), coverMask);
+
+			glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+			glCoverFillPathNV(pathId, GL_CONVEX_HULL_NV); // Clear stencil buffer bits.
+		}
+		sClipPaths.pop_back();
+	}
+}
+
+Path Path::operator+(const Path& other) const {
+	Path path(*this);
+	path += other;
+	return path;
+}
+
+Path Path::operator-(const Path& other) const {
+	Path path(*this);
+	path -= other;
+	return path;
+}
+
+Path& Path::operator+=(const Path& other) {
+	if (mPathId > 0) {
+		// Get the commands and coords of the other path.
+		std::vector<GLubyte> commands;
+		std::vector<GLfloat> coords;
+		other.getPath(commands, coords);
+
+		GLint ourNumCommands = 0;
+		GLint ourNumCoords	 = 0;
+		glGetPathParameterivNV(mPathId, GL_PATH_COMMAND_COUNT_NV, &ourNumCommands);
+		glGetPathParameterivNV(mPathId, GL_PATH_COORD_COUNT_NV, &ourNumCoords);
+
+		glPathSubCommandsNV(mPathId, ourNumCommands, 0, static_cast<GLsizei>(commands.size()), commands.data(),
+							static_cast<GLsizei>(coords.size()), GL_FLOAT, coords.data());
+	} else
+		*this = Path(other);
+
+	return *this;
+}
+
+Path& Path::operator-=(const Path& other) {
+	*this += other.reversed();
+	return *this;
+}
+
+void Path::transform(const glm::mat3x2& m) const {
+	if (mPathId > 0) glTransformPathNV(mPathId, mPathId, GL_AFFINE_2D_NV, reinterpret_cast<const GLfloat*>(&m));
+}
+
+Path Path::transformed(const glm::mat3x2& m) const {
+	Path path(*this);
+	path.transform(m);
+	return path;
+}
+
+void Path::translate(float x, float y) const {
+	transform({1, 0, 0, 1, x, y});
+}
+
+Path Path::translated(float x, float y) const {
+	Path path(*this);
+	path.translate(x, y);
+	return path;
+}
+
+void Path::rotate(float radians) const {
+	if (mPathId > 0) {
+		const auto c = glm::cos(radians);
+		const auto s = glm::sin(radians);
+		transform({c, s, -s, c, 0, 0});
+	}
+}
+
+void Path::rotate(float radians, const vec2& center) const {
+	if (mPathId > 0) {
+		const auto c = glm::cos(radians);
+		const auto s = glm::sin(radians);
+		transform({c, s, -s, c, center.x - c * center.x + s * center.y, center.y - s * center.x - c * center.y});
+	}
+}
+
+Path Path::rotated(float radians) const {
+	Path path(*this);
+	path.rotate(radians);
+	return path;
+}
+
+Path Path::rotated(float radians, const vec2& center) const {
+	Path path(*this);
+	path.rotate(radians, center);
+	return path;
+}
+
+void Path::scale(float sx, float sy) const {
+	if (mPathId > 0) transform({sx, 0, 0, sy, 0, 0});
+}
+
+void Path::scale(float sx, float sy, const vec2& center) const {
+	if (mPathId > 0) transform({sx, 0, 0, sy, center.x - sx * center.x, center.y - sy * center.y});
+}
+
+void Path::scale(const vec2& s, const vec2& center) const {
+	if (mPathId > 0) scale(s.x, s.y, center);
+}
+
+Path Path::scaled(float sx, float sy) const {
+	Path path(*this);
+	path.scale(sx, sy);
+	return path;
+}
+
+Path Path::scaled(const vec2& s, const vec2& center) const {
+	Path path(*this);
+	path.scale(s, center);
+	return path;
+}
+
+void Path::skewX(float radiansX) const {
+	if (mPathId > 0) transform({1, 0, glm::tan(radiansX), 1, 0, 0});
+}
+
+void Path::skewY(float radiansY) const {
+	if (mPathId > 0) transform({1, glm::tan(radiansY), 0, 1, 0, 0});
+}
+
+void Path::skew(float radiansX, float radiansY) const {
+	if (mPathId > 0) transform({1, glm::tan(radiansY), glm::tan(radiansX), 1, 0, 0});
+}
+
+Path Path::skewedX(float radiansX) const {
+	Path path(*this);
+	path.skewX(radiansX);
+	return path;
+}
+
+Path Path::skewedY(float radiansY) const {
+	Path path(*this);
+	path.skewY(radiansY);
+	return path;
+}
+
+Path Path::skewed(float radiansX, float radiansY) const {
+	Path path(*this);
+	path.skew(radiansX, radiansY);
+	return path;
+}
+
+// void Path::optimize() const {
+//	if (mPathId > 0) {
+//		// Get the commands and coords of the path.
+//		std::vector<GLubyte> commands;
+//		std::vector<GLfloat> coords;
+//		getCommandsAndCoords(commands, coords);
+//
+//		// Optimize the path.
+//		optimizeImpl(commands, coords);
+//
+//		// Store the optimized path.
+//		glPathCommandsNV(mPathId, static_cast<GLsizei>(commands.size()), commands.data(),
+//						 static_cast<GLsizei>(coords.size()), GL_FLOAT, coords.data());
+//	}
+// }
+//
+// Path Path::optimized() const {
+//	Path path(*this);
+//	path.optimize();
+//	return path;
+// }
+
+void Path::reverse() const {
+	if (mPathId > 0) {
+		// Get the commands and coords of the path.
+		std::vector<GLubyte> commands;
+		std::vector<GLfloat> coords;
+		getPath(commands, coords);
+
+		// Reverse the path.
+		reverseImpl(commands, coords);
+
+		// Store the reversed path.
+		glPathCommandsNV(mPathId, static_cast<GLsizei>(commands.size()), commands.data(),
+						 static_cast<GLsizei>(coords.size()), GL_FLOAT, coords.data());
+	}
+}
+
+Path Path::reversed() const {
+	Path path(*this);
+	path.reverse();
+	return path;
+}
+
+bool Path::fillContains(const vec2& point) const {
+	if (mPathId > 0) return glIsPointInFillPathNV(mPathId, 0xFF, point.x, point.y);
+
+	return false;
+}
+
+bool Path::strokeContains(const vec2& point) const {
+	if (mPathId > 0) return glIsPointInStrokePathNV(mPathId, point.x, point.y);
+
+	return false;
+}
+
+Shape2d Path::toShape2d() const {
+	Shape2d result;
+
+	if (mPathId > 0) {
+		// Get the commands and coords of the path.
+		std::vector<GLubyte> commands;
+		std::vector<GLfloat> coords;
+		getPath(commands, coords);
+
+		GLfloat* coord = coords.data();
+		for (const auto cmd : commands) {
+			vec2 cp{0}, pep{0};
+
+			const auto& contours = result.getContours();
+			if (!contours.empty()) {
+				const auto& contour = contours.back();
+				const auto& points	= contour.getPoints();
+				if (!points.empty()) {
+					cp = points.back();
+					if (points.size() > 1) pep = points[points.size() - 2];
+				}
+			}
+
+			switch (cmd) {
+			case GL_MOVE_TO_NV:
+				result.moveTo(coord[0], coord[1]);
+				coord += 2;
+				break;
+			case GL_RELATIVE_MOVE_TO_NV:
+				result.moveTo(cp.x + coord[0], cp.y + coord[1]);
+				coord += 2;
+				break;
+			case GL_LINE_TO_NV:
+				result.lineTo(coord[0], coord[1]);
+				coord += 2;
+				break;
+			case GL_RELATIVE_LINE_TO_NV:
+				result.lineTo(cp.x + coord[0], cp.y + coord[1]);
+				coord += 2;
+				break;
+			case GL_HORIZONTAL_LINE_TO_NV:
+				result.lineTo(coord[0], cp.y);
+				coord += 1;
+				break;
+			case GL_RELATIVE_HORIZONTAL_LINE_TO_NV:
+				result.lineTo(cp.x + coord[0], cp.y);
+				coord += 1;
+				break;
+			case GL_VERTICAL_LINE_TO_NV:
+				result.lineTo(cp.x, coord[0]);
+				coord += 1;
+				break;
+			case GL_RELATIVE_VERTICAL_LINE_TO_NV:
+				result.lineTo(cp.x, cp.y + coord[0]);
+				coord += 1;
+				break;
+			case GL_QUADRATIC_CURVE_TO_NV:
+				result.quadTo(coords[0], coords[1], coords[2], coords[3]);
+				coord += 4;
+				break;
+			case GL_RELATIVE_QUADRATIC_CURVE_TO_NV:
+				result.quadTo(cp.x + coords[0], cp.y + coords[1], cp.x + coords[2], cp.y + coords[3]);
+				coord += 4;
+				break;
+			case GL_CUBIC_CURVE_TO_NV:
+				result.curveTo(coords[0], coords[1], coords[2], coords[3], coords[4], coords[5]);
+				coord += 6;
+				break;
+			case GL_RELATIVE_CUBIC_CURVE_TO_NV:
+				result.curveTo(cp.x + coords[0], cp.y + coords[1], cp.x + coords[2], cp.y + coords[3], cp.x + coords[4],
+							   cp.y + coords[5]);
+				coord += 6;
+				break;
+			case GL_SMOOTH_QUADRATIC_CURVE_TO_NV:
+				result.quadTo(2 * cp.x - pep.x, 2 * cp.y - pep.y, coords[0], coords[1]);
+				coord += 2;
+				break;
+			case GL_RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV:
+				result.quadTo(2 * cp.x - pep.x, 2 * cp.y - pep.y, cp.x + coords[0], cp.y + coords[1]);
+				break;
+			case GL_SMOOTH_CUBIC_CURVE_TO_NV:
+				result.curveTo(2 * cp.x - pep.x, 2 * cp.y - pep.y, coords[0], coords[1], coords[2], coords[3]);
+				coord += 4;
+				break;
+			case GL_RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV:
+				result.curveTo(2 * cp.x - pep.x, 2 * cp.y - pep.y, cp.x + coords[0], cp.y + coords[1], cp.x + coords[2],
+							   cp.y + coords[3]);
+				coord += 4;
+				break;
+			case GL_CLOSE_PATH_NV:
+				result.close();
+				break;
+			default:
+				throw std::runtime_error("Unknown path command");
+			}
+		}
+	}
+
+	return result;
+}
+
+GLint Path::getCoordCount(GLubyte command) {
+	switch (command) {
+	case GL_CLOSE_PATH_NV:
+	case GL_RESTART_PATH_NV:
+		return 0;
+	case GL_HORIZONTAL_LINE_TO_NV:
+	case GL_RELATIVE_HORIZONTAL_LINE_TO_NV:
+	case GL_VERTICAL_LINE_TO_NV:
+	case GL_RELATIVE_VERTICAL_LINE_TO_NV:
+		return 1;
+	case GL_MOVE_TO_NV:
+	case GL_RELATIVE_MOVE_TO_NV:
+	case GL_LINE_TO_NV:
+	case GL_RELATIVE_LINE_TO_NV:
+	case GL_SMOOTH_QUADRATIC_CURVE_TO_NV:
+	case GL_RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV:
+		return 2;
+	case GL_QUADRATIC_CURVE_TO_NV:
+	case GL_RELATIVE_QUADRATIC_CURVE_TO_NV:
+	case GL_SMOOTH_CUBIC_CURVE_TO_NV:
+	case GL_RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV:
+	case GL_DUP_FIRST_CUBIC_CURVE_TO_NV:
+	case GL_DUP_LAST_CUBIC_CURVE_TO_NV:
+	case GL_RECT_NV:
+	case GL_RELATIVE_RECT_NV:
+		return 4;
+	case GL_SMALL_CCW_ARC_TO_NV:
+	case GL_RELATIVE_SMALL_CCW_ARC_TO_NV:
+	case GL_SMALL_CW_ARC_TO_NV:
+	case GL_RELATIVE_SMALL_CW_ARC_TO_NV:
+	case GL_LARGE_CCW_ARC_TO_NV:
+	case GL_RELATIVE_LARGE_CCW_ARC_TO_NV:
+	case GL_LARGE_CW_ARC_TO_NV:
+	case GL_RELATIVE_LARGE_CW_ARC_TO_NV:
+	case GL_CONIC_CURVE_TO_NV:
+	case GL_RELATIVE_CONIC_CURVE_TO_NV:
+	case GL_ROUNDED_RECT_NV:
+	case GL_RELATIVE_ROUNDED_RECT_NV:
+	case GL_CIRCULAR_CCW_ARC_TO_NV:
+	case GL_CIRCULAR_CW_ARC_TO_NV:
+	case GL_CIRCULAR_TANGENT_ARC_TO_NV:
+		return 5;
+	case GL_CUBIC_CURVE_TO_NV:
+	case GL_RELATIVE_CUBIC_CURVE_TO_NV:
+	case GL_ROUNDED_RECT2_NV:
+	case GL_RELATIVE_ROUNDED_RECT2_NV:
+		return 6;
+	case GL_ARC_TO_NV:
+	case GL_RELATIVE_ARC_TO_NV:
+		return 7;
+	case GL_ROUNDED_RECT4_NV:
+	case GL_RELATIVE_ROUNDED_RECT4_NV:
+		return 8;
+	case GL_ROUNDED_RECT8_NV:
+	case GL_RELATIVE_ROUNDED_RECT8_NV:
+		return 12;
+	}
+
+	__debugbreak(); // Error!
+}
+
+GLint Path::getCoordOffset(GLubyte command) {
+	switch (command) {
+	case GL_MOVE_TO_NV:
+	case GL_RELATIVE_MOVE_TO_NV:
+	case GL_LINE_TO_NV:
+	case GL_RELATIVE_LINE_TO_NV:
+	case GL_HORIZONTAL_LINE_TO_NV:
+	case GL_RELATIVE_HORIZONTAL_LINE_TO_NV:
+	case GL_VERTICAL_LINE_TO_NV:
+	case GL_RELATIVE_VERTICAL_LINE_TO_NV:
+	case GL_SMOOTH_QUADRATIC_CURVE_TO_NV:
+	case GL_RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV:
+	case GL_RECT_NV:
+	case GL_RELATIVE_RECT_NV:
+		return 0;
+	case GL_QUADRATIC_CURVE_TO_NV:
+	case GL_RELATIVE_QUADRATIC_CURVE_TO_NV:
+	case GL_SMOOTH_CUBIC_CURVE_TO_NV:
+	case GL_RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV:
+	case GL_DUP_FIRST_CUBIC_CURVE_TO_NV:
+	case GL_DUP_LAST_CUBIC_CURVE_TO_NV:
+	case GL_CONIC_CURVE_TO_NV:
+	case GL_RELATIVE_CONIC_CURVE_TO_NV:
+		return 2;
+	case GL_SMALL_CCW_ARC_TO_NV:
+	case GL_RELATIVE_SMALL_CCW_ARC_TO_NV:
+	case GL_SMALL_CW_ARC_TO_NV:
+	case GL_RELATIVE_SMALL_CW_ARC_TO_NV:
+	case GL_LARGE_CCW_ARC_TO_NV:
+	case GL_RELATIVE_LARGE_CCW_ARC_TO_NV:
+	case GL_LARGE_CW_ARC_TO_NV:
+	case GL_RELATIVE_LARGE_CW_ARC_TO_NV:
+		return 3;
+	case GL_CUBIC_CURVE_TO_NV:
+	case GL_RELATIVE_CUBIC_CURVE_TO_NV:
+		return 4;
+	case GL_ARC_TO_NV:
+	case GL_RELATIVE_ARC_TO_NV:
+		return 5;
+	}
+
+	__debugbreak(); // Error!
+}
+
+GLubyte Path::toPathCommand(Path2d::SegmentType type) {
+	switch (type) {
+	case Path2d::SegmentType::MOVETO:
+		return GL_MOVE_TO_NV;
+	case Path2d::SegmentType::LINETO:
+		return GL_LINE_TO_NV;
+	case Path2d::SegmentType::QUADTO:
+		return GL_QUADRATIC_CURVE_TO_NV;
+	case Path2d::SegmentType::CUBICTO:
+		return GL_CUBIC_CURVE_TO_NV;
+	case Path2d::SegmentType::CLOSE:
+		return GL_CLOSE_PATH_NV;
+	}
+
+	return 0;
+}
+
+Paints& Path::getPaints() {
+	thread_local static Paints sGradients;
+	return sGradients;
+}
+
+void Path::optimizeImpl(std::vector<GLubyte>& commands, std::vector<GLfloat>& coords) {
+	std::vector<GLubyte> revcommands;
+	std::vector<GLfloat> revcoords;
+	vec2				 cp, np;
+
+	revcommands.reserve(commands.size());
+	revcoords.reserve(coords.size());
+
+	float* coord = coords.data();
+	for (const auto cmd : commands) {
+		switch (cmd) {
+		case GL_MOVE_TO_NV:
+			revcommands.push_back(GL_MOVE_TO_NV);
+			cp = *reinterpret_cast<vec2*>(coord);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			break;
+		case GL_RELATIVE_HORIZONTAL_LINE_TO_NV:
+			revcommands.push_back(cmd);
+			cp.x += *coord;
+			revcoords.push_back(*coord++);
+			break;
+		case GL_RELATIVE_VERTICAL_LINE_TO_NV:
+			revcommands.push_back(cmd);
+			cp.y += *coord;
+			revcoords.push_back(*coord++);
+			break;
+		case GL_RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV:
+			revcommands.push_back(cmd);
+			cp += *reinterpret_cast<vec2*>(coord);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			break;
+		case GL_RELATIVE_QUADRATIC_CURVE_TO_NV:
+		case GL_RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV:
+			revcommands.push_back(cmd);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			cp += *reinterpret_cast<vec2*>(coord);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			break;
+		case GL_RELATIVE_CUBIC_CURVE_TO_NV:
+			revcommands.push_back(cmd);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			cp += *reinterpret_cast<vec2*>(coord);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			break;
+		case GL_RELATIVE_ARC_TO_NV:
+			revcommands.push_back(cmd);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			cp += *reinterpret_cast<vec2*>(coord);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			break;
+		case GL_LINE_TO_NV:
+			np = *reinterpret_cast<vec2*>(coord);
+			coord += 2;
+			if (ds::approxEqual(cp.x, np.x)) {
+				revcommands.push_back(GL_RELATIVE_VERTICAL_LINE_TO_NV);
+				revcoords.push_back(np.y - cp.y);
+			} else if (ds::approxEqual(cp.y, np.y)) {
+				revcommands.push_back(GL_RELATIVE_HORIZONTAL_LINE_TO_NV);
+				revcoords.push_back(np.x - cp.x);
+			} else {
+				revcommands.push_back(GL_RELATIVE_LINE_TO_NV);
+				revcoords.push_back(np.x - cp.x);
+				revcoords.push_back(np.y - cp.y);
+			}
+			cp = np;
+			break;
+		case GL_HORIZONTAL_LINE_TO_NV:
+			revcommands.push_back(GL_RELATIVE_HORIZONTAL_LINE_TO_NV);
+			np.x = *coord++;
+			revcoords.push_back(np.x - cp.x);
+			cp.x = np.x;
+			break;
+		case GL_VERTICAL_LINE_TO_NV:
+			revcommands.push_back(GL_RELATIVE_VERTICAL_LINE_TO_NV);
+			np.y = *coord++;
+			revcoords.push_back(np.y - cp.y);
+			cp.y = np.y;
+			break;
+		case GL_QUADRATIC_CURVE_TO_NV:
+			revcommands.push_back(GL_RELATIVE_QUADRATIC_CURVE_TO_NV);
+			np = *reinterpret_cast<vec2*>(coord);
+			coord += 2;
+			revcoords.push_back(np.x - cp.x);
+			revcoords.push_back(np.y - cp.y);
+			np = *reinterpret_cast<vec2*>(coord);
+			coord += 2;
+			revcoords.push_back(np.x - cp.x);
+			revcoords.push_back(np.y - cp.y);
+			cp = np;
+			break;
+		case GL_CUBIC_CURVE_TO_NV:
+			revcommands.push_back(GL_RELATIVE_CUBIC_CURVE_TO_NV);
+			np = *reinterpret_cast<vec2*>(coord);
+			coord += 2;
+			revcoords.push_back(np.x - cp.x);
+			revcoords.push_back(np.y - cp.y);
+			np = *reinterpret_cast<vec2*>(coord);
+			coord += 2;
+			revcoords.push_back(np.x - cp.x);
+			revcoords.push_back(np.y - cp.y);
+			np = *reinterpret_cast<vec2*>(coord);
+			coord += 2;
+			revcoords.push_back(np.x - cp.x);
+			revcoords.push_back(np.y - cp.y);
+			cp = np;
+			break;
+		case GL_SMOOTH_QUADRATIC_CURVE_TO_NV:
+			coord += 2;
+			break;
+		case GL_SMOOTH_CUBIC_CURVE_TO_NV:
+			coord += 4;
+			break;
+		case GL_SMALL_CCW_ARC_TO_NV:
+			coord += 5;
+			break;
+		case GL_SMALL_CW_ARC_TO_NV:
+			coord += 5;
+			break;
+		case GL_LARGE_CCW_ARC_TO_NV:
+			coord += 5;
+			break;
+		case GL_LARGE_CW_ARC_TO_NV:
+			coord += 5;
+			break;
+		case GL_ARC_TO_NV:
+			revcommands.push_back(GL_RELATIVE_ARC_TO_NV);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			revcoords.push_back(*coord++);
+			np = *reinterpret_cast<vec2*>(coord);
+			coord += 2;
+			revcoords.push_back(np.x - cp.x);
+			revcoords.push_back(np.y - cp.y);
+			cp = np;
+			break;
+		case GL_CLOSE_PATH_NV:
+			revcommands.push_back(GL_CLOSE_PATH_NV);
+			break;
+		}
+	}
+
+	std::swap(commands, revcommands);
+	std::swap(coords, revcoords);
+}
+
+void Path::reverseImpl(std::vector<GLubyte>& commands, std::vector<GLfloat>& coords) {
+	// Optimize the path, so that we can more easily reverse it.
+	optimizeImpl(commands, coords);
+
+	// Find each sub-path and reverse it.
+	std::vector<GLubyte> revcommands;
+	std::vector<GLfloat> revcoords;
+
+	auto coordinate = coords.data();
+	auto startCmd	= commands.begin();
+	auto endCmd		= commands.begin();
+	while (endCmd != commands.end()) {
+		vec2 sp, cp;
+		sp = cp = *reinterpret_cast<vec2*>(coordinate);
+
+		coordinate += getCoordCount(*endCmd++);
+		// Find the end of the sub-path.
+		while (endCmd != commands.end() && *endCmd != GL_CLOSE_PATH_NV && *endCmd != GL_MOVE_TO_NV &&
+			   *endCmd != GL_RELATIVE_MOVE_TO_NV) {
+			switch (*endCmd) {
+			case GL_RELATIVE_HORIZONTAL_LINE_TO_NV:
+				cp.x += *coordinate;
+				break;
+			case GL_RELATIVE_VERTICAL_LINE_TO_NV:
+				cp.y += *coordinate;
+				break;
+			default:
+				cp += *reinterpret_cast<vec2*>(coordinate + getCoordOffset(*endCmd));
+				break;
+			}
+
+			coordinate += getCoordCount(*endCmd++);
+		}
+
+		// Reverse the sub-path.
+		revcommands.push_back(GL_MOVE_TO_NV);
+		if (*endCmd == GL_CLOSE_PATH_NV) {
+			revcoords.push_back(sp.x);
+			revcoords.push_back(sp.y);
+			if (ds::approxEqual(sp.x, cp.x)) {
+				if (!ds::approxEqual(sp.y, cp.y)) {
+					revcommands.push_back(GL_RELATIVE_VERTICAL_LINE_TO_NV);
+					revcoords.push_back(cp.y - sp.y);
+				}
+			} else if (ds::approxEqual(sp.y, cp.y)) {
+				if (!ds::approxEqual(sp.x, cp.x)) {
+					revcommands.push_back(GL_RELATIVE_HORIZONTAL_LINE_TO_NV);
+					revcoords.push_back(cp.x - sp.x);
+				}
+			} else {
+				revcommands.push_back(GL_RELATIVE_LINE_TO_NV);
+				revcoords.push_back(cp.x - sp.x);
+				revcoords.push_back(cp.y - sp.y);
+			}
+		} else {
+			revcoords.push_back(cp.x);
+			revcoords.push_back(cp.y);
+			sp = cp;
+		}
+
+		auto coord = coordinate;
+		auto cmd   = endCmd;
+		while (--cmd != startCmd) {
+			revcommands.push_back(*cmd);
+			coord -= getCoordCount(*cmd);
+			switch (*cmd) {
+			case GL_RELATIVE_HORIZONTAL_LINE_TO_NV:
+				revcoords.push_back(-coord[0]);
+				cp.x -= *coord;
+				break;
+			case GL_RELATIVE_VERTICAL_LINE_TO_NV:
+				revcoords.push_back(-coord[0]);
+				cp.y -= *coord;
+				break;
+			case GL_RELATIVE_LINE_TO_NV:
+			case GL_RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV: // Not tested.
+				revcoords.push_back(-coord[0]);
+				revcoords.push_back(-coord[1]);
+				cp -= *reinterpret_cast<vec2*>(coord);
+				break;
+			case GL_RELATIVE_QUADRATIC_CURVE_TO_NV:
+			case GL_SMOOTH_CUBIC_CURVE_TO_NV: // Not tested.
+				revcoords.push_back(coord[0] - coord[2]);
+				revcoords.push_back(coord[1] - coord[3]);
+				revcoords.push_back(-coord[2]);
+				revcoords.push_back(-coord[3]);
+				cp -= *reinterpret_cast<vec2*>(coord + 2);
+				break;
+			case GL_RELATIVE_CUBIC_CURVE_TO_NV:
+				revcoords.push_back(coord[2] - coord[4]);
+				revcoords.push_back(coord[3] - coord[5]);
+				revcoords.push_back(coord[0] - coord[4]);
+				revcoords.push_back(coord[1] - coord[5]);
+				revcoords.push_back(-coord[4]);
+				revcoords.push_back(-coord[5]);
+				cp -= *reinterpret_cast<vec2*>(coord + 4);
+				break;
+			case GL_RELATIVE_ARC_TO_NV:
+				revcoords.push_back(coord[0]);
+				revcoords.push_back(coord[1]);
+				revcoords.push_back(coord[2]);
+				revcoords.push_back(coord[3]);
+				revcoords.push_back(1.0f - coord[4]);
+				revcoords.push_back(-coord[5]);
+				revcoords.push_back(-coord[6]);
+				cp -= *reinterpret_cast<vec2*>(coord + 5);
+				break;
+				// TODO: small and large arcs + conics.
+			}
+		}
+
+		// Use CLOSE_PATH_NV if applicable.
+		if (ds::approxEqual(sp.x, cp.x) && ds::approxEqual(sp.y, cp.y)) {
+			if (revcommands.back() == GL_RELATIVE_LINE_TO_NV ||
+				revcommands.back() == GL_RELATIVE_HORIZONTAL_LINE_TO_NV ||
+				revcommands.back() == GL_RELATIVE_VERTICAL_LINE_TO_NV) {
+				for (size_t i = 0; i < getCoordCount(revcommands.back()); ++i)
+					revcoords.pop_back();
+				revcommands.pop_back();
+				revcommands.push_back(GL_CLOSE_PATH_NV);
+			}
+		}
+
+		++endCmd;
+	}
+
+	std::swap(commands, revcommands);
+	std::swap(coords, revcoords);
+}
+
+void Path::getPath(std::vector<GLubyte>& commands, std::vector<GLfloat>& coords) const {
+	if (mPathId > 0) {
+		GLint numCommands;
+		glGetPathParameterivNV(mPathId, GL_PATH_COMMAND_COUNT_NV, &numCommands);
+		GLint numCoords;
+		glGetPathParameterivNV(mPathId, GL_PATH_COORD_COUNT_NV, &numCoords);
+
+		commands.resize(numCommands);
+		glGetPathCommandsNV(mPathId, commands.data());
+
+		coords.resize(numCoords);
+		glGetPathCoordsNV(mPathId, coords.data());
+	}
+}
+
+void Path::setPath(const std::vector<GLubyte>& commands, const std::vector<GLfloat>& coords) {
+	if (hasNvPathRendering()) {
+		if (!mPathId) mPathId = glGenPathsNV(1);
+
+		glPathCommandsNV(mPathId, static_cast<GLsizei>(commands.size()), commands.data(),
+						 static_cast<GLsizei>(coords.size()), GL_FLOAT, coords.data());
+	} else
+		reportNoNvPathRendering();
+}
+
+void Path::setPath(const std::string& svg) {
+	if (hasNvPathRendering()) {
+		if (!mPathId) mPathId = glGenPathsNV(1);
+
+		gl::pathStringNV(mPathId, GL_PATH_FORMAT_SVG_NV, static_cast<GLsizei>(svg.length()), svg.c_str());
+	} else
+		reportNoNvPathRendering();
+}
+
+void PathHelper::set(const Path& path) {
+	mCommands.clear();
+	mCoords.clear();
+	path.getPath(mCommands, mCoords);
+}
+
+void PathHelper::removeLastCommand() {
+	if (!mCommands.empty()) {
+		const auto count = getCoordCount(mCommands.back());
+		mCommands.pop_back();
+		mCoords.resize(mCoords.size() - count);
+	}
+}
+
+bool PathHelper::isSelfIntersecting() const {
+	if (mCommands.size() < 3) return false;
+
+	std::vector<vec2> intersections;
+
+	const float* a = mCoords.data();
+	for (size_t i = 1; i + 1 < mCommands.size(); ++i) {
+		const float* b = a + getCoordCount(mCommands[i]);
+		for (size_t j = i + 1; j < mCommands.size(); ++j) {
+			switch (mCommands[i]) {
+			case GL_LINE_TO_NV:
+				switch (mCommands[j]) {
+				case GL_LINE_TO_NV:
+					intersections = intersectLineLine(util::Line{a}, util::Line{b});
+					if (!intersections.empty()) return true;
+					break;
+				case GL_QUADRATIC_CURVE_TO_NV:
+					intersections = intersectLineQuad(util::Line{a}, util::QuadraticCurve{b});
+					if (!intersections.empty()) return true;
+					break;
+				case GL_CUBIC_CURVE_TO_NV:
+					intersections = intersectLineCubic(util::Line{a}, util::CubicCurve{b});
+					if (!intersections.empty()) return true;
+					break;
+				case GL_ARC_TO_NV:
+					intersections = intersectLineArc(util::Line{a}, util::Arc{b});
+					if (!intersections.empty()) return true;
+					break;
+				}
+
+				break;
+			case GL_QUADRATIC_CURVE_TO_NV:
+				switch (mCommands[j]) {
+				case GL_LINE_TO_NV:
+					intersections = intersectLineQuad(util::Line{b}, util::QuadraticCurve{a});
+					if (!intersections.empty()) return true;
+					break;
+				}
+				break;
+			case GL_CUBIC_CURVE_TO_NV:
+				switch (mCommands[j]) {
+				case GL_LINE_TO_NV:
+					intersections = intersectLineCubic(util::Line{b}, util::CubicCurve{a});
+					if (!intersections.empty()) return true;
+					break;
+				}
+				break;
+			case GL_ARC_TO_NV:
+				switch (mCommands[j]) {
+				case GL_LINE_TO_NV:
+					intersections = intersectLineArc(util::Line{b}, util::Arc{a});
+					if (!intersections.empty()) return true;
+					break;
+				case GL_ARC_TO_NV:
+					intersections = intersectArcArc(util::Arc{b}, util::Arc{a});
+					if (!intersections.empty()) return true;
+					break;
+				}
+				break;
+			}
+			b += getCoordCount(mCommands[j]);
+		}
+		a += getCoordCount(mCommands[i]);
+	}
+
+	return false;
+}
+
+bool PathHelper::isIntersecting(const PathHelper& other) const {
+	if (this == &other) return true;
+
+	if (mCommands.size() < 2) return false;
+	if (other.mCommands.size() < 2) return false;
+
+	std::vector<vec2> intersections;
+
+	const float* a = mCoords.data();
+	for (size_t i = 1; i < mCommands.size(); ++i) {
+		const float* b = other.mCoords.data();
+		for (size_t j = 1; j < other.mCommands.size(); ++j) {
+			switch (mCommands[i]) {
+			case GL_LINE_TO_NV:
+				switch (other.mCommands[j]) {
+				case GL_LINE_TO_NV:
+					intersections = intersectLineLine(util::Line{a}, util::Line{b});
+					if (!intersections.empty()) return true;
+					break;
+				case GL_QUADRATIC_CURVE_TO_NV:
+					intersections = intersectLineQuad(util::Line{a}, util::QuadraticCurve{b});
+					if (!intersections.empty()) return true;
+					break;
+				case GL_CUBIC_CURVE_TO_NV:
+					intersections = intersectLineCubic(util::Line{a}, util::CubicCurve{b});
+					if (!intersections.empty()) return true;
+					break;
+				case GL_ARC_TO_NV:
+					intersections = intersectLineArc(util::Line{a}, util::Arc{b});
+					if (!intersections.empty()) return true;
+					break;
+				}
+
+				break;
+			case GL_QUADRATIC_CURVE_TO_NV:
+				switch (other.mCommands[j]) {
+				case GL_LINE_TO_NV:
+					intersections = intersectLineQuad(util::Line{b}, util::QuadraticCurve{a});
+					if (!intersections.empty()) return true;
+					break;
+				}
+				break;
+			case GL_CUBIC_CURVE_TO_NV:
+				switch (other.mCommands[j]) {
+				case GL_LINE_TO_NV:
+					intersections = intersectLineCubic(util::Line{b}, util::CubicCurve{a});
+					if (!intersections.empty()) return true;
+					break;
+				}
+				break;
+			case GL_ARC_TO_NV:
+				switch (other.mCommands[j]) {
+				case GL_LINE_TO_NV:
+					intersections = intersectLineArc(util::Line{b}, util::Arc{a});
+					if (!intersections.empty()) return true;
+					break;
+				case GL_ARC_TO_NV:
+					intersections = intersectArcArc(util::Arc{b}, util::Arc{a});
+					if (!intersections.empty()) return true;
+					break;
+				}
+				break;
+			}
+
+			b += getCoordCount(other.mCommands[j]);
+		}
+		a += getCoordCount(mCommands[i]);
+	}
+
+	return false;
+}
+
+void PathHelper::moveTo(float x, float y) {
+	mCommands.push_back(GL_MOVE_TO_NV);
+	mCoords.push_back(x);
+	mCoords.push_back(y);
+}
+
+void PathHelper::lineTo(float x, float y) {
+	assert(!mCommands.empty()); // First command must be GL_MOVE_TO_NV.
+	mCommands.push_back(GL_LINE_TO_NV);
+	mCoords.push_back(x);
+	mCoords.push_back(y);
+}
+
+void PathHelper::quadTo(float x1, float y1, float x2, float y2) {
+	assert(!mCommands.empty()); // First command must be GL_MOVE_TO_NV.
+	mCommands.push_back(GL_QUADRATIC_CURVE_TO_NV);
+	mCoords.push_back(x1);
+	mCoords.push_back(y1);
+	mCoords.push_back(x2);
+	mCoords.push_back(y2);
+}
+
+void PathHelper::curveTo(float x1, float y1, float x2, float y2, float x3, float y3) {
+	assert(!mCommands.empty()); // First command must be GL_MOVE_TO_NV.
+	mCommands.push_back(GL_CUBIC_CURVE_TO_NV);
+	mCoords.push_back(x1);
+	mCoords.push_back(y1);
+	mCoords.push_back(x2);
+	mCoords.push_back(y2);
+	mCoords.push_back(x3);
+	mCoords.push_back(y3);
+}
+
+void PathHelper::horizontalLineTo(float x) {
+	assert(!mCommands.empty()); // First command must be GL_MOVE_TO_NV.
+	mCommands.push_back(GL_HORIZONTAL_LINE_TO_NV);
+	mCoords.push_back(x);
+}
+
+void PathHelper::verticalLineTo(float y) {
+	assert(!mCommands.empty()); // First command must be GL_MOVE_TO_NV.
+	mCommands.push_back(GL_VERTICAL_LINE_TO_NV);
+	mCoords.push_back(y);
+}
+
+void PathHelper::smoothQuadTo(float x2, float y2) {
+	assert(!mCommands.empty()); // First command must be GL_MOVE_TO_NV.
+	mCommands.push_back(GL_SMOOTH_QUADRATIC_CURVE_TO_NV);
+	mCoords.push_back(x2);
+	mCoords.push_back(y2);
+}
+
+void PathHelper::smoothCurveTo(float x2, float y2, float x3, float y3) {
+	assert(!mCommands.empty()); // First command must be GL_MOVE_TO_NV.
+	mCommands.push_back(GL_SMOOTH_CUBIC_CURVE_TO_NV);
+	mCoords.push_back(x2);
+	mCoords.push_back(y2);
+	mCoords.push_back(x3);
+	mCoords.push_back(y3);
+}
+
+void PathHelper::arcTo(float radiusX, float radiusY, float xAxisRotation, bool large, bool sweep, float x, float y) {
+	assert(!mCommands.empty()); // First command must be GL_MOVE_TO_NV.
+	mCommands.push_back(GL_ARC_TO_NV);
+	mCoords.push_back(radiusX);
+	mCoords.push_back(radiusY);
+	mCoords.push_back(xAxisRotation);
+	mCoords.push_back(large ? 1.0f : 0.0f);
+	mCoords.push_back(sweep ? 1.0f : 0.0f);
+	mCoords.push_back(x);
+	mCoords.push_back(y);
+}
+
+void PathHelper::close() {
+	assert(!mCommands.empty()); // First command must be GL_MOVE_TO_NV.
+	mCommands.push_back(GL_CLOSE_PATH_NV);
+}
+
+// void PathCommands::arc(float centerX, float centerY, float radius, float startRadians, float endRadians, bool
+// forward) {
+//	// TODO: Implement.
+// }
+//
+// void PathCommands::arcTo(float x, float y, float tanX, float tanY, float radius) {
+//	// TODO: Implement.
+// }
+
+size_t PathHelper::getCoordCount(GLubyte command) {
+	switch (command) {
+	case GL_HORIZONTAL_LINE_TO_NV:
+	case GL_VERTICAL_LINE_TO_NV:
+		return 1;
+	case GL_MOVE_TO_NV:
+	case GL_LINE_TO_NV:
+	case GL_SMOOTH_QUADRATIC_CURVE_TO_NV:
+		return 2;
+	case GL_QUADRATIC_CURVE_TO_NV:
+	case GL_SMOOTH_CUBIC_CURVE_TO_NV:
+		return 4;
+	case GL_CUBIC_CURVE_TO_NV:
+		return 6;
+	case GL_ARC_TO_NV:
+		return 7;
+	default:
+		return 0;
+	}
+}
+
+Shader::Shader(Type type)
+  : mType(type) {
+	switch (type) {
+	case Type::SOLID_COLOR: {
+		static const char* glsl = "#version 330 core\n"
+								  "#extension GL_ARB_separate_shader_objects : enable\n"
+								  "precision highp float;"
+								  "layout(location = 0) in vec4 color;"
+								  "uniform float opacity = 1.0;"
+								  "uniform bool premultiplied = false;"
+								  "out vec4 fragColor;"
+								  "void main() {"
+								  "    fragColor = color;"
+								  "    fragColor.a *= opacity;"
+								  "    if(premultiplied) fragColor.rgb *= fragColor.a;"
+								  "}";
+
+		mProgram = glCreateShaderProgramv(GL_FRAGMENT_SHADER, 1, &glsl);
+		break;
+	}
+	case Type::LINEAR_GRADIENT: {
+		static const char* glsl =
+			"#version 330 core\n"
+			"#extension GL_ARB_separate_shader_objects : enable\n"
+			"precision highp float;"
+			"const  float NOISE_GRANULARITY = 0.5/127.0;" // Assumes 8-bit color, see below.
+			"layout(location = 0) in vec4 color;"
+			"layout(location = 1) in vec2 uv;"
+			"uniform float index = 0.5;"
+			"uniform float opacity = 1.0;"
+			"uniform bool premultiplied = false;"
+			"uniform sampler2D gradTab;"
+			"uniform vec2 gradStart;"
+			"uniform vec2 gradEnd;"
+			"out vec4 fragColor;"
+			"float random( vec2 coords) {"
+			"    return fract(sin(dot(coords.xy, vec2(12.9898,78.233))) * 43758.5453);"
+			"}"
+			"void main() {"
+			"    vec2 gradVec = gradEnd - gradStart;"
+			"    float gradTabIndex = dot(gradVec, uv - gradStart) / (gradVec.x * gradVec.x + gradVec.y * "
+			"gradVec.y);"
+			"    fragColor = texture(gradTab, vec2(gradTabIndex, index));"
+			// The following line of code reduces color banding for 8-bit color, see:
+			// https://shader-tutorial.dev/advanced/color-banding-dithering/
+			"    fragColor.rgb += vec3(mix(-NOISE_GRANULARITY, NOISE_GRANULARITY, random(gl_FragCoord.xy * 0.01)));"
+			"    fragColor.a *= opacity;"
+			"    if(premultiplied) fragColor.rgb *= fragColor.a;"
+			"}";
+
+		mProgram = glCreateShaderProgramv(GL_FRAGMENT_SHADER, 1, &glsl);
+		break;
+	}
+	case Type::RADIAL_GRADIENT: {
+		static const char* glsl =
+			"#version 330 core\n"
+			"#extension GL_ARB_separate_shader_objects : enable\n"
+			"precision highp float;"
+			"const  float NOISE_GRANULARITY = 0.5/127.0;" // Assumes 8-bit color, see below.
+			"uniform sampler2D gradTab;"
+			"uniform float index = 0.5;"
+			"uniform float opacity = 1.0;"
+			"uniform bool premultiplied = false;"
+			"uniform vec2 focalToCenter;"
+			"uniform float centerRadius;"
+			"uniform float focalRadius;"
+			"uniform vec2 translationPoint;"
+			"layout(location = 0) in vec4 color;"
+			"layout(location = 1) in vec2 uv;"
+			"out vec4 fragColor;"
+			"float random( vec2 coords) {"
+			"    return fract(sin(dot(coords.xy, vec2(12.9898,78.233))) * 43758.5453);"
+			"}"
+			"void main() {"
+			"    vec2 coord = uv - translationPoint;"
+			"    float rd = centerRadius - focalRadius;"
+			"    float b = 2.0 * (rd * focalRadius + dot(coord, focalToCenter));"
+			"    float fmp2_m_radius2 = -focalToCenter.x * focalToCenter.x - focalToCenter.y * focalToCenter.y + "
+			"rd * "
+			"rd;"
+			"    float inverse_2_fmp2_m_radius2 = 1.0 / (2.0 * fmp2_m_radius2);"
+			"    float det = b * b - 4.0 * fmp2_m_radius2 * ((focalRadius * focalRadius) - dot(coord, coord));"
+			"    fragColor = vec4(0.0);"
+			"    if (det >= 0.0) {"
+			"        float detSqrt = sqrt(det);"
+			"        float w = max((-b - detSqrt) * inverse_2_fmp2_m_radius2, (-b + detSqrt) * "
+			"inverse_2_fmp2_m_radius2);"
+			"        if (focalRadius + w * (centerRadius - focalRadius) >= 0.0)"
+			"            fragColor = texture(gradTab, vec2(w, index));"
+			"    }"
+			// The following line of code reduces color banding for 8-bit color, see:
+			// https://shader-tutorial.dev/advanced/color-banding-dithering/
+			"    fragColor.rgb += vec3(mix(-NOISE_GRANULARITY, NOISE_GRANULARITY, random(gl_FragCoord.xy * 0.01)));"
+			"    fragColor.a *= opacity;"
+			"    if(premultiplied) fragColor.rgb *= fragColor.a;"
+			"}";
+
+		mProgram = glCreateShaderProgramv(GL_FRAGMENT_SHADER, 1, &glsl);
+		break;
+	}
+	case Type::CONICAL_GRADIENT: { // UNTESTED
+		static const char* glsl = "#version 330 core\n"
+								  "#extension GL_ARB_separate_shader_objects : enable\n"
+								  "precision highp float;"
+								  "#define INVERSE_2PI 0.1591549430918953358"
+								  "uniform sampler2D gradTab;"
+								  "uniform float index = 0.5;"
+								  "uniform float opacity = 1.0;"
+								  "uniform bool premultiplied = false;"
+								  "uniform float angle;"
+								  "uniform vec2 translationPoint;"
+								  "layout(location = 0) in vec4 color;"
+								  "layout(location = 1) in vec2 uv;"
+								  "out vec4 fragColor;"
+								  "void main() {"
+								  "    vec2 coord = uv - translationPoint;"
+								  "    float t;"
+								  "    if (abs(coord.y) == abs(coord.x))"
+								  "        t = (atan(-coord.y + 0.002, coord.x) + angle) * INVERSE_2PI;"
+								  "    else"
+								  "        t = (atan(-coord.y, coord.x) + angle) * INVERSE_2PI;"
+								  "    fragColor = texture(gradTab, vec2(t - floor(t), index));"
+								  "    fragColor.a *= opacity;"
+								  "    if(premultiplied) fragColor.rgb *= fragColor.a;"
+								  "}";
+
+		mProgram = glCreateShaderProgramv(GL_FRAGMENT_SHADER, 1, &glsl);
+		break;
+	}
+	case Type::IMAGE: {
+		static const char* glsl =
+			"#version 330 core\n"
+			"#extension GL_ARB_separate_shader_objects : enable\n"
+			"precision highp float;"
+			"uniform sampler2D image;"
+			"uniform float opacity = 1.0;"
+			"uniform bool premultiplied = false;"
+			"layout(location = 0) in vec4 color;"
+			"layout(location = 1) in vec2 uv;"
+			"out vec4 fragColor;"
+			"void main() {"
+			"    fragColor = texture(image, vec2( uv.x, 1.0 - uv.y ) );" // Flip texture vertically.
+			"    if( uv.x < 0 || uv.y < 0 || uv.x > 1 || uv.y > 1 ) {"
+			"        fragColor.a = 0;"
+			"    }"
+			"    fragColor.a *= opacity;"
+			"    if(premultiplied) fragColor.rgb *= fragColor.a;"
+			"}";
+
+		mProgram = glCreateShaderProgramv(GL_FRAGMENT_SHADER, 1, &glsl);
+		break;
+	}
+	default:
+		mProgram = 0;
+		break;
+	}
+
+	GLint status = 0;
+	glGetProgramiv(mProgram, GL_LINK_STATUS, &status);
+	if (!status) {
+		// error!
+		GLchar	buffer[2048];
+		GLsizei length = 0;
+		glGetProgramInfoLog(mProgram, 2048, &length, buffer);
+		CI_LOG_E(std::string(buffer, length));
+
+		return;
+	}
+
+	glGenProgramPipelines(1, &mPipeline);
+	glUseProgramStages(mPipeline, GL_FRAGMENT_SHADER_BIT, mProgram);
+	glActiveShaderProgram(mPipeline, mProgram);
+	glValidateProgramPipeline(mPipeline);
+
+	status = 0;
+	glGetProgramPipelineiv(mPipeline, GL_VALIDATE_STATUS, &status);
+	if (!status) {
+		// error!
+		GLchar	buffer[2048];
+		GLsizei length = 0;
+		glGetProgramInfoLog(mProgram, 2048, &length, buffer);
+		CI_LOG_E(std::string(buffer, length));
+
+		return;
+	}
+
+	switch (type) {
+	case Type::LINEAR_GRADIENT:
+	case Type::RADIAL_GRADIENT:
+	case Type::CONICAL_GRADIENT:
+	case Type::IMAGE: {
+		const GLfloat data[6] = {1, 0, 0, 0, 1, 0};
+		glProgramPathFragmentInputGenNV(mProgram, 0, GL_PATH_OBJECT_BOUNDING_BOX_NV, 2, &data[0]);
+		break;
+	}
+	case Type::SOLID_COLOR: {
+		break;
+	}
+	default:
+		break;
+	}
+}
+
+Shader::~Shader() {
+	if (mPipeline) glDeleteProgramPipelines(1, &mPipeline);
+	if (mProgram) glDeleteProgram(mProgram);
+
+	mProgram  = 0;
+	mPipeline = 0;
+}
+
+void Shader::bind() const {
+	if (mPipeline) glBindProgramPipeline(mPipeline);
+}
+
+void Shader::unbind() {
+	glBindProgramPipeline(0);
+}
+
+void Shader::uniform(const std::string& name, GLint value) const {
+	if (mPipeline && mProgram) {
+		if (const GLint loc = glGetProgramResourceLocation(mProgram, GL_UNIFORM, name.c_str()); loc >= 0)
+			glProgramUniform1i(mProgram, loc, value);
+	}
+}
+
+void Shader::uniform(const std::string& name, GLfloat value) const {
+	if (mPipeline && mProgram) {
+		if (const GLint loc = glGetProgramResourceLocation(mProgram, GL_UNIFORM, name.c_str()); loc >= 0)
+			glProgramUniform1f(mProgram, loc, value);
+	}
+}
+
+void Shader::uniform(const std::string& name, const vec2& value) const {
+	if (mPipeline && mProgram) {
+		if (const GLint loc = glGetProgramResourceLocation(mProgram, GL_UNIFORM, name.c_str()); loc >= 0)
+			glProgramUniform2fv(mProgram, loc, 1, value_ptr(value));
+	}
+}
+
+void Shader::uniform(const std::string& name, const vec3& value) const {
+	if (mPipeline && mProgram) {
+		if (const GLint loc = glGetProgramResourceLocation(mProgram, GL_UNIFORM, name.c_str()); loc >= 0)
+			glProgramUniform3fv(mProgram, loc, 1, value_ptr(value));
+	}
+}
+
+void Shader::uniform(const std::string& name, const vec4& value) const {
+	if (mPipeline && mProgram) {
+		if (const GLint loc = glGetProgramResourceLocation(mProgram, GL_UNIFORM, name.c_str()); loc >= 0)
+			glProgramUniform4fv(mProgram, loc, 1, value_ptr(value));
+	}
+}
+
+void Shader::uniform(const std::string& name, const mat3& value) const {
+	if (mPipeline && mProgram) {
+		if (const GLint loc = glGetProgramResourceLocation(mProgram, GL_UNIFORM, name.c_str()); loc >= 0)
+			glProgramUniformMatrix3fv(mProgram, loc, 1, false, value_ptr(value));
+	}
+}
+
+void Shader::uniform(const std::string& name, const glm::mat3x2& value) const {
+	if (mPipeline && mProgram) {
+		if (const GLint loc = glGetProgramResourceLocation(mProgram, GL_UNIFORM, name.c_str()); loc >= 0)
+			glProgramUniformMatrix3x2fv(mProgram, loc, 1, false, value_ptr(value));
+	}
+}
+
+void Shader::uniform(const std::string& name, const mat4& value) const {
+	if (mPipeline && mProgram) {
+		if (const GLint loc = glGetProgramResourceLocation(mProgram, GL_UNIFORM, name.c_str()); loc >= 0)
+			glProgramUniformMatrix4fv(mProgram, loc, 1, false, value_ptr(value));
+	}
+}
+
+void Shader::setColor(const ColorA& color) const {
+	glProgramPathFragmentInputGenNV(mProgram, 0, GL_CONSTANT_NV, 4, color.ptr());
+}
+
+ScopedShader::ScopedShader(Shader::Type type)
+  : mCtx(gl::context()) {
+	mShader = Cache::loadShader(type);
+	mShader->bind();
+	mShader->uniform("premultiplied", isPreMultiplied());
+}
+
+ScopedShader::ScopedShader(const ColorA& color, float opacity)
+  : ScopedShader(Shader::Type::SOLID_COLOR) {
+	mShader->setColor(color);
+	mShader->uniform("opacity", opacity);
+	mShader->uniform("premultiplied", isPreMultiplied());
+}
+
+ScopedShader::~ScopedShader() {
+	if (mShader) mShader->unbind();
+}
+
+ShaderRef Cache::loadShader(Shader::Type type) {
+	Cache& self = get();
+
+	if (self.mShaders.count(type) && static_cast<bool>(self.mShaders.at(type))) {
+		return self.mShaders.at(type);
+	}
+
+	CI_LOG_V("Creating shader (" << std::this_thread::get_id() << ")");
+	auto shader = Shader::create(type);
+	self.mShaders.insert_or_assign(type, shader);
+
+	return shader;
+}
+
+void Cache::clean() {
+	auto& shaders = get().mShaders;
+	for (auto itr = shaders.begin(); itr != shaders.end();) {
+		const auto& item = *itr;
+		if (item.second.use_count() < 2) {
+			CI_LOG_V("Removing shader (" << std::this_thread::get_id() << ")");
+			itr = shaders.erase(itr);
+		} else
+			++itr;
+	}
+}
+
+void Cache::clear() {
+	CI_LOG_V("Removing all shaders (" << std::this_thread::get_id() << ")");
+	get().mShaders.clear();
+}
+
+Canvas::Canvas(int samples, int coverageSamples, bool useFloats)
+  : mSamples(samples)
+  , mCoverageSamples(coverageSamples)
+  , mUseFloats(useFloats) {}
+
+Canvas::Canvas(int width, int height, int samples, int coverageSamples, bool useFloats)
+  : mWidth(width)
+  , mHeight(height)
+  , mSamples(samples)
+  , mCoverageSamples(coverageSamples)
+  , mUseFloats(useFloats) {}
+
+void Canvas::bind() const {
+	if (!mIsBound) {
+		if (!mFbo) {
+			mCtx = gl::context();
+			mFbo = gl::Fbo::create(mWidth, mHeight, getFboFormat());
+		}
+		if (mCtx == gl::context()) {
+			mCtx->pushFramebuffer(mFbo);
+			mCtx->pushViewport(std::make_pair(ivec2(0), mFbo->getSize()));
+			mCtx->pushGlslProg(nullptr);
+			gl::pushMatrices();
+			gl::pushModelMatrix();
+			gl::setMatricesWindow(mWidth, mHeight);
+			gl::popModelMatrix();
+			glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+			glMatrixLoadfEXT(GL_PROJECTION, value_ptr(gl::getProjectionMatrix()));
+			gl::clearColor(ColorA(0, 0, 0, 0));
+			gl::clear(GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+			gl::clearStencil(0);
+			gl::stencilMask(~0);
+			mIsBound = true;
+		}
+	}
+}
+
+void Canvas::unbind() const {
+	if (mIsBound && mCtx == gl::context()) {
+		mIsBound = false;
+		gl::popMatrices();
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glMatrixLoadfEXT(GL_PROJECTION, value_ptr(gl::getProjectionMatrix()));
+		mCtx->popGlslProg(true);
+		mCtx->popViewport();
+		mCtx->popFramebuffer();
+	}
+}
+
+void Canvas::draw() const {
+	if (mFbo && !mIsBound) {
+		// Use pre-multiplied alpha!
+		gl::ScopedBlendPremult scpBlend;
+		gl::draw(mFbo->getColorTexture());
+	}
+}
+
+void Canvas::draw(const Rectf& bounds) const {
+	if (mFbo && !mIsBound) {
+		gl::draw(mFbo->getColorTexture(), bounds);
+	}
+}
+
+gl::Texture2dRef Canvas::getTexture(GLenum attachment) const {
+	if (mFbo) return mFbo->getTexture2d(attachment);
+
+	return nullptr;
+}
+
+gl::Fbo::Format Canvas::getFboFormat() const {
+	if (mUseFloats) {
+		// Using GL_NEAREST, we try to avoid additional blurring of the final image.
+		const auto format = gl::Texture2d::Format()
+								.internalFormat(GL_RGBA16F)
+								.dataType(GL_FLOAT)
+								.minFilter(GL_NEAREST)
+								.magFilter(GL_NEAREST);
+		return gl::Fbo::Format()
+			.samples(mSamples)
+			.coverageSamples(mCoverageSamples)
+			.stencilBuffer()
+			.disableDepth()
+			.colorTexture(format);
+	}
+
+	// Using GL_NEAREST, we try to avoid additional blurring of the final image.
+	const auto format = gl::Texture2d::Format().minFilter(GL_NEAREST).magFilter(GL_NEAREST);
+	return gl::Fbo::Format()
+		.samples(mSamples)
+		.coverageSamples(mCoverageSamples)
+		.stencilBuffer()
+		.disableDepth()
+		.colorTexture(format);
+}
+
+void Canvas::resize(const ivec2& size) {
+	if (size.x > 0 && size.y > 0 && (mWidth != size.x || mHeight != size.y)) {
+		mWidth	= size.x;
+		mHeight = size.y;
+
+		const bool isBound = mIsBound;
+		if (isBound) unbind();
+
+		mFbo.reset();
+
+		if (isBound) bind();
+	}
+}
+
+ScopedPathRendering::ScopedPathRendering()
+  : mCtx(gl::context()) {
+	mColor = mCtx->getCurrentColor();
+
+	mCtx->setCurrentColor(Color::white());
+	mCtx->pushGlslProg(nullptr);
+
+	// Use pre-multiplied alpha blending.
+	// mCtx->pushBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+
+	gl::matrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+	gl::matrixLoadfEXT(GL_PROJECTION, value_ptr(gl::getProjectionMatrix()));
+}
+
+ScopedPathRendering::~ScopedPathRendering() {
+	// mCtx->popBlendFuncSeparate();
+	mCtx->popGlslProg();
+	mCtx->setCurrentColor(mColor);
+}
+
+ScopedCover::ScopedCover(bool clearStencil)
+  : mCtx(gl::context()) {
+	mCtx->pushBoolState(GL_STENCIL_TEST, GL_TRUE);
+	gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);							   // TODO store current value and restore later
+	gl::stencilOp(GL_KEEP, GL_KEEP, clearStencil ? GL_ZERO : GL_KEEP); // TODO store current value and restore later
+}
+
+ScopedCover::~ScopedCover() {
+	mCtx->popBoolState(GL_STENCIL_TEST);
+}
+
+} // namespace nvpath
+
+#pragma warning(pop)

--- a/projects/nvpath/src/nvpath/NvPath.h
+++ b/projects/nvpath/src/nvpath/NvPath.h
@@ -1,0 +1,1201 @@
+/*
+Copyright (c) 2023, Paul Houx Creative Coding - All rights reserved.
+This code is intended for use with the Cinder C++ library: http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+namespace nvpath {
+
+//! Returns whether NV Path Rendering is available on this system.
+bool hasNvPathRendering();
+
+void reportNoNvPathRendering();
+
+//! Returns whether pre-multiplied alpha is currently enabled.
+bool isPreMultiplied();
+
+// Forward declarations.
+class Cache;
+class Canvas;
+class Path;
+class PathHelper;
+class Shader;
+
+using CanvasRef = std::shared_ptr<Canvas>;
+using PathRef	= std::shared_ptr<Path>;
+using ShaderRef = std::shared_ptr<Shader>;
+
+//!
+enum class CapsStyle {
+	FLAT	   = GL_FLAT,
+	SQUARE	   = GL_SQUARE_NV,
+	ROUND	   = GL_ROUND_NV,
+	TRIANGULAR = GL_TRIANGULAR_NV,
+	DEFAULT	   = GL_FLAT
+};
+//!
+enum class JoinStyle {
+	ROUND		   = GL_ROUND_NV,
+	BEVEL		   = GL_BEVEL_NV,
+	MITER_REVERT   = GL_MITER_REVERT_NV,
+	MITER_TRUNCATE = GL_MITER_TRUNCATE_NV,
+	DEFAULT		   = GL_MITER_REVERT_NV
+};
+//!
+enum class PathStyle {
+	MOVETO_RESETS	 = GL_MOVE_TO_RESETS_NV,
+	MOVETO_CONTINUES = GL_MOVE_TO_CONTINUES_NV,
+	DEFAULT			 = GL_MOVE_TO_RESETS_NV
+};
+
+//! Defines the coordinate system used by gradients and images.
+enum class CoordinateSpace {
+	OBJECT_BOUNDING_BOX = GL_PATH_OBJECT_BOUNDING_BOX_NV,
+	USER_SPACE_ON_USE	= GL_OBJECT_LINEAR_NV,
+	DEFAULT				= GL_PATH_OBJECT_BOUNDING_BOX_NV
+};
+
+//! Defines the spread method used by gradient and images.
+enum class SpreadMethod { PAD = GL_CLAMP_TO_EDGE, REFLECT = GL_MIRRORED_REPEAT, REPEAT = GL_REPEAT, DEFAULT = PAD };
+
+//!
+enum class PathFormat { SVG = GL_PATH_FORMAT_SVG_NV, PS = GL_PATH_FORMAT_PS_NV };
+
+//! Converts an affine 3x3 matrix to a 3x2 matrix.
+inline glm::mat3x2 toMat3x2(const glm::mat3x3& m) {
+	return glm::mat3x2{m[0][0], m[0][1], m[1][0], m[1][1], m[2][0], m[2][1]};
+}
+//! Converts an affine 4x4 matrix to a 3x2 matrix. Z-components are ignored.
+inline glm::mat3x2 toMat3x2(const glm::mat4x4& m) {
+	return glm::mat3x2{m[0][0], m[0][1], m[1][0], m[1][1], m[3][0], m[3][1]};
+}
+
+class ScopedColorMask {
+  public:
+	ScopedColorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha) {
+		glGetBooleanv(GL_COLOR_WRITEMASK, mMask);
+		glColorMask(red, green, blue, alpha);
+	}
+	~ScopedColorMask() { glColorMask(mMask[0], mMask[1], mMask[2], mMask[3]); }
+
+	ScopedColorMask(const ScopedColorMask&)			   = delete;
+	ScopedColorMask(ScopedColorMask&&)				   = delete;
+	ScopedColorMask& operator=(const ScopedColorMask&) = delete;
+	ScopedColorMask& operator=(ScopedColorMask&&)	   = delete;
+
+  private:
+	GLboolean mMask[4] = {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE};
+};
+
+class ScopedStencilMask {
+  public:
+	ScopedStencilMask(GLuint mask) {
+		glGetIntegerv(GL_STENCIL_WRITEMASK, &mFrontMask);
+		glGetIntegerv(GL_STENCIL_BACK_WRITEMASK, &mBackMask);
+		glStencilMask(mask);
+	}
+	ScopedStencilMask(GLuint front, GLuint back) {
+		glGetIntegerv(GL_STENCIL_WRITEMASK, &mFrontMask);
+		glGetIntegerv(GL_STENCIL_BACK_WRITEMASK, &mBackMask);
+		glStencilMaskSeparate(GL_FRONT, front);
+		glStencilMaskSeparate(GL_BACK, back);
+	}
+	~ScopedStencilMask() {
+		glStencilMaskSeparate(GL_FRONT, mFrontMask);
+		glStencilMaskSeparate(GL_BACK, mBackMask);
+	}
+
+	ScopedStencilMask(const ScopedStencilMask&)			   = delete;
+	ScopedStencilMask(ScopedStencilMask&&)				   = delete;
+	ScopedStencilMask& operator=(const ScopedStencilMask&) = delete;
+	ScopedStencilMask& operator=(ScopedStencilMask&&)	   = delete;
+
+  private:
+	GLint mFrontMask = 0xFF;
+	GLint mBackMask	 = 0xFF;
+};
+
+//! Shader for solid colors or gradients to be applied to paths.
+class Shader {
+  public:
+	enum class Type { SOLID_COLOR, LINEAR_GRADIENT, RADIAL_GRADIENT, CONICAL_GRADIENT, IMAGE, UNDEFINED };
+
+	static ShaderRef create(Type type) { return std::make_shared<Shader>(type); }
+
+	Shader() = default;
+	explicit Shader(Type type);
+	virtual ~Shader();
+
+	Shader(const Shader&)			 = delete;
+	Shader(Shader&&)				 = default;
+	Shader& operator=(const Shader&) = delete;
+	Shader& operator=(Shader&&)		 = default;
+
+	void		bind() const;
+	static void unbind();
+
+	void uniform(const std::string& name, GLint value) const;
+	void uniform(const std::string& name, GLfloat value) const;
+	void uniform(const std::string& name, const glm::vec2& value) const;
+	void uniform(const std::string& name, const glm::vec3& value) const;
+	void uniform(const std::string& name, const glm::vec4& value) const;
+	void uniform(const std::string& name, const glm::mat3& value) const;
+	void uniform(const std::string& name, const glm::mat3x2& value) const;
+	void uniform(const std::string& name, const glm::mat4& value) const;
+
+	void setColor(const ci::ColorA& color) const;
+
+  protected:
+	GLuint mProgram{0};
+	GLuint mPipeline{0};
+	Type   mType{Type::UNDEFINED};
+
+	friend class ScopedShader;
+};
+
+class ScopedShader : public ci::Noncopyable {
+	ci::gl::Context* mCtx = nullptr;
+	ShaderRef		 mShader;
+
+  public:
+	//!
+	explicit ScopedShader(Shader::Type type);
+	//! Activates the solid color shader and sets the current color.
+	explicit ScopedShader(const ci::ColorA& color, float opacity = 1);
+
+	~ScopedShader();
+
+	ScopedShader(const ScopedShader&)			 = delete;
+	ScopedShader(ScopedShader&&)				 = delete;
+	ScopedShader& operator=(const ScopedShader&) = delete;
+	ScopedShader& operator=(ScopedShader&&)		 = delete;
+
+	template <typename T>
+	void uniform(const std::string& name, const T& value) {
+		if (mShader) mShader->uniform(name, value);
+	}
+
+	void setColor(const ci::ColorA& color) const {
+		if (mShader) mShader->setColor(color);
+	}
+
+	//! Only works for linear gradient, radial gradient and image shaders! TODO
+	void setCoords(GLenum genMode = GL_PATH_OBJECT_BOUNDING_BOX_NV, const glm::mat3& transform = {}) const {
+		// Sanity check.
+		static_assert(sizeof(glm::mat3::value_type) == sizeof(GLfloat));
+
+		if (mShader && (mShader->mType == Shader::Type::LINEAR_GRADIENT ||
+						mShader->mType == Shader::Type::RADIAL_GRADIENT || mShader->mType == Shader::Type::IMAGE)) {
+			const auto t = transpose(inverse(transform));
+			glProgramPathFragmentInputGenNV(mShader->mProgram, 1, genMode, 2, value_ptr(t));
+		}
+	}
+
+	//! Only works for linear gradient, radial gradient and image shaders! TODO
+	void setCoords(GLenum genMode, const std::vector<float>& data) const {
+		assert(data.size() == 6);
+
+		if (mShader && (mShader->mType == Shader::Type::LINEAR_GRADIENT ||
+						mShader->mType == Shader::Type::RADIAL_GRADIENT || mShader->mType == Shader::Type::IMAGE)) {
+			glProgramPathFragmentInputGenNV(mShader->mProgram, 1, genMode, 2, data.data());
+		}
+	}
+};
+
+//! SVG Paint specification for fill or stroke, including solids and gradients
+class Paint {
+  public:
+	enum Type : uint8_t { NONE, COLOR, LINEAR_GRADIENT, RADIAL_GRADIENT };
+
+	struct Stop {
+		Stop(float offset, const ci::ColorA8u& color)
+		  : offset(offset)
+		  , color(color) {}
+
+		float		 offset;
+		ci::ColorA8u color;
+
+		bool operator==(const Stop& other) const;
+		bool operator!=(const Stop& other) const { return !(*this == other); }
+		bool operator<(const Stop& other) const { return offset < other.offset; }
+
+		bool operator==(float value) const;
+		bool operator!=(float value) const { return !(*this == value); }
+		bool operator<(float value) const { return offset < value; }
+	};
+
+	static Paint color(const ci::ColorA8u& color, const std::string& id = {});
+	static Paint linear(const std::string& id = {});
+	static Paint radial(const std::string& id = {});
+
+	Paint();
+	explicit Paint(Type type, std::string id = {});
+	explicit Paint(const ci::ColorA8u& color);
+	explicit Paint(std::string url); // Marks Paint as "needs resolve".
+
+	Paint(const Paint&)			   = default;
+	Paint(Paint&&)				   = default;
+	Paint& operator=(const Paint&) = default;
+	Paint& operator=(Paint&&)	   = default;
+
+	~Paint() = default;
+
+	// static Paint parse(const char* value, bool* specified, const SvgNode* parentNode); // TODO parse in SVG code.
+
+	bool			   isNone() const { return mType == NONE; }
+	bool			   isColor() const { return mType == COLOR; }
+	bool			   isLinearGradient() const { return mType == LINEAR_GRADIENT; }
+	bool			   isRadialGradient() const { return mType == RADIAL_GRADIENT; }
+	[[nodiscard]] bool isTransparent() const;
+	bool			   needsResolve() const { return mNeedsResolve; }
+
+	//! Returns the solid color. Returns black or fallback color for gradients.
+	[[nodiscard]] const ci::ColorA8u& getColor() const;
+	//! Replaces all existing colors (if any) with a single /a color.
+	void setColor(const ci::ColorA8u& color);
+
+	const ci::ColorA8u& getColor(size_t idx) const { return mStops.at(idx).color; }
+	float				getOffset(size_t idx) const { return mStops.at(idx).offset; }
+
+	bool   empty() const { return mStops.empty(); }
+	size_t getNumColors() const { return mStops.size(); }
+
+	// only apply to gradients
+	[[nodiscard]] glm::vec2 getCoords0() const { return mCoords0; } // (x1,y1) on linear, (cx,cy) on radial
+	[[nodiscard]] glm::vec2 getCoords1() const { return mCoords1; } // (x2,y2) on linear, (fx,fy) on radial
+	[[nodiscard]] float		getRadius0() const { return mRadius0; } // (r) on radial
+	[[nodiscard]] float		getRadius1() const { return mRadius1; } // (fr) on radial
+
+	bool useObjectBoundingBox() const { return mUseObjectBoundingBox; }
+	void setUseObjectBoundingBox(bool enable) { mUseObjectBoundingBox = enable; }
+
+	bool specifiesTransform() const { return mSpecifiesTransform; }
+	void setTransform(const glm::mat3& m) {
+		mTransform			= m;
+		mSpecifiesTransform = true;
+	}
+	[[nodiscard]] glm::mat3 getTransform() const { return mTransform; }
+	void					multiplyTransform(const glm::mat3& m) {
+		   mTransform *= m;
+		   mSpecifiesTransform = true;
+	}
+
+	bool		 specifiesSpreadMethod() const { return mSpecifiesSpreadMethod; }
+	SpreadMethod getSpreadMethod() const { return mSpreadMethod; }
+	void		 setSpreadMethod(SpreadMethod spreadMethod) {
+		mSpreadMethod		   = spreadMethod;
+		mSpecifiesSpreadMethod = true;
+	}
+
+	[[nodiscard]] CoordinateSpace getCoordinateSpace() const {
+		return mUseObjectBoundingBox ? CoordinateSpace::OBJECT_BOUNDING_BOX : CoordinateSpace::USER_SPACE_ON_USE;
+	}
+
+	[[nodiscard]] const std::string& getId() const { return mId; }
+
+	const std::shared_ptr<Paint>& fallback() const { return mFallback; }
+
+	bool operator==(const Paint& rhs) const { return mId == rhs.mId && mType == rhs.mType && mStops == rhs.mStops; }
+	bool operator!=(const Paint& rhs) const { return !(*this == rhs); }
+	bool operator<(const Paint& rhs) const { return this < &rhs; }
+
+	//! Sets a stop color.
+	void set(float offset, const ci::ColorA8u& color);
+	//! Sets (x1,y1) on linear, (cx,cy) on radial.
+	void setCoords0(float a, float b) {
+		mCoords0.x = a;
+		mCoords0.y = b;
+	}
+	//! Sets (x1,y1) on linear, (cx,cy) on radial.
+	void setCoords0(const glm::vec2& coords) { mCoords0 = coords; }
+	//! Sets (x2,y2) on linear, (fx,fy) on radial.
+	void setCoords1(float a, float b) {
+		mCoords1.x = a;
+		mCoords1.y = b;
+	}
+	//! Sets (x2,y2) on linear, (fx,fy) on radial.
+	void setCoords1(const glm::vec2& coords) { mCoords1 = coords; }
+	//! Sets (r) on radial.
+	void setRadius0(float radius) { mRadius0 = radius; }
+	//! Sets (fr) on radial.
+	void setRadius1(float radius) { mRadius1 = radius; }
+
+	//! Returns the (interpolated) color at position \a t.
+	[[nodiscard]] ci::ColorA8u at(float t, bool preMultiply = false) const;
+
+	//! Returns the nearest stop lower than position \a t.
+	[[nodiscard]] const Stop& floor(float t) const;
+	//! Returns the nearest stop higher than position \a t.
+	[[nodiscard]] const Stop& ceil(float t) const;
+	//! Returns all stops as a read-only vector.
+	const std::vector<Stop>& getStops() const { return mStops; }
+	//! Returns all stops as a writable vector.
+	std::vector<Stop>& getStops() { return mStops; }
+
+	[[nodiscard]] auto begin() const { return mStops.begin(); }
+	[[nodiscard]] auto end() const { return mStops.end(); }
+
+	[[nodiscard]] auto rbegin() const { return mStops.rbegin(); }
+	[[nodiscard]] auto rend() const { return mStops.rend(); }
+
+	//! Returns raw 8-bit RGBA data. You can use this to construct a Surface.
+	[[nodiscard]] std::unique_ptr<uint8_t[]> data(int32_t width, int32_t height, bool preMultiply = false,
+												  float from = 0.0f, float to = 1.0f) const;
+
+	const std::shared_ptr<Paint>& getFallback() const { return mFallback; }
+	void						  setFallback(const std::shared_ptr<Paint>& fallback) { mFallback = fallback; }
+
+  protected:
+	glm::vec2			   mCoords0{0, 0}, mCoords1{0, 1};	 //
+	float				   mRadius0{0}, mRadius1{0};		 //
+	glm::mat3			   mTransform{};					 //
+	SpreadMethod		   mSpreadMethod{SpreadMethod::PAD}; //
+	Type				   mType{NONE};						 //
+	std::vector<Stop>	   mStops;							 //
+	bool				   mSpecifiesTransform{false};		 //
+	bool				   mUseObjectBoundingBox{true};		 // Used to default to false. Please check.
+	bool				   mSpecifiesSpreadMethod{false};	 //
+	bool				   mNeedsResolve{false};			 //
+	std::string			   mId;								 //
+	std::shared_ptr<Paint> mFallback;						 //
+};
+
+//! Stores multiple paints in a single texture for maximum performance.
+class Paints {
+  public:
+	Paints()  = default;
+	~Paints() = default;
+
+	Paints(const Paints&)				 = delete;
+	Paints(Paints&&) noexcept			 = default;
+	Paints& operator=(const Paints&)	 = delete;
+	Paints& operator=(Paints&&) noexcept = default;
+
+	//!
+	bool empty() const { return mPaints.empty(); }
+	//!
+	void clear() {
+		mIndex = 0;
+		mPaints.clear();
+		mTexture.reset();
+		mDirty = true;
+	}
+	//!
+	size_t size() const { return mPaints.size(); }
+
+	//! Returns whether the paint is known.
+	bool contains(const std::string& paintId) const;
+	//! Returns whether the paint is known.
+	bool contains(const Paint& paint) const;
+	//! Returns the coordinate of the paint in the texture.
+	float index(const std::string& paintId) const;
+	//! Returns the coordinate of the paint in the texture.
+	float index(const Paint& paint) const;
+	//! Sets or updates the paint.
+	float set(const Paint& paint);
+
+	//! Binds the paint texture to \a textureUnit. If the texture does not yet exist, or if paints have changed,
+	//! it will be created.
+	void bind(ci::gl::Context* ctx, uint8_t textureUnit = 0);
+	//!
+	void unbind(const ci::gl::Context* ctx) const;
+
+	//! Applies the spread \a method to the paint texture.
+	void setSpreadMethod(SpreadMethod method) const;
+
+	//! Creates or activates a paint. Optionally prepares the correct shader as well.
+	Shader::Type preparePaint(const Paint& paint, float opacity = 1, bool prepareShader = true);
+
+  private:
+	//!  Creates or activates a linear gradient. Optionally prepares the correct shader as well.
+	Shader::Type prepareLinearGradient(const Paint& paint, float opacity = 1, bool prepareShader = true);
+	//!  Creates or activates a radial gradient. Optionally prepares the correct shader as well.
+	Shader::Type prepareRadialGradient(const Paint& paint, float opacity = 1, bool prepareShader = true);
+	//!
+	GLint textureSize() const;
+
+	ci::gl::Context*					   mCtx = nullptr;	//
+	size_t								   mIndex{0};		//
+	std::unordered_map<std::string, Paint> mPaints;			//
+	ci::gl::Texture2dRef				   mTexture{};		//
+	uint8_t								   mTextureUnit{0}; //
+	bool								   mDirty{true};	//
+};
+
+class ScopedPaints {
+	Paints&			 mPaints;
+	ci::gl::Context* mCtx = nullptr;
+
+  public:
+	explicit ScopedPaints(Paints& paints, uint8_t textureUnit = 0)
+	  : mPaints(paints)
+	  , mCtx(ci::gl::context()) {
+		mPaints.bind(mCtx, textureUnit);
+	}
+	~ScopedPaints() { mPaints.unbind(mCtx); }
+
+	ScopedPaints(const ScopedPaints&)			 = delete;
+	ScopedPaints(ScopedPaints&&)				 = delete;
+	ScopedPaints& operator=(const ScopedPaints&) = delete;
+	ScopedPaints& operator=(ScopedPaints&&)		 = delete;
+};
+
+//! Path represents a vector shape stored efficiently on the GPU.
+class Path {
+  public:
+	~Path();
+
+	Path() = default;
+	Path(const Path& other);
+	Path(Path&& other) noexcept;
+	Path& operator=(const Path& other);
+	Path& operator=(Path&& other) noexcept;
+
+	//! Construct a path from a Path2d. Note the correct winding order: points should be defined in counter clockwise
+	//! order.
+	Path(const ci::Path2d& path);
+	//! Construct a path from a Shape2d. Note the correct winding order: holes should be defined in clockwise order.
+	Path(const ci::Shape2d& shape);
+	//! Construct a path from a PolyLine2. Note the correct winding order: points should be defined in counter clockwise
+	//! order.
+	Path(const ci::PolyLine2& polyLine);
+	//! Construct a path from a \a path string. Accepts SVG or PostScript \a format.
+	explicit Path(const std::string& path, PathFormat format = PathFormat::SVG);
+	//! Construct a path from a vector of \a commands and 2D \a points.
+	explicit Path(const std::vector<GLubyte>& commands, const std::vector<glm::vec2>& points);
+	//! Construct a path from a vector of \a commands and 2D \a points.
+	explicit Path(const std::vector<GLubyte>& commands, const std::vector<GLfloat>& points);
+	//! Construct a path from the \a commands.
+	explicit Path(const class PathHelper& commands);
+
+	//! Creates a shallow clone of this path. Use with care.
+	[[nodiscard]] PathRef clone() const { return std::make_shared<Path>(*this); }
+
+	//! Returns the path's unique id number.
+	GLuint getId() const { return mPathId; }
+
+	//! Returns a point on the path at a given \a distance along the path, as well as the (unnormalized) tangent at that
+	//! point. Returns false if the distance is out of bounds.
+	bool getPointAlongPath(float distance, glm::vec2& point, glm::vec2& tangent) const;
+	//! Returns the total length of the path.
+	[[nodiscard]] float getLength() const;
+	//! Returns the path's bounding box, calculated from the actual shape.
+	[[nodiscard]] ci::Rectf getFillBounds() const;
+	//! Returns the path's bounding box, calculated from the actual shape and adjusted for stroke width.
+	[[nodiscard]] ci::Rectf getStrokeBounds() const;
+
+	//! Returns the path's client length. Dash patterns use the client length to scale the dash pattern. Returns zero if
+	//! not set.
+	[[nodiscard]] float getClientLength() const;
+	//! Sets the path's client length. Dash patterns use the client length to scale the dash pattern. Use zero to
+	//! disable.
+	void setClientLength(float length) const;
+
+	//! Obtains the path's commands and coords.
+	void getPath(std::vector<GLubyte>& commands, std::vector<GLfloat>& coords) const;
+	//! Set the path's commands and coords. This will overwrite any existing commands and coords.
+	void setPath(const std::vector<GLubyte>& commands, const std::vector<GLfloat>& coords);
+	//! Set the path's commands and coords using the provided \a svg string. This will overwrite any existing commands
+	//! and coords.
+	void setPath(const std::string& svg);
+
+	//! Returns the number of segments defined for this path.
+	[[nodiscard]] int getNumSegments() const;
+
+	//! Resets the dash pattern.
+	void resetDashPattern() const;
+	//! Sets the dash pattern.
+	void setDashPattern(const std::vector<float>& pattern) const;
+	//! Sets the dash pattern offset.
+	void setDashOffset(float offset, PathStyle style = PathStyle::DEFAULT) const;
+	//! Sets the caps for dashed strokes.
+	void setDashCaps(CapsStyle caps) const;
+	//! Sets the caps for dashed strokes.
+	void setDashCaps(CapsStyle initialCap, CapsStyle terminalCap) const;
+	//! Sets the path's end caps for strokes.
+	void setEndCaps(CapsStyle caps) const;
+	//! Sets the path's end caps for strokes.
+	void setEndCaps(CapsStyle initialCap, CapsStyle terminalCap) const;
+	//! Sets the join style for strokes.
+	void setJoinStyle(JoinStyle joins) const;
+	//! Sets the stroke width.
+	void setStrokeWidth(float width) const;
+	//! Sets the miter limit for stokes.
+	void setMiterLimit(float limit) const;
+
+	//! Sets multiple stroke parameters at once.
+	void setStroke(CapsStyle caps, float strokeWidth) const { setStroke(caps, JoinStyle::DEFAULT, strokeWidth); }
+	//! Sets multiple stroke parameters at once.
+	void setStroke(JoinStyle join, float strokeWidth) const { setStroke(CapsStyle::DEFAULT, join, strokeWidth); }
+	//! Sets multiple stroke parameters at once.
+	void setStroke(CapsStyle caps, JoinStyle join, float strokeWidth) const;
+
+	//! Renders the path to the stencil buffer but does not cover the path.
+	//! Use the `stroke()` methods to stencil and cover the path in a single step.
+	void stencilStroke(GLuint stencilMask = 0xFF) const;
+	//! Renders the path to the stencil buffer but does not cover the path.
+	//! Use the `fill()` methods to stencil and cover the path in a single step.
+	void stencilFill(GLuint stencilMask = 0xFF, GLenum fillMode = GL_COUNT_UP_NV) const;
+
+	//! Renders the path instances to the stencil buffer but does not cover the path instances.
+	void stencilStrokeInstanced(const std::vector<glm::mat3x2>& transforms, GLuint stencilMask = 0xFF) const;
+	//! Renders the path instances to the stencil buffer but does not cover the path instances. The \a paths vector
+	//! contains offsets to the base path id.
+	void stencilStrokeInstanced(const std::vector<GLuint>& paths, const std::vector<glm::mat3x2>& transforms,
+								GLuint stencilMask = 0xFF) const;
+	//! Renders the path instances to the stencil buffer but does not cover the path instances.
+	void stencilFillInstanced(const std::vector<glm::mat3x2>& transforms, GLuint stencilMask = 0xFF,
+							  GLenum fillMode = GL_COUNT_UP_NV) const;
+	//! Renders the path instances to the stencil buffer but does not cover the path instances. The \a paths vector
+	//! contains offsets to the base path id.
+	void stencilFillInstanced(const std::vector<GLuint>& paths, const std::vector<glm::mat3x2>& transforms,
+							  GLuint stencilMask = 0xFF, GLenum fillMode = GL_COUNT_UP_NV) const;
+
+	//!
+	void clearStroke(GLuint stencilMask = 0xFF) const;
+	//!
+	void clearFill(GLuint stencilMask = 0xFF) const;
+
+	//! Covers the paths that have already been rendered to the stencil buffer using a solid \a color. Clears the
+	//! affected region of the stencil buffer by default, but this can be overridden. Use the `stroke()`
+	//! method to stencil and cover the path in a single step.
+	void coverStroke(const ci::ColorA& color, bool clearStencil = true) const;
+	//! Covers the paths that have already been rendered to the stencil buffer using a solid \a color. Clears the
+	//! affected region of the stencil buffer by default, but this can be overridden. Use the `fill()`
+	//! method to stencil and cover the path in a single step.
+	void coverFill(const ci::ColorA& color, float opacity = 1, bool clearStencil = true) const;
+	//! Covers the paths that have already been rendered to the stencil buffer using a \a paint, which can be a
+	//! gradient. Clears the affected region of the stencil buffer by default, but this can be overridden. Use the
+	//! `fill()` method to stencil and cover the path in a single step.
+	void coverFill(const Paint& paint, float opacity = 1, bool clearStencil = true) const;
+	//! Covers the paths that have already been rendered to the stencil buffer using a \a paint, but using the \a
+	//! texture for its colors. Clears the affected region of the stencil buffer by default, but this can be overridden.
+	//! Use the `fill()` method to stencil and cover the path in a single step.
+	void coverFill(const Paint& paint, const ci::gl::Texture2dRef& texture, float opacity = 1,
+				   bool clearStencil = true) const;
+	//! Covers the paths that have already been rendered to the stencil buffer using a solid \a color. Clears the
+	//! affected region of the stencil buffer by default, but this can be overridden.
+	void coverFill(const ci::ColorA& color, const ci::Rectf& bounds, bool clearStencil = true) const;
+	//! Covers the paths that have already been rendered to the stencil buffer using the provided \a texture. Clears the
+	//! affected region of the stencil buffer by default, but this can be overridden.
+	void coverFill(const ci::gl::Texture2dRef& texture, const ci::Rectf& bounds, bool clearStencil = true) const;
+
+	//! Strokes the path with a solid \a color.
+	void stroke(const ci::ColorA& color, float opacity = 1, bool clearStencil = true) const;
+	//! Strokes the path with a \a paint. Gradients are currently not supported.
+	void stroke(const Paint& paint, float opacity = 1, bool clearStencil = true) const;
+
+	//! Strokes the path instances with a solid \a color.
+	void strokeInstanced(const std::vector<glm::mat3x2>& transforms, const ci::ColorA& color,
+						 bool clearStencil = true) const;
+	//! Strokes the path instances with a solid \a color.
+	void strokeInstanced(const std::vector<glm::mat4x3>& transforms, const ci::ColorA& color,
+						 bool clearStencil = true) const;
+	//! Strokes the path instances with a solid \a color. The \a paths vector contains offsets to the base path id.
+	void strokeInstanced(const std::vector<GLuint>& paths, const std::vector<glm::mat3x2>& transforms,
+						 const ci::ColorA& color, bool clearStencil = true) const;
+	//! Strokes the path instances with a solid \a color. The \a paths vector contains offsets to the base path id.
+	void strokeInstanced(const std::vector<GLuint>& paths, const std::vector<glm::mat4x3>& transforms,
+						 const ci::ColorA& color, bool clearStencil = true) const;
+
+	//! Fills the path with a solid \a color.
+	void fill(const ci::ColorA& color, float opacity = 1, bool clearStencil = true) const;
+	//! Fills the path with a \a paint, which can be a gradient.
+	void fill(const Paint& paint, float opacity = 1, bool clearStencil = true) const;
+	//! Fills the path with a \a paint, but uses the \a texture for its colors.
+	void fill(const Paint& paint, const ci::gl::TextureRef& texture, float opacity = 1, bool clearStencil = true) const;
+	//! Fills the path with a \a texture, automatically centered within the path's bounding box.
+	void fill(const ci::gl::TextureRef& texture, float opacity = 1, bool clearStencil = true) const {
+		fill(texture, getFillBounds(), opacity, clearStencil);
+	}
+	//! Fills the path with a \a texture, automatically centered within the specified \a bounding box.
+	void fill(const ci::gl::TextureRef& texture, const ci::Rectf& bounds, float opacity = 1,
+			  bool clearStencil = true) const;
+	//! Fills the path with a \a texture.
+	void fill(const ci::gl::TextureRef& texture, const glm::vec2& upperLeftTexCoord,
+			  const glm::vec2& lowerRightTexCoord, float opacity = 1, bool clearStencil = true) const;
+
+	//! Fills the path instances with a solid \a color.
+	void fillInstanced(const std::vector<glm::mat3x2>& transforms, const ci::ColorA& color,
+					   bool clearStencil = true) const;
+	//! Fills the path instances with a solid \a color.
+	void fillInstanced(const std::vector<glm::mat4x3>& transforms, const ci::ColorA& color,
+					   bool clearStencil = true) const;
+	//! Fills the path instances with a solid \a color. The \a paths vector contains offsets to the base path id.
+	void fillInstanced(const std::vector<GLuint>& paths, const std::vector<glm::mat3x2>& transforms,
+					   const ci::ColorA& color, bool clearStencil = true) const;
+	//! Fills the path instances with a solid \a color. The \a paths vector contains offsets to the base path id.
+	void fillInstanced(const std::vector<GLuint>& paths, const std::vector<glm::mat4x3>& transforms,
+					   const ci::ColorA& color, bool clearStencil = true) const;
+
+	//!
+	static void pushClipPath(const Path& mask, bool showMask = false);
+	//!
+	static void popClipPath();
+
+	//! Adds the \a other path to our path and returns the result as a new path.
+	[[nodiscard]] Path operator+(const Path& other) const;
+	//! Subtracts the \a other path from our path, creating a hole and returns the result as a new path.
+	[[nodiscard]] Path operator-(const Path& other) const;
+
+	//! Adds the \a other path to our path.
+	Path& operator+=(const Path& other);
+	//! Subtracts the \a other path from our path, creating a hole.
+	Path& operator-=(const Path& other);
+
+	//! Transforms the coordinates of our path.
+	void transform(const glm::mat3x2& m) const;
+	//! Transforms the coordinates of our path. Assumes matrix \a m is affine.
+	void transform(const glm::mat3x3& m) const { transform(toMat3x2(m)); }
+	//! Transforms the coordinates of our path. Assumes matrix \a m is affine.
+	void transform(const glm::mat4x4& m) const { transform(toMat3x2(m)); }
+
+	//! Returns the result of this path's transformation as a new path.
+	[[nodiscard]] Path transformed(const glm::mat3x2& m) const;
+	//! Returns the result of this path's transformation as a new path. Assumes matrix \a m is affine.
+	[[nodiscard]] Path transformed(const glm::mat3x3& m) const { return transformed(toMat3x2(m)); }
+	//! Returns the result of this path's transformation as a new path. Assumes matrix \a m is affine.
+	[[nodiscard]] Path transformed(const glm::mat4x4& m) const { return transformed(toMat3x2(m)); }
+
+	//! Translates the path by \a x and \a y.
+	void translate(float x, float y) const;
+	//! Translates the path by \a offset.
+	void translate(const glm::vec2& offset) const { translate(offset.x, offset.y); }
+
+	//! Returns the result of translating this path by \a x and \a y as a new path.
+	[[nodiscard]] Path translated(float x, float y) const;
+	//! Returns the result of translating this path by \a offset as a new path.
+	[[nodiscard]] Path translated(const glm::vec2& offset) const { return translated(offset.x, offset.y); }
+
+	//! Rotates the path \a radians around its origin.
+	void rotate(float radians) const;
+	//! Rotates the path \a radians around the specified \a center.
+	void rotate(float radians, const glm::vec2& center) const;
+
+	//! Returns the result of rotating this path \a radians around its origin as a new path.
+	[[nodiscard]] Path rotated(float radians) const;
+	//! Returns the result of rotating this path \a radians around the specified \a center as a new path.
+	[[nodiscard]] Path rotated(float radians, const glm::vec2& center) const;
+
+	//! Scales the path uniformly.
+	void scale(float s) const { scale(s, s); }
+	//! Scales the path uniformly around the specified \a center.
+	void scale(float s, const glm::vec2& center) const { scale(s, s, center); }
+	//! Scales the path.
+	void scale(float sx, float sy) const;
+	//! Scales the path around the specified \a center.
+	void scale(float sx, float sy, const glm::vec2& center) const;
+	//! Scales the path.
+	void scale(const glm::vec2& s) const { scale(s.x, s.y); }
+	//! Scales the path around the specified \a center.
+	void scale(const glm::vec2& s, const glm::vec2& center) const;
+
+	//! Returns the result of scaling this path uniformly as a new path.
+	[[nodiscard]] Path scaled(float s) const { return scaled(s, s); }
+	//! Returns the result of scaling this path as a new path.
+	[[nodiscard]] Path scaled(float sx, float sy) const;
+	//! Returns the result of scaling this path as a new path.
+	[[nodiscard]] Path scaled(const glm::vec2& s) const { return scaled(s.x, s.y); }
+	//! Returns the result of scaling this path around the specified \a center as a new path.
+	[[nodiscard]] Path scaled(const glm::vec2& s, const glm::vec2& center) const;
+
+	//! Skews the path by \a radiansX.
+	void skewX(float radiansX) const;
+	//! Skews the path by \a radiansY.
+	void skewY(float radiansY) const;
+	//! Skews the path by \a radiansX and \a radiansY.
+	void skew(float radiansX, float radiansY) const;
+
+	//! Returns the result of skewing this path by \a radiansX as a new path.
+	[[nodiscard]] Path skewedX(float radiansX) const;
+	//! Returns the result of skewing this path by \a radiansY as a new path.
+	[[nodiscard]] Path skewedY(float radiansY) const;
+	//! Returns the result of skewing this path by \a radiansX and \a radiansY as a new path.
+	[[nodiscard]] Path skewed(float radiansX, float radiansY) const;
+
+	////! Attempts to minimize the number of commands and coordinates used to represent the path.
+	// void optimize() const;
+	////! Attempts to minimize the number of commands and coordinates used to represent the path and returns the result
+	/// as
+	////! a new path.
+	//[[nodiscard]] Path optimized() const;
+
+	//! Reverses the order of the points and segments, effectively changing the winding.
+	void reverse() const;
+	//! Reverses the order of the points and segments, effectively changing the winding and returns the result as a new
+	//! path.
+	[[nodiscard]] Path reversed() const;
+
+	//! Returns whether \a point is inside the fill path.
+	bool fillContains(const ci::vec2& point) const;
+	//! Returns whether \a point is inside the stroke path.
+	bool strokeContains(const ci::vec2& point) const;
+
+	//! Converts the path to Cinder's Shape2d.
+	ci::Shape2d toShape2d() const;
+
+  protected:
+	//! Returns the number of coordinates (floats) for the specified command.
+	static GLint getCoordCount(GLubyte command);
+	//! Returns the offset of the end coordinate (float) for the specified command.
+	static GLint getCoordOffset(GLubyte command);
+
+	static GLubyte toPathCommand(ci::Path2d::SegmentType type);
+	static Paints& getPaints();
+
+	static void optimizeImpl(std::vector<GLubyte>& commands, std::vector<GLfloat>& coords);
+	static void reverseImpl(std::vector<GLubyte>& commands, std::vector<GLfloat>& coords);
+
+	GLuint mPathId{0};
+
+	inline thread_local static std::vector<GLuint> sPaths{};
+	inline thread_local static std::vector<GLuint> sClipPaths{};
+};
+
+//! Can be used to construct paths from code. No validation is performed whatsoever.
+class PathHelper {
+	std::vector<GLubyte> mCommands;
+	std::vector<GLfloat> mCoords;
+
+  public:
+	PathHelper()  = default;
+	~PathHelper() = default;
+
+	PathHelper(const PathHelper&)			 = default;
+	PathHelper(PathHelper&&)				 = default;
+	PathHelper& operator=(const PathHelper&) = default;
+	PathHelper& operator=(PathHelper&&)		 = default;
+
+	explicit PathHelper(const Path& path) { path.getPath(mCommands, mCoords); }
+
+	//! Returns the path's commands.
+	const std::vector<GLubyte>& getCommands() const { return mCommands; }
+	//! Returns the path's coordinates.
+	const std::vector<GLfloat>& getCoords() const { return mCoords; }
+
+	ci::vec2 getCurrentPoint() const {
+		assert(!mCoords.empty());
+		return {mCoords[mCoords.size() - 2], mCoords[mCoords.size() - 1]};
+	}
+
+	//! Sets the path's commands.
+	void setCommands(const std::vector<GLubyte>& commands) { mCommands = commands; }
+	//! Sets the path's coordinates.
+	void setCoords(const std::vector<GLfloat>& coords) { mCoords = coords; }
+	//! Sets the path's commands and coordinates.
+	void set(const Path& path);
+	//! Removes the last command and its coordinates.
+	void removeLastCommand();
+	//! Returns whether any two segments of the path intersect.
+	[[nodiscard]] bool isSelfIntersecting() const;
+	//!
+	[[nodiscard]] bool isIntersecting(const PathHelper& other) const;
+
+	void moveTo(const ci::vec2& p) { moveTo(p.x, p.y); }
+	void moveTo(float x, float y);
+	void lineTo(const ci::vec2& p) { lineTo(p.x, p.y); }
+	void lineTo(float x, float y);
+	void quadTo(const ci::vec2& p1, const ci::vec2& p2) { quadTo(p1.x, p1.y, p2.x, p2.y); }
+	void quadTo(float x1, float y1, float x2, float y2);
+	void curveTo(const ci::vec2& p1, const ci::vec2& p2, const ci::vec2& p3) {
+		curveTo(p1.x, p1.y, p2.x, p2.y, p3.x, p3.y);
+	}
+	void curveTo(float x1, float y1, float x2, float y2, float x3, float y3);
+	void horizontalLineTo(float x);
+	void verticalLineTo(float y);
+	void smoothQuadTo(const ci::vec2& p2) { smoothQuadTo(p2.x, p2.y); }
+	void smoothQuadTo(float x2, float y2);
+	void smoothCurveTo(const ci::vec2& p2, const ci::vec2& p3) { smoothCurveTo(p2.x, p2.y, p3.x, p3.y); }
+	void smoothCurveTo(float x2, float y2, float x3, float y3);
+	void arcTo(float radiusX, float radiusY, float xAxisRotation, bool large, bool sweep, const ci::vec2& p) {
+		arcTo(radiusX, radiusY, xAxisRotation, large, sweep, p.x, p.y);
+	}
+	void arcTo(float radiusX, float radiusY, float xAxisRotation, bool large, bool sweep, float x, float y);
+	void close();
+
+	////! Mimics Cinder's arc method. The arc is approximated by cubic Bezier curves.
+	// void arc(const ci::vec2& center, float radius, float startRadians, float endRadians, bool forward = true) {
+	//	arc(center.x, center.y, radius, startRadians, endRadians, forward);
+	// }
+	////! Mimics Cinder's arc method. The arc is approximated by cubic Bezier curves.
+	// void arc(float centerX, float centerY, float radius, float startRadians, float endRadians, bool forward = true);
+	////! Mimics Cinder's arc method. The arc is approximated by cubic Bezier curves.
+	// void arcTo(const ci::vec2& p, const ci::vec2& t, float radius) { arcTo(p.x, p.y, t.x, t.y, radius); }
+	////! Mimics Cinder's arc method. The arc is approximated by cubic Bezier curves.
+	// void arcTo(float x, float y, float tanX, float tanY, float radius);
+
+	//! Returns the number of coordinates (floats) for the specified command.
+	static size_t getCoordCount(GLubyte command);
+};
+
+//! Stores shaders so they can be easily reused by other parts of your code.
+class Cache {
+	std::unordered_map<Shader::Type, ShaderRef> mShaders;
+
+  public:
+	static Cache& get() {
+		thread_local static Cache instance;
+		return instance;
+	}
+
+	static ShaderRef loadShader(Shader::Type type);
+
+	static void clean();
+
+	static void clear();
+
+  private:
+	Cache() = default;
+};
+
+//! Sets up a canvas to render NvPath graphics to.
+class Canvas {
+  public:
+	Canvas(int samples = 8, int coverageSamples = 16, bool useFloats = false);
+	Canvas(int width, int height, int samples = 8, int coverageSamples = 16, bool useFloats = false);
+
+	explicit Canvas(const glm::ivec2& size, int samples = 8, int coverageSamples = 16, bool useFloats = false)
+	  : Canvas(size.x, size.y, samples, useFloats) {}
+
+	//! Binds the canvas. Please consider using ScopedCanvas instead.
+	void bind() const;
+	//! Unbinds the canvas. Please consider using ScopedCanvas instead.
+	void unbind() const;
+	//! Returns whether the canvas is currently bound.
+	bool isBound() const { return mIsBound; }
+
+	//! Draws the canvas.
+	void draw() const;
+	//! Draws the canvas.
+	void draw(const ci::Rectf& bounds) const;
+
+	//! Returns the width of the canvas in pixels.
+	int32_t getWidth() const { return mWidth; }
+	//! Returns the height of the canvas in pixels.
+	int32_t getHeight() const { return mHeight; }
+	//! Returns the size of the canvas in pixels.
+	glm::ivec2 getSize() const { return {mWidth, mHeight}; }
+	//! Returns the bounds of the canvas in pixels.
+	ci::Area getBounds() const { return {0, 0, mWidth, mHeight}; }
+
+	//! Returns the number of samples used per pixel.
+	int getSamples() const { return getFboFormat().getSamples(); }
+
+	//! Returns the canvas texture if it exists, otherwise returns nullptr.
+	ci::gl::Texture2dRef getTexture(GLenum attachment = GL_COLOR_ATTACHMENT0) const;
+	//! Returns the frame buffer format for this canvas.
+	ci::gl::Fbo::Format getFboFormat() const;
+
+	//! Sets the size of the canvas in pixels.
+	void resize(const glm::ivec2& size);
+
+  private:
+	int32_t					 mWidth{640};		   //
+	int32_t					 mHeight{480};		   //
+	int						 mSamples{8};		   //
+	int						 mCoverageSamples{16}; //
+	bool					 mUseFloats{false};	   //
+	mutable ci::gl::Context* mCtx = nullptr;	   //
+	mutable ci::gl::FboRef	 mFbo;				   //
+	mutable bool			 mIsBound = false;	   //
+};
+
+class ScopedCanvas {
+	const Canvas& mCanvas;
+
+  public:
+	explicit ScopedCanvas(const Canvas& canvas)
+	  : mCanvas(canvas) {
+		mCanvas.bind();
+	}
+	~ScopedCanvas() { mCanvas.unbind(); }
+
+	ScopedCanvas(const ScopedCanvas&)			 = delete;
+	ScopedCanvas(ScopedCanvas&&)				 = delete;
+	ScopedCanvas& operator=(const ScopedCanvas&) = delete;
+	ScopedCanvas& operator=(ScopedCanvas&&)		 = delete;
+};
+
+class ScopedPathRendering {
+	ci::gl::Context* mCtx = nullptr;
+	ci::ColorAf		 mColor;
+
+  public:
+	ScopedPathRendering();
+	[[deprecated]] explicit ScopedPathRendering(bool)
+	  : ScopedPathRendering() {}
+	~ScopedPathRendering();
+
+	ScopedPathRendering(const ScopedPathRendering&)			   = delete;
+	ScopedPathRendering(ScopedPathRendering&&)				   = delete;
+	ScopedPathRendering& operator=(const ScopedPathRendering&) = delete;
+	ScopedPathRendering& operator=(ScopedPathRendering&&)	   = delete;
+};
+
+class ScopedClipPath {
+  public:
+	ScopedClipPath(const Path& mask, bool showMask = false) { Path::pushClipPath(mask, showMask); }
+	~ScopedClipPath() { Path::popClipPath(); }
+
+	ScopedClipPath(const ScopedClipPath&)			 = delete;
+	ScopedClipPath(ScopedClipPath&&)				 = delete;
+	ScopedClipPath& operator=(const ScopedClipPath&) = delete;
+	ScopedClipPath& operator=(ScopedClipPath&&)		 = delete;
+};
+
+class ScopedCover {
+	ci::gl::Context* mCtx = nullptr;
+
+  public:
+	ScopedCover(bool clearStencil = true);
+	~ScopedCover();
+
+	ScopedCover(const ScopedCover&)			   = delete;
+	ScopedCover(ScopedCover&&)				   = delete;
+	ScopedCover& operator=(const ScopedCover&) = delete;
+	ScopedCover& operator=(ScopedCover&&)	   = delete;
+};
+
+inline Path circle(float x, float y, float r) {
+	std::stringstream ss;
+
+	ss << 'M' << x + r << ',' << y;
+	ss << 'a' << r << ',' << r << ',' << 0 << ',' << false << ',' << true << ',' << -(r + r) << ',' << 0;
+	ss << 'a' << r << ',' << r << ',' << 0 << ',' << false << ',' << true << ',' << +(r + r) << ',' << 0;
+	ss << 'Z';
+
+	return Path{ss.str()};
+}
+
+inline Path ellipse(float x, float y, float rx, float ry) {
+	std::stringstream ss;
+
+	ss << 'M' << x + rx << ',' << y;
+	ss << 'a' << rx << ',' << ry << ',' << 0 << ',' << false << ',' << true << ',' << -(rx + rx) << ',' << 0;
+	ss << 'a' << rx << ',' << ry << ',' << 0 << ',' << false << ',' << true << ',' << +(rx + rx) << ',' << 0;
+	ss << 'Z';
+
+	return Path{ss.str()};
+}
+
+inline Path arc(float cx, float cy, float rx, float ry, float angle, bool closed = true) {
+	angle = glm::sign(angle) * glm::min(glm::abs(angle), glm::radians(360.0f) - 1.0e-5f);
+
+	std::stringstream ss;
+
+	const float s	  = sin(angle);
+	const float c	  = cos(angle);
+	const bool	large = glm::abs(angle) > glm::pi<float>();
+	const bool	sweep = angle > 0;
+
+	ss << 'M' << cx + rx << ',' << cy;
+	ss << 'A' << rx << ',' << ry << ',' << 0 << ',' << large << ',' << sweep << ',' << cx + c * rx << ','
+	   << cy + s * ry;
+
+	if (closed) {
+		ss << 'L' << cx << ',' << cy;
+		ss << 'Z';
+	}
+
+	return Path{ss.str()};
+}
+
+inline Path line(float x1, float y1, float x2, float y2) {
+	std::stringstream ss;
+
+	ss << 'M' << x1 << ',' << y1;
+	ss << 'L' << x2 << ',' << y2;
+
+	return Path{ss.str()};
+}
+
+inline Path line(const glm::vec2& a, const glm::vec2& b) {
+	return line(a.x, a.y, b.x, b.y);
+}
+
+inline Path polygon(const glm::vec2* points, size_t count, bool closed) {
+	std::stringstream ss;
+
+	if (count > 1) {
+		ss << 'M' << points[0].x << ',' << points[0].y;
+		for (size_t i = 1; i < count; ++i)
+			ss << 'L' << points[i].x << ',' << points[i].y;
+		if (closed) ss << 'Z';
+	}
+
+	return Path{ss.str()};
+}
+
+inline Path polygon(const std::vector<glm::vec2>& points, bool closed) {
+	return polygon(points.data(), points.size(), closed);
+}
+
+inline Path polygon(const std::vector<float>& points, bool closed) {
+	return polygon(reinterpret_cast<const glm::vec2*>(points.data()), points.size() / 2, closed);
+}
+
+//! Returns a path with rounded corners. Define your path in CW order for this to work correctly.
+inline Path roundedPolygon(const glm::vec2* points, size_t count, float r, bool closed) {
+	std::stringstream ss;
+
+	// See: https://stackoverflow.com/a/24780108/858219
+	if (count > 1) {
+		for (size_t i = 0; i < count; ++i) {
+			size_t im = (i + count - 1) % count; // i - 1
+			size_t ip = (i + 1) % count;		 // i + 1
+			if (i == 0 && !closed) {
+				// No rounding for the first segment.
+				ss << 'M' << points[i].x << ',' << points[i].y;
+			} else if (i + 1 < count || closed) {
+				auto a = mix(points[i], points[im], 0.5f);
+				auto b = points[i];
+				auto c = mix(points[i], points[ip], 0.5f);
+
+				auto angle	 = glm::atan(c.y - b.y, c.x - b.x) - glm::atan(a.y - b.y, a.x - b.x);
+				auto radius	 = r;
+				auto segment = radius / glm::abs(glm::tan(angle / 2.0f));
+
+				auto la = distance(points[i], points[im]);
+				auto lc = distance(points[i], points[ip]);
+				if (segment > la || segment > lc) {
+					segment = glm::min(la, lc);
+					radius	= segment * glm::abs(glm::tan(angle / 2.0f));
+				}
+
+				a = mix(points[i], points[im], segment / la);
+				c = mix(points[i], points[ip], segment / lc);
+
+				ss << (i == 0 ? 'M' : 'L') << a.x << ',' << a.y;
+				ss << 'A' << radius << ',' << radius << ',' << 0 << ',' << false << ',' << true << ',' << c.x << ','
+				   << c.y;
+
+			} else {
+				// No rounding for the last segment.
+				ss << 'L' << points[i].x << ',' << points[i].y;
+			}
+		}
+
+		if (closed) ss << 'Z';
+	}
+
+	return Path{ss.str()};
+}
+
+inline Path roundedPolygon(const std::vector<glm::vec2>& points, float r, bool closed) {
+	return roundedPolygon(points.data(), points.size(), r, closed);
+}
+
+inline Path roundedPolygon(const std::vector<float>& points, float r, bool closed) {
+	return roundedPolygon(reinterpret_cast<const glm::vec2*>(points.data()), points.size() / 2, r, closed);
+}
+
+inline Path rectangle(float x, float y, float width, float height) {
+	std::stringstream ss;
+
+	ss << 'M' << x << ',' << y;
+	ss << 'L' << x + width << ',' << y;
+	ss << 'L' << x + width << ',' << y + height;
+	ss << 'L' << x << ',' << y + height;
+	ss << 'Z';
+
+	return Path{ss.str()};
+}
+
+inline Path rectangle(const ci::Rectf& bounds) {
+	return rectangle(bounds.x1, bounds.y1, bounds.getWidth(), bounds.getHeight());
+}
+
+inline Path roundedRectangle(float x, float y, float width, float height, float rx, float ry) {
+	std::stringstream ss;
+
+	ss << 'M' << x + rx << ',' << y;
+	ss << 'L' << x + width - rx << ',' << y;
+	ss << 'A' << rx << ',' << ry << ',' << 0 << ',' << false << ',' << true << ',' << x + width << ',' << y + ry;
+	ss << 'L' << x + width << ',' << y + height - ry;
+	ss << 'A' << rx << ',' << ry << ',' << 0 << ',' << false << ',' << true << ',' << x + width - rx << ','
+	   << y + height;
+	ss << 'L' << x + rx << ',' << y + height;
+	ss << 'A' << rx << ',' << ry << ',' << 0 << ',' << false << ',' << true << ',' << x << ',' << y + height - ry;
+	ss << 'L' << x << ',' << y + ry;
+	ss << 'A' << rx << ',' << ry << ',' << 0 << ',' << false << ',' << true << ',' << x + rx << ',' << y;
+	ss << 'Z';
+
+	return Path{ss.str()};
+}
+
+inline Path roundedRectangle(const ci::Rectf& bounds, float rx, float ry) {
+	return roundedRectangle(bounds.x1, bounds.y1, bounds.getWidth(), bounds.getHeight(), rx, ry);
+}
+
+inline Path star(float cx, float cy, float rmax, float rmin, float points, float angle) {
+	std::stringstream ss;
+
+	const float step = glm::radians(180.0f / glm::round(points));
+	for (float i = 0.f; i < glm::radians(360.0f);) {
+		float x = cx + rmax * glm::sin(angle + i);
+		float y = cy - rmax * glm::cos(angle + i);
+		if (ss.str().empty())
+			ss << 'M' << x << ',' << y;
+		else
+			ss << 'L' << x << ',' << y;
+		i += step;
+		x = cx + rmin * glm::sin(angle + i);
+		y = cy - rmin * glm::cos(angle + i);
+		ss << 'L' << x << ',' << y;
+		i += step;
+	}
+
+	ss << 'Z';
+
+	return Path{ss.str()};
+}
+
+inline Path arrow(const glm::vec2& p0, const glm::vec2& p1, float thickness, float width = 4, float length = 4,
+				  float concavity = 0) {
+	std::stringstream ss;
+
+	const auto dist		 = glm::distance(p0, p1);
+	const auto direction = (p1 - p0) / dist;
+	const auto normal	 = glm::vec2(-direction.y, direction.x) * 0.5f * thickness;
+	const auto base		 = p0 + direction * glm::max(0.0f, dist - thickness * length);
+	const auto size		 = thickness * length * concavity * direction;
+
+	ss << 'M' << p0.x - normal.x << ',' << p0.y - normal.y;
+	ss << 'L' << base.x - normal.x + size.x << ',' << base.y - normal.y + size.y;
+	ss << 'L' << base.x - normal.x * width << ',' << base.y - normal.y * width;
+	ss << 'L' << p1.x << ',' << p1.y;
+	ss << 'L' << base.x + normal.x * width << ',' << base.y + normal.y * width;
+	ss << 'L' << base.x + normal.x + size.x << ',' << base.y + normal.y + size.y;
+	ss << 'L' << p0.x + normal.x << ',' << p0.y + normal.y;
+	ss << 'Z';
+
+	return Path{ss.str()};
+}
+
+inline glm::mat3x3 toMat3x3(const glm::mat3x2& m) {
+	return {m[0][0], m[0][1], 0, m[1][0], m[1][1], 0, m[2][0], m[2][1], 1};
+}
+
+inline glm::mat4x4 toMat4x4(const glm::mat3x2& m) {
+	return {m[0][0], m[0][1], 0, 0, m[1][0], m[1][1], 0, 0, 0, 0, 1, 0, m[2][0], m[2][1], 0, 1};
+}
+
+} // namespace nvpath

--- a/projects/nvpath/src/nvpath/NvPathSvg.cpp
+++ b/projects/nvpath/src/nvpath/NvPathSvg.cpp
@@ -1,0 +1,3848 @@
+/*
+Copyright (c) 2023, Paul Houx Creative Coding - All rights reserved.
+This code is intended for use with the Cinder C++ library: http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "stdafx.h"
+
+#pragma warning(push)
+#pragma warning(disable : 4996)
+
+#include <cinder/Base64.h>
+#include <cinder/ImageIo.h>
+#include <cinder/Log.h>
+#include <cinder/Text.h>
+#include <cinder/Utilities.h>
+
+#include <ds/util/string_util.h>
+
+#include "nvpath/NvPathSvg.h"
+
+using namespace std;
+using namespace ci;
+
+namespace nvpath::svg {
+
+namespace {
+
+	char charToLower(const char c) {
+		if (c >= 'A' && c <= 'Z') return char(c + 32);
+		return c;
+	}
+
+	char charToUpper(const char c) {
+		if (c >= 'a' && c <= 'z') return char(c - 32);
+		return c;
+	}
+
+	// float parseFloat(const char** sInOut) {
+	//	char		  temp[256];
+	//	unsigned char i = 0;
+	//	const char*	  s = *sInOut;
+	//	while (*s && (isspace(*s) || *s == ','))
+	//		s++;
+	//	if (!s) throw FloatParseExc();
+	//	if (ds::isNumeric(*s)) {
+	//		while (*s == '-' || *s == '+') {
+	//			temp[i++] = *s;
+	//			if (!i) throw FloatParseExc(); // buffer overflow
+	//			s++;
+	//		}
+	//		bool parsingExponent  = false;
+	//		bool startingExponent = false;
+	//		bool seenDecimal	  = false;
+	//		while (*s && (parsingExponent || (*s != '-' && *s != '+')) && ds::isNumeric(*s)) {
+	//			startingExponent = false;
+	//			if (*s == '.' && seenDecimal)
+	//				break;
+	//			else if (*s == '.')
+	//				seenDecimal = true;
+	//			temp[i++] = *s;
+	//			if (!i) throw FloatParseExc(); // buffer overflow
+	//			if (*s == 'e' || *s == 'E') {
+	//				parsingExponent	 = true;
+	//				startingExponent = true;
+	//			} else
+	//				parsingExponent = false;
+	//			s++;
+	//		}
+	//		if (startingExponent) { // if we got a false positive on an exponent, for example due to "ex" or "em"
+	//								// unit, back up one
+	//			--i;
+	//			--s;
+	//		}
+	//		temp[i]			  = 0;
+	//		const auto result = float(strtod(temp, nullptr));
+	//		*sInOut			  = s;
+	//		return result;
+	//	} else
+	//		throw FloatParseExc();
+	// }
+
+	// parses float from comma-separated parenthetical list
+	vector<float> parseFloatList(const char** c) {
+		vector<float> result;
+		while (**c && isspace(**c))
+			(*c)++;
+		if (**c != '(') return result; // failure
+		(*c)++;
+		do {
+			result.push_back(ds::parseFloat(c));
+			while (**c && (**c == ',' || isspace(**c)))
+				(*c)++;
+		} while (**c && **c != ')');
+
+		// get rid of trailing closing paren
+		if (**c) (*c)++;
+
+		return result;
+	}
+
+	vector<Value> parseValueList(const char** c, bool requireParens = true) {
+		vector<Value> result;
+		while (**c && isspace(**c))
+			(*c)++;
+		if (requireParens) {
+			if (**c != '(') return result; // failure
+			(*c)++;
+		}
+		do {
+			result.push_back(Value::parse(c));
+			while (**c && (**c == ',' || isspace(**c)))
+				(*c)++;
+		} while (**c && **c != ')');
+
+		// get rid of trailing closing paren
+		if (requireParens && **c) (*c)++;
+
+		return result;
+	}
+
+	vector<Value> readValueList(const std::string& s, bool requireParens = true) {
+		const char* temp = s.c_str();
+		return parseValueList(&temp, requireParens);
+	}
+
+	vector<Value> readValueList(const char* c, bool requireParens = true) {
+		const char* temp = c;
+		return parseValueList(&temp, requireParens);
+	}
+
+	Value readValue(const std::string& s, float minV, float maxV) {
+		const char* temp   = s.c_str();
+		Value		result = Value::parse(&temp);
+		if (result.value() < minV) result = minV;
+		if (result.value() > maxV) result = maxV;
+		return result;
+	}
+
+	Value readValue(const std::string& s) {
+		const char* temp   = s.c_str();
+		const Value result = Value::parse(&temp);
+		return result;
+	}
+
+	// breaks comma-separated list into strings, optionally strips single or double quotes; removes all leading and
+	// trailing white space
+	vector<string> readStringList(const std::string& s, bool stripQuotes = false) {
+		vector<string> result = split(s, ",");
+		for (auto& resultIt : result) {
+			auto trimmed = trim(resultIt);
+			if (stripQuotes) {
+				trimmed.erase(std::remove(trimmed.begin(), trimmed.end(), '"'), trimmed.end());
+				trimmed.erase(std::remove(trimmed.begin(), trimmed.end(), '\''), trimmed.end());
+			}
+			resultIt = trimmed;
+		}
+
+		return result;
+	}
+
+} // anonymous namespace
+
+CapsStyle toCapsStyle(LineCap lineCap) {
+	switch (lineCap) {
+	case LINE_CAP_BUTT:
+		return CapsStyle::FLAT;
+	case LINE_CAP_ROUND:
+		return CapsStyle::ROUND;
+	case LINE_CAP_SQUARE:
+		return CapsStyle::SQUARE;
+	}
+
+	return CapsStyle::DEFAULT;
+}
+
+JoinStyle toJoinStyle(LineJoin lineJoin) {
+	switch (lineJoin) {
+	case LINE_JOIN_BEVEL:
+		return JoinStyle::BEVEL;
+	case LINE_JOIN_MITER:
+		return JoinStyle::MITER_REVERT;
+	case LINE_JOIN_ROUND:
+		return JoinStyle::ROUND;
+	}
+
+	return JoinStyle::DEFAULT;
+}
+
+SpreadMethod toSpreadMethod(std::string style) {
+	style = trim(style);
+	if (!asciiCaseCmp(style.c_str(), "reflect")) return SpreadMethod::REFLECT;
+	if (asciiCaseCmp(style.c_str(), "repeat")) return SpreadMethod::REPEAT;
+	return SpreadMethod::PAD;
+}
+
+CoordinateSpace toGradientUnits(std::string style) {
+	style = trim(style);
+	if (style == "userSpaceOnUse") return CoordinateSpace::USER_SPACE_ON_USE;
+	return CoordinateSpace::OBJECT_BOUNDING_BOX;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Renderer
+void Renderer::setVisitor(const function<bool(const SvgNode&, Style*)>& visitor) {
+	mVisitor = std::make_shared<function<bool(const SvgNode&, Style*)>>(visitor);
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Style
+Style::Style() {
+	clear();
+}
+
+Style::Style(const XmlTree& xml, const SvgNode* parent) {
+	clear();
+
+	// Make sure to parse the 'color' property before 'fill' or 'stroke',
+	// so that 'fill="currentColor"' works. See: https://www.w3.org/TR/SVGTiny12/painting.html#ColorProperty
+	if (xml.hasAttribute("color")) parseProperty("color", xml.getAttribute("color").getValue(), parent);
+
+	for (const auto& attrib : xml.getAttributes()) {
+		if (attrib.getName() == "class")
+			parseClassAttribute(attrib.getValue(), parent);
+		else if (attrib.getName() == "style")
+			parseStyleAttribute(attrib.getValue(), parent);
+		else
+			parseProperty(attrib.getName(), attrib.getValue(), parent);
+	}
+}
+
+Style Style::makeGlobalDefaults() {
+	Style result;
+
+	result.setColor(getColorDefault());
+	result.setFill(getFillDefault());
+	result.setStroke(getStrokeDefault());
+	result.setFillOpacity(getFillOpacityDefault());
+	result.setStrokeOpacity(getStrokeOpacityDefault());
+
+	result.setStrokeWidth(getStrokeWidthDefault());
+	result.setFillRule(getFillRuleDefault());
+	result.setLineCap(getLineCapDefault());
+	result.setLineJoin(getLineJoinDefault());
+	result.setMiterLimit(getMiterLimitDefault());
+	result.setDashArray(getDashArrayDefault());
+	result.setDashOffset(getDashOffsetDefault());
+	result.setStopColor(getStopColorDefault());
+	result.setStopOpacity(getStopOpacityDefault());
+
+	result.setFontFamilies(getFontFamiliesDefault());
+	result.setFontSize(getFontSizeDefault());
+	result.setFontWeight(getFontWeightDefault());
+	result.setTextAnchor(getTextAnchorDefault());
+
+	result.setVisible(true);
+	result.setDisplayNone(false);
+
+	return result;
+}
+
+void Style::clear() {
+	mSpecifiesColor = false;
+	mSpecifiesFill = mSpecifiesStroke = false;
+	mSpecifiesOpacity = mSpecifiesFillOpacity = mSpecifiesStrokeOpacity = false;
+	mOpacity															= 1.0f;
+	mSpecifiesStrokeWidth												= false;
+	mSpecifiesFillRule													= false;
+	mSpecifiesLineCap													= false;
+	mSpecifiesLineJoin													= false;
+	mSpecifiesMiterLimit												= false;
+	mSpecifiesDashArray													= false;
+	mSpecifiesDashOffset												= false;
+	mSpecifiesClipPath													= false;
+	mSpecifiesStopColor													= false;
+	mSpecifiesStopOpacity												= false;
+	mSpecifiesFontFamilies = mSpecifiesFontSize = mSpecifiesFontWeight = mSpecifiesTextAnchor = false;
+	mSpecifiesVisible																		  = false;
+	mVisible																				  = true;
+	mDisplayNone																			  = false;
+	mClipPath																				  = nullptr;
+}
+
+const ColorA8u& Style::getColorDefault() {
+	static ColorA8u sBlack(0, 0, 0, 255); // Default color depends on user agent.
+	return sBlack;
+}
+
+const Paint& Style::getFillDefault() {
+	static const Paint sPaintBlack = Paint(Color::black());
+	return sPaintBlack;
+}
+const Paint& Style::getStrokeDefault() {
+	static const Paint sPaintNone = Paint();
+	return sPaintNone;
+}
+
+const std::vector<std::string>& Style::getFontFamiliesDefault() {
+	static shared_ptr<vector<string>> sDefault;
+	if (!sDefault) {
+		sDefault = std::make_shared<vector<string>>();
+		sDefault->push_back("Times New Roman"); // Most browsers use Times New Roman as the default font.
+	}
+
+	return *sDefault;
+}
+
+void Style::parseClassAttribute(const std::string& stylePropertyString, const SvgNode* parent) {
+	// Find <style> tag in ancestors.
+	const auto styles = dynamic_cast<const SvgStyles*>(parent->findTagInAncestors("style"));
+
+	// Merge styles.
+	if (styles) *this += styles->findStyle(stylePropertyString);
+}
+
+void Style::parseStyleAttribute(const std::string& stylePropertyString, const SvgNode* parent) {
+	// separate into pairs based on semicolons
+	const vector<string> valuePairs = split(stylePropertyString, ';');
+	for (const auto& pair : valuePairs) {
+		vector<string> valuePair = split(pair, ':');
+		if (valuePair.size() != 2) continue;
+
+		parseProperty(trim(valuePair[0]), trim(valuePair[1]), parent);
+	}
+}
+
+bool Style::parseProperty(const std::string& key, const std::string& value, const SvgNode* parent) {
+	if (key == "color") {
+		mColor = parsePaint(value.c_str(), &mSpecifiesColor, parent).getColor();
+		return true;
+	} else if (key == "fill") {
+		mFill = parsePaint(value.c_str(), &mSpecifiesFill, parent);
+		return true;
+	} else if (key == "stroke") {
+		mStroke = parsePaint(value.c_str(), &mSpecifiesStroke, parent);
+		return true;
+	} else if (key == "opacity") {
+		mOpacity		  = readValue(value, 0, 1).asUser();
+		mSpecifiesOpacity = true;
+		return true;
+	} else if (key == "fill-opacity") {
+		mFillOpacity		  = readValue(value, 0, 1).asUser();
+		mSpecifiesFillOpacity = true;
+		return true;
+	} else if (key == "stroke-opacity") {
+		mStrokeOpacity			= readValue(value, 0, 1).asUser();
+		mSpecifiesStrokeOpacity = true;
+		return true;
+	} else if (key == "stroke-width") {
+		if (value != "inherit") {
+			mSpecifiesStrokeWidth = true;
+			mStrokeWidth		  = float(strtod(value.c_str(), nullptr));
+		}
+		return true;
+	} else if (key == "fill-rule") {
+		if (value == "evenodd") {
+			mSpecifiesFillRule = true;
+			mFillRule		   = FILL_RULE_EVEN_ODD;
+		} else if (value == "nonzero") {
+			mSpecifiesFillRule = true;
+			mFillRule		   = FILL_RULE_NONZERO;
+		}
+		return true;
+	} else if (key == "stroke-linecap") {
+		if (value == "butt") {
+			mSpecifiesLineCap = true;
+			mLineCap		  = LINE_CAP_BUTT;
+		} else if (value == "round") {
+			mSpecifiesLineCap = true;
+			mLineCap		  = LINE_CAP_ROUND;
+		} else if (value == "square") {
+			mSpecifiesLineCap = true;
+			mLineCap		  = LINE_CAP_SQUARE;
+		}
+		return true;
+	} else if (key == "stroke-linejoin") {
+		if (value == "miter") {
+			mSpecifiesLineJoin = true;
+			mLineJoin		   = LINE_JOIN_MITER;
+		} else if (value == "round") {
+			mSpecifiesLineJoin = true;
+			mLineJoin		   = LINE_JOIN_ROUND;
+		} else if (value == "bevel") {
+			mSpecifiesLineJoin = true;
+			mLineJoin		   = LINE_JOIN_BEVEL;
+		}
+		return true;
+	} else if (key == "stroke-miterlimit") {
+		if (value != "inherit") {
+			mSpecifiesMiterLimit = true;
+			mMiterLimit			 = float(atof(value.c_str())); // should be >= 1, otherwise error
+		}
+		return true;
+	} else if (key == "stroke-dasharray") {
+		if (value != "inherit") {
+			mSpecifiesDashArray = true;
+			mDashArray.clear();
+			if (!(value == "none" || value.empty())) {
+				const auto values = readValueList(value, false);
+				for (const auto& val : values)
+					mDashArray.push_back(val.asUser());
+			}
+		}
+		return true;
+	} else if (key == "stroke-dashoffset") {
+		if (value != "inherit") {
+			if (!(value == "none" || value.empty())) {
+				mSpecifiesDashOffset = true;
+				mDashOffset			 = Value::parse(value).asUser();
+			}
+		}
+		return true;
+	} else if (key == "clip-path") {
+		if (value != "inherit") {
+			if (!strncmp(value.c_str(), "url", 3)) {
+				char		id[1024];
+				const char* hash	   = strchr(value.c_str(), '#');
+				const char* closeParen = strchr(value.c_str(), ')');
+				if ((!closeParen) || (!hash) || (closeParen - hash >= 1024)) return false;
+				strncpy(id, hash + 1, closeParen - hash - 1);
+				id[closeParen - hash - 1] = 0;
+				mSpecifiesClipPath		  = true;
+				mClipPathId				  = id;
+				return true;
+			}
+			return false;
+		}
+		return true;
+	} else if (key == "stop-color") {
+		if (value != "inherit") mStopColor = parsePaint(value.c_str(), &mSpecifiesStopColor, nullptr).getColor();
+		return true;
+	} else if (key == "stop-opacity") {
+		if (value != "inherit") {
+			mStopOpacity		  = readValue(value, 0, 1).asUser();
+			mSpecifiesStopOpacity = true;
+		}
+		return true;
+	} else if (key == "font-family") {
+		mSpecifiesFontFamilies = true;
+		setFontFamilies(readStringList(value, true));
+		return true;
+	} else if (key == "font-size") {
+		if (!value.empty() && isdigit(value[0])) { // we don't parse something like font-size:medium
+			mSpecifiesFontSize = true;
+			setFontSize(readValue(value));
+		}
+		return true;
+	} else if (key == "font-weight") {
+		const string weightString = trim(value);
+		if (isdigit(weightString[0])) {
+			int v = strtol(weightString.c_str(), nullptr, 10);
+			if (v > 900) v = 900;
+			if (v < 100) v = 100;
+			mFontWeight			 = FontWeight(static_cast<int>(WEIGHT_100) + ((v / 100) - 1));
+			mSpecifiesFontWeight = true;
+		} else if (asciiCaseEqual(weightString, "normal")) {
+			mFontWeight			 = WEIGHT_NORMAL;
+			mSpecifiesFontWeight = true;
+		} else if (asciiCaseEqual(weightString, "bold")) {
+			mFontWeight			 = WEIGHT_BOLD;
+			mSpecifiesFontWeight = true;
+		}
+		return true;
+	} else if (key == "text-anchor") {
+		mSpecifiesTextAnchor = true;
+		if (asciiCaseEqual(value, "start")) mTextAnchor = TEXT_ANCHOR_START;
+		if (asciiCaseEqual(value, "middle"))
+			mTextAnchor = TEXT_ANCHOR_MIDDLE;
+		else if (asciiCaseEqual(value, "end"))
+			mTextAnchor = TEXT_ANCHOR_END;
+		else
+			mSpecifiesTextAnchor = false;
+		return true;
+	} else if (key == "display") {
+		// we can't handle most of the possibilities yet; only 'none'
+		if (value == "none")
+			mDisplayNone = true;
+		else
+			mDisplayNone = false;
+		return true;
+	} else if (key == "visibility") {
+		if (value != "inherit") {
+			mSpecifiesVisible = true;
+			if (value == "hidden" || value == "collapse")
+				mVisible = false;
+			else
+				mVisible = true;
+		}
+		return true;
+	} else
+		return false;
+}
+
+Paint Style::parsePaint(const char* value, bool* specified, const SvgNode* parent) const {
+	*specified = false;
+	while (*value && isspace(*value))
+		value++;
+
+	if (!*value) return {};
+
+	if (!strncmp(value, "inherit", 7)) {
+		*specified = false;
+		return {};
+	}
+
+	if (!strncmp(value, "currentColor", 12)) {
+		*specified = true;
+		return Paint{parent->getColor()};
+	}
+
+	if (value[0] == '#') { // hex color
+		uint32_t v = 0;
+		if (strlen(value) > 4) {
+			for (int c = 0; c < 6; ++c) {
+				const char	   ch  = charToUpper(value[1 + c]);
+				const uint32_t col = ch - ((ch > '9') ? ('A' - 10) : '0');
+				v += col << ((5 - c) * 4);
+			}
+		} else { // 3-digit hex shorthand; double each digit
+			for (int c = 0; c < 3; ++c) {
+				const char	   ch  = charToUpper(value[1 + c]);
+				const uint32_t col = ch - ((ch > '9') ? ('A' - 10) : '0');
+				v += col << ((5 - (c * 2 + 0)) * 4);
+				v += col << ((5 - (c * 2 + 1)) * 4);
+			}
+		}
+		*specified = true;
+		return Paint{ColorA8u(char(v >> 16), char(v >> 8) & 255, char(v) & 255, 255)};
+	} else if (!strncmp(value, "none", 4)) {
+		*specified = true;
+		return {};
+	} else if (!strncmp(value, "rgba", 4)) {
+		const vector<Value> values = readValueList(value + 4);
+		if (values.size() == 4) {
+			*specified = true;
+			return Paint{ColorA8u(uint8_t(values[0].asUser(255)), uint8_t(values[1].asUser(255)),
+								  uint8_t(values[2].asUser(255)), uint8_t(255 * values[3].asUser(1)))};
+		}
+		*specified = false;
+		return {};
+	} else if (!strncmp(value, "rgb", 3)) {
+		const vector<Value> values = readValueList(value + 3);
+		if (values.size() == 3) {
+			*specified = true;
+			return Paint{ColorA8u(uint8_t(values[0].asUser(255)), uint8_t(values[1].asUser(255)),
+								  uint8_t(values[2].asUser(255)), 255)};
+		}
+		*specified = false;
+		return {};
+	} else if (!strncmp(value, "url", 3)) {
+		char		id[1024];
+		const char* hash	   = strchr(value, '#');
+		const char* closeParen = strchr(value, ')');
+		if ((!closeParen) || (!hash) || (closeParen - hash >= 1024)) return {};
+		strncpy(id, hash + 1, closeParen - hash - 1);
+		id[closeParen - hash - 1] = 0;
+
+		Paint result = parent->findPaintInAncestors(id);
+		if ((closeParen + 1)) // Parse fallback color.
+			result.setFallback(std::make_shared<Paint>(parsePaint(closeParen + 1, specified, parent)));
+
+		*specified = true;
+
+		return result;
+	} else { // try to find color amongst named colors
+		Color8u result = svgNameToRgb(value, specified);
+		if (specified)
+			return Paint{result};
+		else
+			return {};
+	}
+}
+
+void Style::resolve(const SvgNode* node) const {
+	if (mSpecifiesFill && mFill.needsResolve()) {
+		mFill = node->findPaintInAncestors(mFill.getId());
+	}
+	if (mSpecifiesStroke && mStroke.needsResolve()) {
+		mStroke = node->findPaintInAncestors(mStroke.getId());
+	}
+}
+
+bool Style::operator==(const Style& other) const {
+	if (mSpecifiesOpacity && !ds::approxEqual(mOpacity, other.mOpacity)) return false;
+	if (mSpecifiesFillOpacity && !ds::approxEqual(mFillOpacity, other.mFillOpacity)) return false;
+	if (mSpecifiesStrokeOpacity && !ds::approxEqual(mStrokeOpacity, other.mStrokeOpacity)) return false;
+	if (mSpecifiesFill && mFill != other.mFill) return false;
+	if (mSpecifiesStroke && mStroke != other.mStroke) return false;
+	if (mSpecifiesStrokeWidth && !ds::approxEqual(mStrokeWidth, other.mStrokeWidth)) return false;
+	if (mSpecifiesFillRule && mFillRule != other.mFillRule) return false;
+	if (mSpecifiesLineCap && mLineCap != other.mLineCap) return false;
+	if (mSpecifiesLineJoin && mLineJoin != other.mLineJoin) return false;
+	if (mSpecifiesMiterLimit && !ds::approxEqual(mMiterLimit, other.mMiterLimit)) return false;
+	if (mSpecifiesDashArray && mDashArray != other.mDashArray) return false;
+	if (mSpecifiesDashOffset && !ds::approxEqual(mDashOffset, other.mDashOffset)) return false;
+	if (mSpecifiesClipPath && mClipPathId != other.mClipPathId) return false;
+	return true;
+}
+
+void Style::operator+=(const Style& other) {
+	if (other.mSpecifiesOpacity) setOpacity(other.mOpacity);
+	if (other.mSpecifiesFillOpacity) setFillOpacity(other.mFillOpacity);
+	if (other.mSpecifiesStrokeOpacity) setStrokeOpacity(other.mStrokeOpacity);
+	if (other.mSpecifiesFill) setFill(other.mFill);
+	if (other.mSpecifiesStroke) setStroke(other.mStroke);
+	if (other.mSpecifiesStrokeWidth) setStrokeWidth(other.mStrokeWidth);
+	if (other.mSpecifiesFillRule) setFillRule(other.mFillRule);
+	if (other.mSpecifiesLineCap) setLineCap(other.mLineCap);
+	if (other.mSpecifiesLineJoin) setLineJoin(other.mLineJoin);
+	if (other.mSpecifiesMiterLimit) setMiterLimit(other.mMiterLimit);
+	if (other.mSpecifiesDashArray) setDashArray(other.mDashArray);
+	if (other.mSpecifiesDashOffset) setDashOffset(other.mDashOffset);
+	if (other.mSpecifiesClipPath) setClipPath(other.mClipPathId);
+	mClipPath = other.mClipPath;
+}
+
+Style Style::operator+(const Style& other) const {
+	Style result(*this);
+	result += other;
+	return result;
+}
+
+void Style::startRender(Renderer& renderer, const SvgNode* node) const {
+	if (mSpecifiesFill) renderer.pushFill(mFill);
+	if (mSpecifiesStroke) renderer.pushStroke(mStroke);
+	if (mSpecifiesOpacity) {
+		// if this node draws, we'll force both fill opacity and stroke opacity to be 'opacity'
+		if (node->isDrawable()) {
+			renderer.pushFillOpacity(mOpacity);
+			renderer.pushStrokeOpacity(mOpacity);
+		}
+	} else {
+		if (mSpecifiesFillOpacity) renderer.pushFillOpacity(mFillOpacity);
+		if (mSpecifiesStrokeOpacity) renderer.pushStrokeOpacity(mStrokeOpacity);
+	}
+	if (mSpecifiesStrokeWidth) renderer.pushStrokeWidth(mStrokeWidth);
+	if (mSpecifiesFillRule) renderer.pushFillRule(mFillRule);
+	if (mSpecifiesLineCap) renderer.pushLineCap(mLineCap);
+	if (mSpecifiesLineJoin) renderer.pushLineJoin(mLineJoin);
+	if (mSpecifiesMiterLimit) renderer.pushMiterLimit(mMiterLimit);
+	if (mSpecifiesDashArray) renderer.pushDashArray(mDashArray);
+	if (mSpecifiesDashOffset) renderer.pushDashOffset(mDashOffset);
+	if (mSpecifiesClipPath) {
+		if (!mClipPath) mClipPath = node->getClipPath(*this);
+		if (mClipPath->useObjectBoundingBox()) {
+			// Calculate object space transform matrix.
+			const auto bounds	 = node->getBoundingBox();
+			const auto transform = scale(translate(mat3(), bounds.getUpperLeft()), bounds.getSize());
+
+			// Apply matrix prior to rendering the clip path and restore afterwards.
+			renderer.pushMatrix(transform);
+			renderer.pushClipPath(*mClipPath);
+			renderer.popMatrix();
+		} else
+			renderer.pushClipPath(*mClipPath);
+	}
+}
+
+void Style::finishRender(Renderer& renderer, const SvgNode* node) const {
+	if (mSpecifiesClipPath) renderer.popClipPath();
+	if (mSpecifiesDashOffset) renderer.popDashOffset();
+	if (mSpecifiesDashArray) renderer.popDashArray();
+	if (mSpecifiesMiterLimit) renderer.popMiterLimit();
+	if (mSpecifiesLineJoin) renderer.popLineJoin();
+	if (mSpecifiesLineCap) renderer.popLineCap();
+	if (mSpecifiesFillRule) renderer.popFillRule();
+	if (mSpecifiesStrokeWidth) renderer.popStrokeWidth();
+	if ((mSpecifiesOpacity && node->isDrawable()) || ((!mSpecifiesOpacity) && mSpecifiesStrokeOpacity))
+		renderer.popStrokeOpacity();
+	if ((mSpecifiesOpacity && node->isDrawable()) || ((!mSpecifiesOpacity) && mSpecifiesFillOpacity))
+		renderer.popFillOpacity();
+	if (mSpecifiesStroke) renderer.popStroke();
+	if (mSpecifiesFill) renderer.popFill();
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Value
+float Value::asUser(float percentOf, float dpi, float fontSize, float fontXHeight) const {
+	switch (mUnit) {
+	case USER:
+	case PX:
+		return mValue;
+	case PERCENT:
+		return mValue * percentOf / 100;
+	case PT:
+		return mValue * (dpi / 72);
+	case PC:
+		return mValue * 12 * (dpi / 72); // there are 12pts in a pica
+	case MM:
+		return mValue * dpi / 25.4f; // 25.4mm in an inch
+	case CM:
+		return mValue * dpi / 2.54f; // 2.54cm in an inch
+	case INCH:
+		return mValue * dpi;
+	case EM:
+		return mValue * fontSize;
+	case EX:
+		return mValue * fontXHeight;
+	}
+
+	return mValue;
+}
+
+float Value::asUser(const SvgDoc* doc, const Style& style) const {
+	return asUser(100, doc->getDpi(), style.getFontSize().asUser(), style.getFontSize().asUser() * 7.0f / 12.0f);
+}
+
+float Value::asUserWidth(const SvgDoc* doc, const Style& style) const {
+	return asUser(doc->getWidth(), doc->getDpi(), style.getFontSize().asUser(),
+				  style.getFontSize().asUser() * 7.0f / 12.0f);
+}
+
+float Value::asUserHeight(const SvgDoc* doc, const Style& style) const {
+	return asUser(doc->getHeight(), doc->getDpi(), style.getFontSize().asUser(),
+				  style.getFontSize().asUser() * 7.0f / 12.0f);
+}
+
+// Reads the suffix and converts it to user units based on dpi
+Value Value::parse(const char** sInOut) {
+	float v = ds::parseFloat(sInOut);
+	if (strncmp(*sInOut, "px", 2) == 0) {
+		*sInOut += 2;
+		return {v, PX};
+	} else if (**sInOut == '%') {
+		*sInOut += 1;
+		return {v, PERCENT};
+	} else if (strncmp(*sInOut, "pt", 2) == 0) {
+		*sInOut += 2;
+		return {v, PT};
+	} else if (strncmp(*sInOut, "pc", 2) == 0) { // picas
+		*sInOut += 2;
+		return {v, PC};
+	} else if (strncmp(*sInOut, "mm", 2) == 0) {
+		*sInOut += 2;
+		return {v, MM};
+	} else if (strncmp(*sInOut, "cm", 2) == 0) {
+		*sInOut += 2;
+		return {v, CM};
+	} else if (strncmp(*sInOut, "in", 2) == 0) {
+		*sInOut += 2;
+		return {v, INCH};
+	} else if (strncmp(*sInOut, "em", 2) == 0) {
+		*sInOut += 2;
+		return {v, EM};
+	} else if (strncmp(*sInOut, "ex", 2) == 0) {
+		*sInOut += 2;
+		return {v, EX};
+	} else if (strncmp(*sInOut, "auto", 4) == 0) {
+		*sInOut += 4;
+		return {0, AUTO};
+	} else
+		return {v, USER};
+}
+
+Value Value::parse(const std::string& s) {
+	const char* temp = s.c_str();
+	return parse(&temp);
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Node
+SvgNode::SvgNode(SvgNode* parent, const XmlTree& xml)
+  : mParent(parent)
+  , mBoundingBoxCached(false)
+  , mStyle(xml, this) {
+	mUuid				= nextUuid();
+	mSpecifiesTransform = false;
+	mTag				= xml.getTag();
+	mId					= xml["id"];
+	if (xml.hasAttribute("transform")) {
+		mSpecifiesTransform = true;
+		mTransform			= parseTransform(xml["transform"]);
+	} else
+		mTransform = mat3();
+}
+
+const SvgDoc* SvgNode::getDoc() const {
+	const SvgNode* parent = mParent;
+	while (parent) {
+		const SvgDoc* doc = dynamic_cast<const SvgDoc*>(parent);
+		if (doc) return doc;
+
+		parent = parent->mParent;
+	}
+
+	return nullptr;
+}
+
+string SvgNode::getDomPath() const {
+	string		   result = mId;
+	const SvgNode* parent = this;
+	while (parent && parent->mParent) {
+		parent = parent->mParent;
+		result = parent->getId();
+		result += string("/") + result;
+	}
+
+	return result;
+}
+
+const ColorA8u& SvgNode::getColor() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesColor())
+		return style.getColor();
+	else if (mParent)
+		return mParent->getColor();
+	else
+		return Style::getColorDefault();
+}
+
+const Paint& SvgNode::getFill() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesFill())
+		return style.getFill();
+	else if (mParent)
+		return mParent->getFill();
+	else
+		return Style::getFillDefault();
+}
+
+const Paint& SvgNode::getStroke() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesStroke())
+		return style.getStroke();
+	else if (mParent)
+		return mParent->getStroke();
+	else
+		return Style::getStrokeDefault();
+}
+
+float SvgNode::getStrokeWidth() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesStrokeWidth())
+		return style.getStrokeWidth();
+	else if (mParent)
+		return mParent->getStrokeWidth();
+	else
+		return Style::getStrokeWidthDefault();
+}
+
+float SvgNode::getOpacity() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesOpacity())
+		return style.getOpacity();
+	else if (mParent)
+		return mParent->getOpacity();
+	else
+		return Style::getOpacityDefault();
+}
+
+float SvgNode::getFillOpacity() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesFillOpacity())
+		return style.getFillOpacity();
+	else if (mParent)
+		return mParent->getFillOpacity();
+	else
+		return Style::getFillOpacityDefault();
+}
+
+float SvgNode::getStrokeOpacity() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesStrokeOpacity())
+		return style.getStrokeOpacity();
+	else if (mParent)
+		return mParent->getStrokeOpacity();
+	else
+		return Style::getStrokeOpacityDefault();
+}
+
+FillRule SvgNode::getFillRule() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesFillRule())
+		return style.getFillRule();
+	else if (mParent)
+		return mParent->getFillRule();
+	else
+		return Style::getFillRuleDefault();
+}
+
+LineCap SvgNode::getLineCap() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesLineCap())
+		return style.getLineCap();
+	else if (mParent)
+		return mParent->getLineCap();
+	else
+		return Style::getLineCapDefault();
+}
+
+LineJoin SvgNode::getLineJoin() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesLineJoin())
+		return style.getLineJoin();
+	else if (mParent)
+		return mParent->getLineJoin();
+	else
+		return Style::getLineJoinDefault();
+}
+
+float SvgNode::getMiterLimit() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesMiterLimit())
+		return style.getMiterLimit();
+	else if (mParent)
+		return mParent->getMiterLimit();
+	else
+		return Style::getMiterLimitDefault();
+}
+
+const std::vector<float>& SvgNode::getDashArray() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesDashArray())
+		return style.getDashArray();
+	else if (mParent)
+		return mParent->getDashArray();
+	else
+		return Style::getDashArrayDefault();
+}
+
+float SvgNode::getDashOffset() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesDashOffset())
+		return style.getDashOffset();
+	else if (mParent)
+		return mParent->getDashOffset();
+	else
+		return Style::getDashOffsetDefault();
+}
+
+ColorA8u SvgNode::getStopColor() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesStopColor())
+		return style.getStopColor();
+	else if (mParent)
+		return mParent->getStopColor();
+	else
+		return Style::getStopColorDefault();
+}
+
+float SvgNode::getStopOpacity() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesStopOpacity())
+		return style.getStopOpacity();
+	else if (mParent)
+		return mParent->getStopOpacity();
+	else
+		return Style::getStopOpacityDefault();
+}
+
+const vector<string>& SvgNode::getFontFamilies() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesFontFamilies())
+		return style.getFontFamilies();
+	else if (mParent)
+		return mParent->getFontFamilies();
+	else
+		return Style::getFontFamiliesDefault();
+}
+
+Value SvgNode::getFontSize() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesFontSize())
+		return style.getFontSize();
+	else if (mParent)
+		return mParent->getFontSize();
+	else
+		return Style::getFontSizeDefault();
+}
+
+TextAnchor SvgNode::getTextAnchor() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesTextAnchor())
+		return style.getTextAnchor();
+	else if (mParent)
+		return mParent->getTextAnchor();
+	else
+		return Style::getTextAnchorDefault();
+}
+
+bool SvgNode::isVisible() const {
+	const auto& style = getStyle(); // Resolves style if needed.
+	if (style.specifiesVisible())
+		return style.isVisible();
+	else if (mParent)
+		return mParent->isVisible();
+	else
+		return true;
+}
+
+Paint SvgNode::parsePaint(const char* value, bool* specified, const SvgNode* parentNode) {
+	*specified = false;
+	while (*value && isspace(*value))
+		value++;
+
+	if (!*value) return {};
+
+	if (!strncmp(value, "inherit", 7)) {
+		*specified = false;
+		return {};
+	}
+
+	if (!strncmp(value, "currentColor", 12)) {
+		*specified = true;
+		return Paint{parentNode->getColor()};
+	}
+
+	if (value[0] == '#') { // hex color
+		uint32_t v = 0;
+		if (strlen(value) > 4) {
+			for (int c = 0; c < 6; ++c) {
+				const char	   ch  = charToUpper(value[1 + c]);
+				const uint32_t col = ch - ((ch > '9') ? ('A' - 10) : '0');
+				v += col << ((5 - c) * 4);
+			}
+		} else { // 3-digit hex shorthand; double each digit
+			for (int c = 0; c < 3; ++c) {
+				const char	   ch  = charToUpper(value[1 + c]);
+				const uint32_t col = ch - ((ch > '9') ? ('A' - 10) : '0');
+				v += col << ((5 - (c * 2 + 0)) * 4);
+				v += col << ((5 - (c * 2 + 1)) * 4);
+			}
+		}
+		*specified = true;
+		return Paint{ColorA8u(char(v >> 16), char(v >> 8) & 255, char(v) & 255, 255)};
+	} else if (!strncmp(value, "none", 4)) {
+		*specified = true;
+		return {};
+	} else if (!strncmp(value, "rgb", 3)) {
+		const vector<Value> values = readValueList(value + 3);
+		if (values.size() == 3) {
+			*specified = true;
+			return Paint{ColorA8u(uint8_t(values[0].asUser(255)), uint8_t(values[1].asUser(255)),
+								  uint8_t(values[2].asUser(255)), 255)};
+		}
+		*specified = false;
+		return {};
+	} else if (!strncmp(value, "url", 3)) {
+		char		id[1024];
+		const char* hash	   = strchr(value, '#');
+		const char* closeParen = strchr(value, ')');
+		if ((!closeParen) || (!hash) || (closeParen - hash >= 1024)) return {};
+		strncpy(id, hash + 1, closeParen - hash - 1);
+		id[closeParen - hash - 1] = 0;
+		*specified				  = true;
+		return parentNode->findPaintInAncestors(id);
+	} else { // try to find color amongst named colors
+		Color8u result = svgNameToRgb(value, specified);
+		if (specified)
+			return Paint{result};
+		else
+			return {};
+	}
+}
+
+mat3 SvgNode::parseTransform(const std::string& value) {
+	const char* c = value.c_str();
+	mat3		curMat;
+	mat3		nextMat;
+	while (parseTransformComponent(&c, &nextMat)) {
+		curMat = curMat * nextMat;
+	}
+	return curMat;
+}
+
+bool SvgNode::parseTransformComponent(const char** c, mat3* result) {
+	// skip leading whitespace
+	while (**c && (isspace(**c) || (**c == ',')))
+		(*c)++;
+
+	mat3 m;
+	if (!strncmp(*c, "scale", 5)) {
+		*c += 5; // strlen( "scale" );
+		const vector<float> v = parseFloatList(c);
+		if (v.size() == 1) {
+			m = scale(mat3(), vec2(v[0]));
+		} else if (v.size() == 2) {
+			m = scale(mat3(), vec2(v[0], v[1]));
+		} else
+			throw SvgTransformParseExc();
+	} else if (!strncmp(*c, "translate", 9)) {
+		*c += 9; // strlen( "translate" );
+		const vector<float> v = parseFloatList(c);
+		if (v.size() == 1)
+			m = translate(mat3(), vec2(v[0], 0));
+		else if (v.size() == 2) {
+			m = translate(mat3(), vec2(v[0], v[1]));
+		} else
+			throw SvgTransformParseExc();
+	} else if (!strncmp(*c, "rotate", 6)) {
+		*c += 6; // strlen( "rotate" );
+		const vector<float> v = parseFloatList(c);
+		if (v.size() == 1) {
+			const float a = toRadians(v[0]);
+			m			  = rotate(mat3(), a);
+		} else if (v.size() == 3) { // rotate around point
+			const float a = toRadians(v[0]);
+			const vec2	origin(v[1], v[2]);
+			m = translate(mat3(), origin);
+			m = rotate(m, a);
+			m = translate(m, -origin);
+		} else
+			throw SvgTransformParseExc();
+	} else if (!strncmp(*c, "matrix", 6)) {
+		*c += 6; // strlen( "matrix" );
+		const vector<float> v = parseFloatList(c);
+		if (v.size() == 6)
+			m = mat3(v[0], v[1], 0, v[2], v[3], 0, v[4], v[5], 1);
+		else
+			throw SvgTransformParseExc();
+	} else if (!strncmp(*c, "skewX", 5)) {
+		*c += 5; // strlen( "skewX" );
+		const vector<float> v = parseFloatList(c);
+		if (v.size() == 1) {
+			const float a = toRadians(v[0]);
+			m			  = shearY(mat3(), tan(a));
+		} else
+			throw SvgTransformParseExc();
+	} else if (!strncmp(*c, "skewY", 5)) {
+		*c += 5; // strlen( "skewY" );
+		const vector<float> v = parseFloatList(c);
+		if (v.size() == 1) {
+			const float a = toRadians(v[0]);
+			m			  = shearX(mat3(), tan(a));
+		} else
+			throw SvgTransformParseExc();
+	} else
+		return false;
+
+	*result = m;
+	return true;
+}
+
+// Parse a 'style' attribute searching for the key 'key', and returning its corresponding value or the empty string
+// if not found
+std::string SvgNode::findStyleValue(const std::string& styleString, const std::string& key) {
+	const vector<string> valuePairs = split(styleString, ';');
+	for (const auto& pair : valuePairs) {
+		vector<string> valuePair = split(pair, ':');
+		if (valuePair.size() != 2) continue;
+		if (valuePair[0] == key) return valuePair[1];
+	}
+	return {};
+}
+
+void SvgNode::parseStyle(const XmlTree& xml) {
+	mStyle = Style(xml, this);
+}
+
+Style SvgNode::calcInheritedStyle() const {
+	Style result;
+	result.setFill(getFill());
+	result.setStroke(getStroke());
+	result.setOpacity(getOpacity());
+	result.setFillOpacity(getFillOpacity());
+	result.setStrokeOpacity(getStrokeOpacity());
+	result.setFillRule(getFillRule());
+	result.setLineCap(getLineCap());
+	result.setLineJoin(getLineJoin());
+	result.setMiterLimit(getMiterLimit());
+	result.setDashArray(getDashArray());
+	result.setDashOffset(getDashOffset());
+	result.setStrokeWidth(getStrokeWidth());
+	result.setStopColor(getStopColor());
+	result.setStopOpacity(getStopOpacity());
+	result.setFontFamilies(getFontFamilies());
+	result.setFontSize(getFontSize());
+	return result;
+}
+
+const SvgClipPath* SvgNode::getClipPath() const {
+	if (getStyle().specifiesClipPath())
+		return dynamic_cast<const SvgClipPath*>(findInAncestors(getStyle().getClipPath()));
+
+	return nullptr;
+}
+
+const SvgClipPath* SvgNode::getClipPath(const Style& style) const {
+	if (style.specifiesClipPath()) return dynamic_cast<const SvgClipPath*>(findInAncestors(style.getClipPath()));
+
+	return nullptr;
+}
+
+void SvgNode::render(Renderer& renderer) const {
+	renderer.start();
+
+	const Style style = calcInheritedStyle();
+	if (mParent) renderer.pushMatrix(mParent->getTransformAbsolute());
+
+	startRender(renderer, style);
+	renderSelf(renderer);
+	finishRender(renderer, style);
+
+	renderer.finish();
+}
+
+void SvgNode::firstStartRender(Renderer& renderer) const {
+	renderer.pushFill(getFill());
+}
+
+void SvgNode::startRender(Renderer& renderer, const Style& style) const {
+	if (mSpecifiesTransform) renderer.pushMatrix(mTransform);
+	renderer.pushStyle(style);
+	style.startRender(renderer, this);
+}
+
+void SvgNode::finishRender(Renderer& renderer, const Style& style) const {
+	style.finishRender(renderer, this);
+	renderer.popStyle();
+	if (mSpecifiesTransform) renderer.popMatrix();
+}
+
+const SvgNode* SvgNode::findInAncestors(const std::string& elementId) const {
+	if (mId == elementId)
+		return this;
+	else if (mParent)
+		return mParent->findInAncestors(elementId);
+	else
+		return nullptr;
+}
+
+Paint SvgNode::findPaintInAncestors(const std::string& paintName) const {
+	const SvgNode* node = findInAncestors(paintName);
+	if (!node) return Paint{paintName}; // Needs to be resolved later.
+
+	if (typeid(SvgLinearGradient) == typeid(*node)) {
+		const auto* linearGradient = static_cast<const SvgLinearGradient*>(node);
+		return linearGradient->asPaint();
+	} else if (typeid(SvgRadialGradient) == typeid(*node)) {
+		const auto* radialGradient = static_cast<const SvgRadialGradient*>(node);
+		return radialGradient->asPaint();
+	} else
+		return {};
+}
+
+const SvgNode* SvgNode::findTagInAncestors(const std::string& elementTag) const {
+	if (mTag == elementTag)
+		return this;
+	else if (mParent)
+		return mParent->findTagInAncestors(elementTag);
+	else
+		return nullptr;
+}
+
+mat3 SvgNode::getTransformAbsolute() const {
+	mat3 result;
+	if (mSpecifiesTransform)
+		result = mTransform;
+	else
+		result = mat3();
+
+	const SvgNode* parent = mParent;
+	while (parent) {
+		if (parent->specifiesTransform()) result = parent->getTransform() * result;
+		parent = parent->getParent();
+	}
+
+	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Gradient
+SvgGradient::SvgGradient(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml) {
+	parse(xml);
+}
+
+void SvgGradient::parse(const XmlTree& xml) {
+	std::string ref;
+	if (xml.hasAttribute("xlink:href"))
+		ref = xml.getAttributeValue<string>("xlink:href");
+	else if (xml.hasAttribute("href"))
+		ref = xml.getAttributeValue<string>("href");
+
+	if (ref.size() > 1) {
+		if (ref[0] == '#') {
+			const string elementId		= ref.substr(1, string::npos);
+			const auto*	 referencedGrad = dynamic_cast<const SvgGradient*>(findInAncestors(elementId));
+			if (referencedGrad) {
+				copyAttributesFrom(*referencedGrad);
+			}
+		}
+	}
+
+	for (XmlTree::ConstIter stopsIt = xml.begin("stop"); stopsIt != xml.end(); ++stopsIt) {
+		mStops.emplace_back(this, *stopsIt);
+	}
+	if (xml.hasAttribute("gradientUnits"))
+		mUseObjectBoundingBox = xml.getAttributeValue<string>("gradientUnits") != string("userSpaceOnUse");
+	if (xml.hasAttribute("gradientTransform")) {
+		mSpecifiesTransform = true;
+		mTransform			= parseTransform(xml.getAttributeValue<string>("gradientTransform"));
+	}
+	if (xml.hasAttribute("spreadMethod")) {
+		mSpecifiesSpreadMethod = true;
+		mSpreadMethod		   = toSpreadMethod(xml.getAttributeValue<string>("spreadMethod"));
+	}
+
+	// See: https://svgwg.org/svg2-draft/pservers.html#GradientStops
+	// "Each gradient offset value is required to be equal to or greater than the previous gradient stop's offset
+	// value.
+	//  If a given gradient stop's offset value is not equal to or greater than all previous offset values, then the
+	//  offset value is adjusted to be equal to the largest of all previous offset values."
+	if (!mStops.empty()) {
+		float offset = mStops.front().offset;
+		for (auto& stop : mStops) {
+			offset = stop.offset = glm::max(offset, stop.offset);
+		}
+	}
+}
+
+void SvgGradient::copyAttributesFrom(const SvgGradient& rhs) {
+	mStops				  = rhs.mStops;
+	mUseObjectBoundingBox = rhs.mUseObjectBoundingBox;
+	if (rhs.mSpecifiesTransform) {
+		mSpecifiesTransform = true;
+		mTransform			= rhs.mTransform;
+	}
+	if (rhs.mSpecifiesSpreadMethod) {
+		mSpecifiesSpreadMethod = true;
+		mSpreadMethod		   = rhs.mSpreadMethod;
+	}
+}
+
+SvgGradient::Stop::Stop(const SvgNode* parent, const XmlTree& xml) {
+	if (xml.hasAttribute("offset"))
+		offset = Value::parse(xml.getAttributeValue<string>("offset"))
+					 .asUser(1); // Percentages will be converted to decimals, where 100% = 1.0f
+	if (xml.hasAttribute("stop-color"))
+		color = parsePaint(xml.getAttributeValue<string>("stop-color").c_str(), &specifiesColor, parent).getColor();
+	if (xml.hasAttribute("stop-opacity")) {
+		const auto value = xml.getAttributeValue<string>("stop-opacity");
+		if (value == "inherit") {
+			specifiesOpacity = false;
+		} else {
+			specifiesOpacity = true;
+			color.a			 = uint8_t(Value::parse(value).asUser() * 255);
+		}
+	}
+
+	if (xml.hasAttribute("style")) {
+		const string stopColorString = findStyleValue(xml.getAttributeValue<string>("style"), "stop-color");
+		if (!stopColorString.empty()) color = parsePaint(stopColorString.c_str(), &specifiesColor, parent).getColor();
+		const string stopOpacityString = findStyleValue(xml.getAttributeValue<string>("style"), "stop-opacity");
+		if (!stopOpacityString.empty()) {
+			color.a = uint8_t(Value::parse(stopOpacityString).asUser() * 255);
+		}
+	}
+
+	// See: https://svgwg.org/svg2-draft/pservers.html#GradientStops
+	// "Gradient offset values less than 0 (or less than 0%) are rounded up to 0%.
+	//  Gradient offset values greater than 1 (or greater than 100%) are rounded down to 100%."
+	offset = glm::clamp(offset, 0.0f, 1.0f);
+}
+
+Paint SvgGradient::asPaint() const {
+	// See: https://svgwg.org/svg2-draft/pservers.html#GradientStops
+	// "If no stops are defined, then painting shall occur as if 'none' were specified as the paint style."
+	if (getStyle().isDisplayNone() || !getStyle().isVisible() || mStops.empty()) {
+		return Paint{Paint::Type::NONE, getId()};
+	}
+
+	Paint result{getType(), getId()};
+	auto& stops = result.getStops();
+
+	stops.clear();
+	for (const auto& stop : mStops) {
+		if (stop.specifiesColor)
+			stops.emplace_back(stop.offset, stop.color);
+		else
+			stops.emplace_back(stop.offset, getStopColor());
+
+		// See: https://svgwg.org/svg2-draft/pservers.html#GradientStops
+		// "The opacity value used for the gradient calculation is the product of the value of stop-opacity and
+		// the opacity of the value of stop-color."
+		auto& opacity = stops.back().color.a;
+		if (stop.specifiesOpacity)
+			opacity = opacity * uint8_t(stop.opacity * 255.0f) / 255;
+		else
+			opacity = opacity * uint8_t(getStopOpacity() * 255.0f) / 255;
+	}
+
+	result.setUseObjectBoundingBox(mUseObjectBoundingBox);
+
+	if (mSpecifiesTransform) {
+		result.setTransform(mTransform);
+	}
+	if (mSpecifiesSpreadMethod) {
+		result.setSpreadMethod(mSpreadMethod);
+	}
+
+	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// LinearGradient
+SvgLinearGradient::SvgLinearGradient(SvgNode* parent, const XmlTree& xml)
+  : SvgGradient(parent, xml) {
+	parse(xml);
+}
+
+void SvgLinearGradient::parse(const XmlTree& xml) {
+	std::string ref;
+	if (xml.hasAttribute("xlink:href"))
+		ref = xml.getAttributeValue<string>("xlink:href");
+	else if (xml.hasAttribute("href"))
+		ref = xml.getAttributeValue<string>("href");
+
+	if (ref.size() > 1) {
+		if (ref[0] == '#') {
+			const string elementId		= ref.substr(1, string::npos);
+			const auto*	 referencedGrad = dynamic_cast<const SvgLinearGradient*>(findInAncestors(elementId));
+			if (referencedGrad) {
+				copyAttributesFrom(*referencedGrad);
+			}
+		}
+	}
+
+	if (xml.hasAttribute("x1")) mX1 = Value::parse(xml.getAttributeValue<string>("x1"));
+	if (xml.hasAttribute("y1")) mY1 = Value::parse(xml.getAttributeValue<string>("y1"));
+	if (xml.hasAttribute("x2")) mX2 = Value::parse(xml.getAttributeValue<string>("x2"));
+	if (xml.hasAttribute("y2")) mY2 = Value::parse(xml.getAttributeValue<string>("y2"));
+}
+
+void SvgLinearGradient::copyAttributesFrom(const SvgLinearGradient& rhs) {
+	mX1 = rhs.mX1;
+	mY1 = rhs.mY1;
+	mX2 = rhs.mX2;
+	mY2 = rhs.mY2;
+}
+
+Paint SvgLinearGradient::asPaint() const {
+	Paint result = SvgGradient::asPaint();
+
+	// Percentages will be converted to decimals, where 100% = 1.0f
+	result.setCoords0(mX1.asUser(1), mY1.asUser(1));
+	result.setCoords1(mX2.asUser(1), mY2.asUser(1));
+
+	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// RadialGradient
+SvgRadialGradient::SvgRadialGradient(SvgNode* parent, const XmlTree& xml)
+  : SvgGradient(parent, xml) {
+	parse(xml);
+}
+
+void SvgRadialGradient::parse(const XmlTree& xml) {
+	std::string ref;
+	if (xml.hasAttribute("xlink:href"))
+		ref = xml.getAttributeValue<string>("xlink:href");
+	else if (xml.hasAttribute("href"))
+		ref = xml.getAttributeValue<string>("href");
+
+	if (ref.size() > 1) {
+		if (ref[0] == '#') {
+			const string elementId		= ref.substr(1, string::npos);
+			const auto*	 referencedGrad = dynamic_cast<const SvgRadialGradient*>(findInAncestors(elementId));
+			if (referencedGrad) {
+				copyAttributesFrom(*referencedGrad);
+			}
+		}
+	}
+
+	if (xml.hasAttribute("cx")) mCx = Value::parse(xml.getAttributeValue<string>("cx"));
+	if (xml.hasAttribute("cy")) mCy = Value::parse(xml.getAttributeValue<string>("cy"));
+	if (xml.hasAttribute("r")) mR = Value::parse(xml.getAttributeValue<string>("r"));
+	if (xml.hasAttribute("fx"))
+		mFx = Value::parse(xml.getAttributeValue<string>("fx"));
+	else
+		mFx = mCx;
+	if (xml.hasAttribute("fy"))
+		mFy = Value::parse(xml.getAttributeValue<string>("fy"));
+	else
+		mFy = mCy;
+	if (xml.hasAttribute("fr")) mFr = Value::parse(xml.getAttributeValue<string>("fr"));
+}
+
+void SvgRadialGradient::copyAttributesFrom(const SvgRadialGradient& rhs) {
+	mCx = rhs.mCx;
+	mCy = rhs.mCy;
+	mR	= rhs.mR;
+	mFx = rhs.mFx;
+	mFy = rhs.mFy;
+	mFr = rhs.mFr;
+}
+
+Paint SvgRadialGradient::asPaint() const {
+	Paint result = SvgGradient::asPaint();
+
+	// Percentages will be converted to decimals, where 100% = 1.0f
+	result.setCoords0(mCx.asUser(1), mCy.asUser(1));
+	result.setCoords1(mFx.asUser(1), mFy.asUser(1));
+	result.setRadius0(mR.asUser(1));
+	result.setRadius1(mFr.asUser(1));
+
+	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Svg
+Svg::Svg(const DataSourceRef& src)
+  : Svg(SvgDoc::create(src)) {}
+
+Svg::Svg(const SvgDocRef& svg)
+  : mDoc(svg)
+  , mBounds(svg->getBounds()) {}
+
+const Path* Svg::findPath(size_t uuid) const {
+	if (mPaths.count(static_cast<GLuint>(uuid))) return &mPaths.at(static_cast<GLuint>(uuid));
+
+	return nullptr;
+}
+
+const Path* Svg::insertPath(size_t uuid, const Path& path, bool isClipPath) {
+	if (!findPath(uuid)) {
+		mPaths.insert_or_assign(static_cast<GLuint>(uuid), path);
+
+		// Set path parameters.
+		if (!isClipPath) {
+			const auto& path = mPaths.at(static_cast<GLuint>(uuid));
+			path.setMiterLimit(mStacks.miterLimit.back());
+			path.setDashPattern(mStacks.dashArray.back());
+			path.setDashOffset(mStacks.dashOffset.back());
+			path.setEndCaps(toCapsStyle(mStacks.lineCap.back()));
+			path.setDashCaps(toCapsStyle(mStacks.lineCap.back()), toCapsStyle(mStacks.lineCap.back()));
+			path.setJoinStyle(toJoinStyle(mStacks.lineJoin.back()));
+			path.setStrokeWidth(mStacks.strokeWidth.back());
+		}
+	}
+
+	return &mPaths.at(static_cast<GLuint>(uuid));
+}
+
+const Path* Svg::insertPath(size_t uuid, const std::string& path, bool isClipPath) {
+	if (!findPath(uuid)) {
+		mPaths.insert_or_assign(static_cast<GLuint>(uuid), Path(path));
+
+		// Set path parameters.
+		if (!isClipPath) {
+			const auto& path = mPaths.at(static_cast<GLuint>(uuid));
+			path.setMiterLimit(mStacks.miterLimit.back());
+			path.setDashPattern(mStacks.dashArray.back());
+			path.setDashOffset(mStacks.dashOffset.back());
+			path.setEndCaps(toCapsStyle(mStacks.lineCap.back()));
+			path.setDashCaps(toCapsStyle(mStacks.lineCap.back()), toCapsStyle(mStacks.lineCap.back()));
+			path.setJoinStyle(toJoinStyle(mStacks.lineJoin.back()));
+			path.setStrokeWidth(mStacks.strokeWidth.back());
+		}
+	}
+
+	return &mPaths.at(static_cast<GLuint>(uuid));
+}
+
+const Path* Svg::insertPath(size_t uuid, const Path2d& path, bool isClipPath) {
+	if (!findPath(uuid)) {
+		mPaths.insert_or_assign(static_cast<GLuint>(uuid), Path(path));
+
+		// Set path parameters.
+		if (!isClipPath) {
+			const auto& path = mPaths.at(static_cast<GLuint>(uuid));
+			path.setMiterLimit(mStacks.miterLimit.back());
+			path.setDashPattern(mStacks.dashArray.back());
+			path.setDashOffset(mStacks.dashOffset.back());
+			path.setEndCaps(toCapsStyle(mStacks.lineCap.back()));
+			path.setDashCaps(toCapsStyle(mStacks.lineCap.back()), toCapsStyle(mStacks.lineCap.back()));
+			path.setJoinStyle(toJoinStyle(mStacks.lineJoin.back()));
+			path.setStrokeWidth(mStacks.strokeWidth.back());
+		}
+	}
+
+	return &mPaths.at(static_cast<GLuint>(uuid));
+}
+
+const Path* Svg::insertPath(size_t uuid, const Shape2d& shape, bool isClipPath) {
+	if (!findPath(uuid)) {
+		mPaths.insert_or_assign(static_cast<GLuint>(uuid), Path(shape));
+
+		// Set path parameters.
+		if (!isClipPath) {
+			const auto& path = mPaths.at(static_cast<GLuint>(uuid));
+			path.setMiterLimit(mStacks.miterLimit.back());
+			path.setDashPattern(mStacks.dashArray.back());
+			path.setDashOffset(mStacks.dashOffset.back());
+			path.setEndCaps(toCapsStyle(mStacks.lineCap.back()));
+			path.setDashCaps(toCapsStyle(mStacks.lineCap.back()));
+			path.setJoinStyle(toJoinStyle(mStacks.lineJoin.back()));
+			path.setStrokeWidth(mStacks.strokeWidth.back());
+		}
+	}
+
+	return &mPaths.at(static_cast<GLuint>(uuid));
+}
+
+void Svg::start() {
+	assert(nullptr == mCtx);
+
+	// Clear stacks.
+	mStacks.defaults();
+
+	// Keep track of OpenGL context.
+	mCtx = gl::context();
+
+	// Disable any shader.
+	mCtx->pushGlslProg(nullptr);
+
+	// Enable stencil buffer testing.
+	mCtx->pushBoolState(GL_STENCIL_TEST, GL_TRUE);
+
+	// Enable pre-multiplied alpha blending.
+	mCtx->pushBoolState(GL_BLEND, GL_TRUE);
+	mCtx->pushBlendFuncSeparate(GL_ONE, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+
+	// Disable sRGB correct rendering.
+	mCtx->pushBoolState(GL_FRAMEBUFFER_SRGB, GL_FALSE);
+
+	// Bind gradient texture.
+	mPaints.bind(mCtx, 0);
+
+	// Store current transformations.
+	gl::pushModelView();
+}
+
+void Svg::finish() {
+	assert(gl::context() == mCtx);
+
+	// Restore current transformations.
+	gl::popModelView();
+
+	// Unbind gradient texture.
+	mPaints.unbind(mCtx);
+
+	// Restore sRGB correct rendering.
+	mCtx->popBoolState(GL_FRAMEBUFFER_SRGB);
+
+	// Restore blending.
+	mCtx->popBlendFuncSeparate();
+	mCtx->popBoolState(GL_BLEND);
+
+	// Restore stencil buffer testing.
+	mCtx->popBoolState(GL_STENCIL_TEST);
+
+	// Restore shader.
+	mCtx->popGlslProg();
+
+	// Done.
+	mCtx = nullptr;
+}
+
+void Svg::clear() {
+	mPaints.clear();
+	mTextures.clear();
+	mPaths.clear();
+	mPaints.clear();
+}
+
+void Svg::pushGroup(const SvgGroup& group, float opacity) {
+	mStacks.groupOpacity.push_back(opacity);
+}
+
+void Svg::popGroup() {
+	mStacks.groupOpacity.pop_back();
+}
+
+void Svg::pushClipPath(const SvgClipPath& clippath) {
+	assert(gl::context() == mCtx);
+
+	if (mStacks.clipPath.size() > 5) CI_LOG_W("Maximum number of nested clip-paths reached! Results are undefined.");
+
+	// Only render clip path if visible.
+	if (clippath.isVisible() && !clippath.isDisplayNone()) {
+		// Store clip-path in cache.
+		const Path* path = findPath(clippath.getUuid());
+		if (!path) {
+			// Obtain shape from clip-path, which is a merge of all shapes contained within.
+			path = insertPath(clippath.getUuid(), clippath.getShape(), true);
+		}
+
+		/// <summary>
+		/// Clip paths are handled as follows:
+		///	  1. The path or group of paths are rendered to the stencil buffer using either non-zero or even-odd
+		/// fill
+		/// rule.
+		///	  2. The lowest bits of the stencil are now set for all pixels that need to be covered.
+		///	  3. We then cover the pixels without writing to the color buffer, replacing the stencil value with the
+		/// highest bit (0x80) if the test is passed.
+		///	  4. Repeat this for each nested clip path, but use the next highest bit (0x40, 0x20, etc.) instead.
+		///	  5. When rendering the actual clipped content, render normally but only draw pixels if all clip bits
+		/// are
+		/// set.
+		///	  6. We then reset the lowest clip bits by doing a cover with the appropriate stencil functions set.
+		///	  7. At the end of each clip path, reset the corresponding clip bit.
+		/// </summary>
+		const GLuint pathId		 = path->getId();
+		const GLuint clipMask	 = 0x80 >> mStacks.clipPath.size();
+		const GLuint coverMask	 = clipMask - 1;
+		const GLuint stencilMask = getStencilMask();
+
+		// Render shape to stencil buffer to use it as a clip-path.
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glMatrixMult3x3fNV(GL_MODELVIEW, value_ptr(mStacks.matrix.back()));
+
+		ScopedColorMask	  scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+		ScopedStencilMask scpStencilMask(coverMask | clipMask);					// Don't write to previous clip bits.
+
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
+		gl::stencilFunc(GL_NOTEQUAL, static_cast<GLint>(clipMask), coverMask);
+
+		gl::stencilFillPathNV(pathId, GL_COUNT_UP_NV,
+							  coverMask & stencilMask); // Write path to LSB portion (step 1).
+
+		gl::coverFillPathNV(pathId, GL_CONVEX_HULL_NV); // Convert LSB portion to clip bit (step 3).
+	}
+
+	//
+	mStacks.clipPath.push_back(&clippath);
+}
+
+void Svg::popClipPath() {
+	assert(gl::context() == mCtx);
+	assert(!mStacks.clipPath.empty());
+
+	// Generate draw call to reset the clip-path.
+	const auto& clipPath = *mStacks.clipPath.back();
+	if (clipPath.isVisible() && !clipPath.isDisplayNone()) {
+		const Path* path = findPath(clipPath.getUuid());
+		if (!path) {
+			__debugbreak(); // Path should already be cached!
+		}
+
+		//
+		const GLuint pathId	   = path->getId();
+		const GLuint clipMask  = 0x80 >> (mStacks.clipPath.size() - 1);
+		const GLuint coverMask = clipMask - 1;
+
+		// Render shape to stencil buffer to use it as a clip-path.
+		glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+		glMatrixMult3x3fNV(GL_MODELVIEW, value_ptr(mStacks.matrix.back()));
+
+		ScopedColorMask	  scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+		ScopedStencilMask scpStencilMask(coverMask | clipMask);					// Don't write to previous clip bits.
+
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+		gl::stencilFunc(GL_ALWAYS, static_cast<GLint>(clipMask), coverMask);
+
+		gl::coverFillPathNV(pathId, GL_CONVEX_HULL_NV); // Clear stencil buffer bits (step 7).
+	}
+
+	//
+	mStacks.clipPath.pop_back();
+}
+
+void Svg::drawPath(const SvgPath& path) {
+	assert(gl::context() == mCtx);
+
+	const Path* ptr = findPath(path.getUuid());
+	if (!ptr) {
+		ptr = insertPath(path.getUuid(), path.getShape());
+	}
+
+	render(*ptr);
+}
+
+void Svg::drawPolyline(const SvgPolyline& polyline) {
+	assert(gl::context() == mCtx);
+
+	const Path* ptr = findPath(polyline.getUuid());
+	if (!ptr) {
+		ptr = insertPath(polyline.getUuid(), polyline.getShape());
+	}
+
+	render(*ptr);
+}
+
+void Svg::drawPolygon(const SvgPolygon& polygon) {
+	assert(gl::context() == mCtx);
+
+	const Path* ptr = findPath(polygon.getUuid());
+	if (!ptr) {
+		ptr = insertPath(polygon.getUuid(), polygon.getShape());
+	}
+
+	render(*ptr);
+}
+
+void Svg::drawLine(const SvgLine& line) {
+	assert(gl::context() == mCtx);
+
+	const Path* ptr = findPath(line.getUuid());
+	if (!ptr) {
+		ptr = insertPath(line.getUuid(), line.getShape());
+	}
+
+	render(*ptr);
+}
+
+void Svg::drawRect(const SvgRect& rect) {
+	assert(gl::context() == mCtx);
+
+	const Path* ptr = findPath(rect.getUuid());
+	if (!ptr) {
+		ptr = insertPath(rect.getUuid(), rect.getShape());
+	}
+
+	render(*ptr);
+}
+
+void Svg::drawCircle(const SvgCircle& circle) {
+	assert(gl::context() == mCtx);
+
+	const Path* ptr = findPath(circle.getUuid());
+	if (!ptr) {
+		ptr = insertPath(circle.getUuid(), circle.getShape());
+	}
+
+	render(*ptr);
+}
+
+void Svg::drawEllipse(const SvgEllipse& ellipse) {
+	assert(gl::context() == mCtx);
+
+	const Path* ptr = findPath(ellipse.getUuid());
+	if (!ptr) {
+		ptr = insertPath(ellipse.getUuid(), ellipse.getShape());
+	}
+
+	render(*ptr);
+}
+
+void Svg::drawImage(const SvgImage& image) {
+	assert(gl::context() == mCtx);
+
+	if (!shouldRender()) return;
+
+	const Path* ptr = findPath(image.getUuid());
+	if (!ptr) {
+		ptr = insertPath(image.getUuid(), rectangle(image.getRect()));
+	}
+
+	//
+	const GLuint pathId = ptr->getId();
+
+	// Obtain image texture.
+	if (!mTextures.count(static_cast<GLuint>(image.getUuid()))) {
+		const auto svg = image.getSvg();
+		if (svg) {
+			// Render embedded SVG to texture.
+			Svg renderer;
+
+			gl::pushModelMatrix();
+			gl::setModelMatrix(mat4());
+
+			const Canvas canvas(static_cast<int>(svg->getWidth()), static_cast<int>(svg->getHeight()), 8, 16);
+			canvas.bind();
+			svg->render(renderer);
+			canvas.unbind();
+
+			gl::popModelMatrix();
+
+			auto texture = canvas.getTexture();
+			if (texture) mTextures.insert_or_assign(static_cast<GLuint>(image.getUuid()), texture);
+		} else {
+			const auto surface = image.getSurface();
+			if (surface)
+				mTextures.insert_or_assign(static_cast<GLuint>(image.getUuid()),
+										   gl::Texture2d::create(*surface, gl::Texture2d::Format().loadTopDown(false)));
+		}
+	}
+
+	const auto& texture = mTextures.at(static_cast<GLuint>(image.getUuid()));
+
+	// Render image.
+	gl::ScopedTextureBind scpImage(texture, 2);
+	glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+	glMatrixMult3x3fNV(GL_MODELVIEW, value_ptr(mStacks.matrix.back()));
+
+	ScopedShader scpShader(Shader::Type::IMAGE);
+	scpShader.setColor(ColorA::white());
+	scpShader.setCoords(GL_PATH_OBJECT_BOUNDING_BOX_NV /* TODO support userSpaceOnUse */, image.getTextureMatrix());
+	scpShader.uniform("image", 2);
+	scpShader.uniform("opacity", image.getOpacity());
+
+	if (!mStacks.clipPath.empty()) {
+		// Render clipped image.
+		const GLuint clipMask  = 0x80 >> mStacks.clipPath.size();
+		const GLuint coverMask = clipMask - 1;
+
+		ScopedStencilMask scpStencilMask(coverMask | clipMask); // Don't write to previous clip bits.
+
+		const GLuint mask = coverMask << 1 | 0x01;
+		gl::stencilFunc(GL_LESS, static_cast<GLint>(~mask & 0xFF), 0xFF); // (step 5).
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+
+		const GLuint stencilMask = getStencilMask();
+		glStencilThenCoverFillPathNV(pathId, GL_COUNT_UP_NV, stencilMask & coverMask,
+									 GL_CONVEX_HULL_NV); // (step 5).
+
+		// Remove shape from stencil buffer (step 6).
+		ScopedColorMask scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+		gl::stencilFunc(GL_ALWAYS, static_cast<GLint>(clipMask), coverMask);
+
+		gl::coverFillPathNV(pathId, GL_CONVEX_HULL_NV);
+	} else {
+		const GLuint stencilMask = getStencilMask();
+		gl::stencilFunc(GL_NOTEQUAL, 0, stencilMask);
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+
+		glStencilThenCoverFillPathNV(pathId, GL_COUNT_UP_NV, stencilMask, GL_CONVEX_HULL_NV);
+	}
+}
+
+void Svg::pushMatrix(const mat3& m) {
+	mStacks.matrix.push_back(mStacks.matrix.back() * m);
+}
+
+void Svg::popMatrix() {
+	mStacks.matrix.pop_back();
+}
+
+void Svg::pushFill(const Paint& paint) {
+	mStacks.fill.push_back(paint);
+
+	// Render gradients to texture.
+	mPaints.preparePaint(paint, 1, false);
+}
+
+void Svg::popFill() {
+	mStacks.fill.pop_back();
+}
+
+void Svg::pushStroke(const Paint& paint) {
+	mStacks.stroke.push_back(paint);
+
+	// Render gradients to texture.
+	mPaints.preparePaint(paint, 1, false);
+}
+
+void Svg::popStroke() {
+	mStacks.stroke.pop_back();
+}
+
+void Svg::pushFillOpacity(float opacity) {
+	mStacks.fillOpacity.push_back(opacity);
+}
+
+void Svg::popFillOpacity() {
+	mStacks.fillOpacity.pop_back();
+}
+
+void Svg::pushStrokeOpacity(float opacity) {
+	mStacks.strokeOpacity.push_back(opacity);
+}
+
+void Svg::popStrokeOpacity() {
+	mStacks.strokeOpacity.pop_back();
+}
+
+void Svg::pushStrokeWidth(float x) {
+	mStacks.strokeWidth.push_back(x);
+}
+
+void Svg::popStrokeWidth() {
+	mStacks.strokeWidth.pop_back();
+}
+
+void Svg::pushFillRule(FillRule fillRule) {
+	mStacks.fillRule.push_back(fillRule);
+}
+
+void Svg::popFillRule() {
+	mStacks.fillRule.pop_back();
+}
+
+void Svg::pushLineCap(LineCap lineCap) {
+	mStacks.lineCap.push_back(lineCap);
+}
+
+void Svg::popLineCap() {
+	mStacks.lineCap.pop_back();
+}
+
+void Svg::pushLineJoin(LineJoin lineJoin) {
+	mStacks.lineJoin.push_back(lineJoin);
+}
+
+void Svg::popLineJoin() {
+	mStacks.lineJoin.pop_back();
+}
+
+void Svg::pushMiterLimit(float miterLimit) {
+	mStacks.miterLimit.push_back(miterLimit);
+}
+
+void Svg::popMiterLimit() {
+	mStacks.miterLimit.pop_back();
+}
+
+void Svg::pushDashArray(const std::vector<float>& dashArray) {
+	mStacks.dashArray.push_back(dashArray);
+}
+
+void Svg::popDashArray() {
+	mStacks.dashArray.pop_back();
+}
+
+void Svg::pushDashOffset(float dashOffset) {
+	mStacks.dashOffset.push_back(dashOffset);
+}
+
+void Svg::popDashOffset() {
+	mStacks.dashOffset.pop_back();
+}
+
+void Svg::pushTextPen(const vec2& vec2) {
+	mStacks.textPen.push_back(vec2);
+}
+
+void Svg::popTextPen() {
+	mStacks.textPen.pop_back();
+}
+
+void Svg::pushTextRotation(float x) {
+	mStacks.textRotation.push_back(x);
+}
+
+void Svg::popTextRotation() {
+	mStacks.textRotation.pop_back();
+}
+
+void Svg::render(const Path& path) {
+	if (!shouldRender()) return;
+
+	if (!mStacks.fill.back().isNone()) {
+		// Vertical and horizontal lines don't have a bounding box, since they are one-dimensional,
+		// even though the stroke-width makes it look like they should have a bounding box with non-zero width and
+		// height.
+		if (mStacks.fill.back().fallback() && ds::approxZero(path.getFillBounds().calcArea())) {
+			if (!mStacks.fill.back().fallback()->isNone())
+				fill(path.getId(), *mStacks.fill.back().fallback(),
+					 mOpacity * mStacks.fillOpacity.back() * mStacks.calcGroupOpacity());
+		} else
+			fill(path.getId(), mStacks.fill.back(), mOpacity * mStacks.fillOpacity.back() * mStacks.calcGroupOpacity());
+	}
+	if (!mStacks.stroke.back().isNone()) {
+		// Vertical and horizontal lines don't have a bounding box, since they are one-dimensional,
+		// even though the stroke-width makes it look like they should have a bounding box with non-zero width and
+		// height.
+		if (mStacks.stroke.back().fallback() && ds::approxZero(path.getFillBounds().calcArea())) {
+			if (!mStacks.stroke.back().fallback()->isNone())
+				stroke(path.getId(), *mStacks.stroke.back().fallback(),
+					   mOpacity * mStacks.strokeOpacity.back() * mStacks.calcGroupOpacity());
+		} else
+			stroke(path.getId(), mStacks.stroke.back(),
+				   mOpacity * mStacks.strokeOpacity.back() * mStacks.calcGroupOpacity());
+	}
+}
+
+void Svg::fill(GLuint pathId, const Paint& paint, float opacity) {
+	glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+	glMatrixMult3x3fNV(GL_MODELVIEW, value_ptr(mStacks.matrix.back()));
+
+	//
+	ScopedShader scpShader(mPaints.preparePaint(paint, opacity));
+
+	//
+	if (!mStacks.clipPath.empty()) {
+		// Render clipped path.
+		const GLuint clipMask  = 0x80 >> mStacks.clipPath.size();
+		const GLuint coverMask = clipMask - 1;
+
+		ScopedStencilMask scpStencilMask(coverMask | clipMask); // Don't write to previous clip bits.
+
+		const GLuint mask = coverMask << 1 | 0x01;
+		gl::stencilFunc(GL_LESS, static_cast<GLint>(~mask & 0xFF), 0xFF); // (step 5).
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+
+		const GLuint stencilMask = getStencilMask();
+		glStencilThenCoverFillPathNV(pathId, GL_COUNT_UP_NV, stencilMask & coverMask,
+									 GL_CONVEX_HULL_NV); // (step 5).
+
+		// Remove path from stencil buffer (step 6).
+		ScopedColorMask scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+		gl::stencilFunc(GL_ALWAYS, static_cast<GLint>(clipMask), coverMask);
+
+		gl::coverFillPathNV(pathId, GL_CONVEX_HULL_NV);
+	} else {
+		const GLuint stencilMask = getStencilMask();
+		gl::stencilFunc(GL_NOTEQUAL, 0, stencilMask);
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+
+		glStencilThenCoverFillPathNV(pathId, GL_COUNT_UP_NV, stencilMask, GL_CONVEX_HULL_NV);
+	}
+}
+
+void Svg::stroke(GLuint pathId, const Paint& paint, float opacity) {
+	glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+	glMatrixMult3x3fNV(GL_MODELVIEW, value_ptr(mStacks.matrix.back()));
+
+	//
+	ScopedShader scpShader(mPaints.preparePaint(paint, opacity));
+
+	if (!mStacks.clipPath.empty()) {
+		// Render clipped path.
+		const GLuint clipMask  = 0x80 >> mStacks.clipPath.size();
+		const GLuint coverMask = clipMask - 1;
+
+		ScopedStencilMask scpStencilMask(coverMask | clipMask); // Don't write to previous clip bits.
+
+		const GLuint mask = coverMask << 1 | 0x01;
+		gl::stencilFunc(GL_LESS, static_cast<GLint>(~mask & 0xFF), 0xFF); // (step 5).
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+
+		glStencilThenCoverStrokePathNV(pathId, GL_COUNT_UP_NV, coverMask, GL_CONVEX_HULL_NV); // (step 5).
+
+		// Remove path from stencil buffer (step 6).
+		ScopedColorMask scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+		gl::stencilFunc(GL_ALWAYS, static_cast<GLint>(clipMask), coverMask);
+
+		gl::coverStrokePathNV(pathId, GL_CONVEX_HULL_NV);
+	} else {
+		gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+
+		glStencilThenCoverStrokePathNV(pathId, GL_COUNT_UP_NV, 0xFF, GL_CONVEX_HULL_NV);
+	}
+}
+
+void Svg::fillInstanced(GLuint baseId, GLsizei count, const glm::mat3x2* transforms, const uint32_t* indices,
+						const Paint& paint, float opacity) {
+	glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+	glMatrixMult3x3fNV(GL_MODELVIEW, value_ptr(mStacks.matrix.back()));
+
+	//
+	ScopedShader scpShader(mPaints.preparePaint(paint, opacity));
+
+	//
+	if (!mStacks.clipPath.empty()) {
+		// Render clipped text.
+		const GLuint clipMask  = 0x80 >> mStacks.clipPath.size();
+		const GLuint coverMask = clipMask - 1;
+
+		ScopedStencilMask scpStencilMask(coverMask | clipMask); // Don't write to previous clip bits.
+
+		const GLuint mask = coverMask << 1 | 0x01;
+		gl::stencilFunc(GL_LESS, static_cast<GLint>(~mask & 0xFF), 0xFF); // (step 5).
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+
+		// (step 5).
+		const GLuint stencilMask = getStencilMask();
+		glStencilThenCoverFillPathInstancedNV(count, GL_UNSIGNED_INT, indices, baseId, GL_PATH_FILL_MODE_NV,
+											  stencilMask & coverMask, GL_BOUNDING_BOX_OF_BOUNDING_BOXES_NV,
+											  GL_AFFINE_2D_NV, reinterpret_cast<const GLfloat*>(transforms));
+
+		// Remove text from stencil buffer (step 6).
+		ScopedColorMask scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+		gl::stencilFunc(GL_ALWAYS, static_cast<GLint>(clipMask), coverMask);
+
+		glStencilThenCoverFillPathInstancedNV(count, GL_UNSIGNED_INT, indices, baseId, GL_PATH_FILL_MODE_NV,
+											  stencilMask & coverMask, GL_BOUNDING_BOX_OF_BOUNDING_BOXES_NV,
+											  GL_AFFINE_2D_NV, reinterpret_cast<const GLfloat*>(transforms));
+	} else {
+		const GLuint stencilMask = getStencilMask();
+		gl::stencilFunc(GL_NOTEQUAL, 0, stencilMask);
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+
+		glStencilThenCoverFillPathInstancedNV(count, GL_UNSIGNED_INT, indices, baseId, GL_PATH_FILL_MODE_NV,
+											  stencilMask, GL_BOUNDING_BOX_OF_BOUNDING_BOXES_NV, GL_AFFINE_2D_NV,
+											  reinterpret_cast<const GLfloat*>(transforms));
+	}
+}
+
+void Svg::strokeInstanced(GLuint baseId, GLsizei count, const glm::mat3x2* transforms, const uint32_t* indices,
+						  const Paint& paint, float opacity) {
+	glMatrixLoadfEXT(GL_MODELVIEW, value_ptr(gl::getModelView()));
+	glMatrixMult3x3fNV(GL_MODELVIEW, value_ptr(mStacks.matrix.back()));
+
+	// Set stroke parameters for each glyph.
+	if (!paint.isNone()) {
+		const float scale = transforms[0][0][0]; // Assume uniform scaling and single font size per call.
+
+		for (GLsizei i = 0; i < count; ++i) {
+			const GLuint pathId = baseId + indices[i];
+			gl::pathParameteriNV(pathId, GL_PATH_END_CAPS_NV, static_cast<GLint>(toCapsStyle(mStacks.lineCap.back())));
+			gl::pathParameteriNV(pathId, GL_PATH_JOIN_STYLE_NV,
+								 static_cast<GLint>(toJoinStyle(mStacks.lineJoin.back())));
+			gl::pathParameterfNV(pathId, GL_PATH_STROKE_WIDTH_NV,
+								 static_cast<GLfloat>(mStacks.strokeWidth.back() / scale));
+			gl::pathParameterfNV(pathId, GL_PATH_MITER_LIMIT_NV, static_cast<GLfloat>(mStacks.miterLimit.back()));
+			// TODO: add support for dashing?
+		}
+	}
+
+	//
+	ScopedShader scpShader(mPaints.preparePaint(paint, opacity));
+
+	//
+	if (!mStacks.clipPath.empty()) {
+		// Render clipped text.
+		const GLuint clipMask  = 0x80 >> mStacks.clipPath.size();
+		const GLuint coverMask = clipMask - 1;
+
+		ScopedStencilMask scpStencilMask(coverMask | clipMask); // Don't write to previous clip bits.
+
+		const GLuint mask = coverMask << 1 | 0x01;
+		gl::stencilFunc(GL_LESS, static_cast<GLint>(~mask & 0xFF), 0xFF); // (step 5).
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+
+		// (step 5).
+		glStencilThenCoverStrokePathInstancedNV(count, GL_UNSIGNED_INT, indices, baseId, GL_PATH_FILL_MODE_NV,
+												coverMask, GL_BOUNDING_BOX_OF_BOUNDING_BOXES_NV, GL_AFFINE_2D_NV,
+												reinterpret_cast<const GLfloat*>(transforms));
+
+		// Remove text from stencil buffer (step 6).
+		ScopedColorMask scpColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // Don't write to color buffer.
+
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+		gl::stencilFunc(GL_ALWAYS, static_cast<GLint>(clipMask), coverMask);
+
+		glStencilThenCoverStrokePathInstancedNV(count, GL_UNSIGNED_INT, indices, baseId, GL_PATH_FILL_MODE_NV,
+												coverMask, GL_BOUNDING_BOX_OF_BOUNDING_BOXES_NV, GL_AFFINE_2D_NV,
+												reinterpret_cast<const GLfloat*>(transforms));
+	} else {
+		gl::stencilFunc(GL_NOTEQUAL, 0, 0xFF);
+		gl::stencilOp(GL_KEEP, GL_KEEP, GL_ZERO);
+
+		glStencilThenCoverStrokePathInstancedNV(count, GL_UNSIGNED_INT, indices, baseId, GL_PATH_FILL_MODE_NV, 0xFF,
+												GL_BOUNDING_BOX_OF_BOUNDING_BOXES_NV, GL_AFFINE_2D_NV,
+												reinterpret_cast<const GLfloat*>(transforms));
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Circle
+SvgCircle::SvgCircle(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml) {
+	const auto doc	 = getDoc();
+	const auto style = calcInheritedStyle();
+	if (xml.hasAttribute("cx")) mCenter.x = Value::parse(xml.getAttributeValue<string>("cx")).asUserWidth(doc, style);
+	if (xml.hasAttribute("cy")) mCenter.y = Value::parse(xml.getAttributeValue<string>("cy")).asUserHeight(doc, style);
+
+	const auto m = getTransformAbsolute();
+	mRadius		 = Value::parse(xml.getAttributeValue<string>("r")).asUser(100 * m[0][0]); // Use absolute scale.
+}
+
+void SvgCircle::renderSelf(Renderer& renderer) const {
+	if (mRadius > 0) // Zero-radius circles should never be drawn.
+		renderer.drawCircle(*this);
+}
+
+Shape2d SvgCircle::getShape() const {
+	Shape2d result;
+	result.arc(mCenter, mRadius, 0, float(M_PI) * 2);
+	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Ellipse
+SvgEllipse::SvgEllipse(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml) {
+	const auto doc	 = getDoc();
+	const auto style = calcInheritedStyle();
+	if (xml.hasAttribute("cx")) mCenter.x = Value::parse(xml.getAttributeValue<string>("cx")).asUserWidth(doc, style);
+	if (xml.hasAttribute("cy")) mCenter.y = Value::parse(xml.getAttributeValue<string>("cy")).asUserHeight(doc, style);
+	mRadiusX = Value::parse(xml.getAttributeValue<string>("rx")).asUserWidth(doc, style);
+	mRadiusY = Value::parse(xml.getAttributeValue<string>("ry")).asUserHeight(doc, style);
+}
+
+void SvgEllipse::renderSelf(Renderer& renderer) const {
+	if (mRadiusX > 0 && mRadiusY > 0) // Zero-radius ellipses should never be drawn.
+		renderer.drawEllipse(*this);
+}
+
+bool SvgEllipse::containsPoint(const vec2& pt) const {
+	const float x = (pt.x - mCenter.x) * (pt.x - mCenter.x) / (mRadiusX * mRadiusX);
+	const float y = (pt.y - mCenter.y) * (pt.y - mCenter.y) / (mRadiusY * mRadiusY);
+	return x + y < 1;
+}
+
+Shape2d SvgEllipse::getShape() const {
+	Shape2d result;
+
+	constexpr float magic = 0.552284749830793398402f; // 4/3*(sqrt(2)-1)
+	const vec2		offset(mRadiusX * magic, mRadiusY * magic);
+
+	result.moveTo(vec2(mCenter.x + mRadiusX, mCenter.y));
+	result.curveTo(vec2(mCenter.x + mRadiusX, mCenter.y + offset.y), vec2(mCenter.x + offset.x, mCenter.y + mRadiusY),
+				   vec2(mCenter.x, mCenter.y + mRadiusY));
+	result.curveTo(vec2(mCenter.x - offset.x, mCenter.y + mRadiusY), vec2(mCenter.x - mRadiusX, mCenter.y + offset.y),
+				   vec2(mCenter.x - mRadiusX, mCenter.y));
+	result.curveTo(vec2(mCenter.x - mRadiusX, mCenter.y - offset.y), vec2(mCenter.x - offset.x, mCenter.y - mRadiusY),
+				   vec2(mCenter.x, mCenter.y - mRadiusY));
+	result.curveTo(vec2(mCenter.x + offset.x, mCenter.y - mRadiusY), vec2(mCenter.x + mRadiusX, mCenter.y - offset.y),
+				   vec2(mCenter.x + mRadiusX, mCenter.y));
+	result.close();
+
+	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+//
+void ellipticalArc(Shape2d& path, float x1, float y1, float x2, float y2, float rx, float ry, float xAxisRotation,
+				   bool largeArcFlag, bool sweepFlag) {
+	// This is a translation of the  spec section "Elliptical Arc Implementation Notes"
+	// http://www.w3.org/TR//implnote.html#ArcImplementationNotes
+	float	   cosXAxisRotation = cosf(xAxisRotation);
+	float	   sinXAxisRotation = sinf(xAxisRotation);
+	const vec2 cPrime(cosXAxisRotation * (x2 - x1) * 0.5f + sinXAxisRotation * (y2 - y1) * 0.5f,
+					  -sinXAxisRotation * (x2 - x1) * 0.5f + cosXAxisRotation * (y2 - y1) * 0.5f);
+
+	// http://www.w3.org/TR//implnote.html#ArcCorrectionOutOfRangeRadii
+	float radiiScale = (cPrime.x * cPrime.x) / (rx * rx) + (cPrime.y * cPrime.y) / (ry * ry);
+	if (radiiScale > 1) {
+		radiiScale = math<float>::sqrt(radiiScale);
+		rx *= radiiScale;
+		ry *= radiiScale;
+	}
+
+	vec2 invRadius(1.0f / rx, 1.0f / ry);
+	vec2 point1 =
+		vec2(cosXAxisRotation * x1 + sinXAxisRotation * y1, -sinXAxisRotation * x1 + cosXAxisRotation * y1) * invRadius;
+	vec2 point2 =
+		vec2(cosXAxisRotation * x2 + sinXAxisRotation * y2, -sinXAxisRotation * x2 + cosXAxisRotation * y2) * invRadius;
+	vec2  delta = point2 - point1;
+	float d		= delta.x * delta.x + delta.y * delta.y;
+	if (d <= 0) return;
+
+	float theta1;
+	float thetaDelta;
+	vec2  center;
+
+	float s = math<float>::sqrt(std::max<float>(1 / d - 0.25f, 0));
+	if (sweepFlag == largeArcFlag) s = -s;
+
+	center = vec2(0.5f * (point1.x + point2.x) - delta.y * s, 0.5f * (point1.y + point2.y) + delta.x * s);
+
+	theta1		 = math<float>::atan2(point1.y - center.y, point1.x - center.x);
+	float theta2 = math<float>::atan2(point2.y - center.y, point2.x - center.x);
+
+	thetaDelta = theta2 - theta1;
+	if (thetaDelta < 0 && sweepFlag)
+		thetaDelta += 2 * float(M_PI);
+	else if (thetaDelta > 0 && (!sweepFlag))
+		thetaDelta -= 2 * float(M_PI);
+
+	// divide the full arc delta into pi/2 arcs and convert those to cubic beziers
+	int segments = int(ceilf(fabsf(thetaDelta / (float(M_PI) / 2))) + 1);
+	for (int i = 0; i < segments; ++i) {
+		float thetaStart	= theta1 + i * thetaDelta / segments;
+		float thetaEnd		= theta1 + (i + 1) * thetaDelta / segments;
+		float t				= (4 / 3.0f) * tanf(0.25f * (thetaEnd - thetaStart));
+		float sinThetaStart = math<float>::sin(thetaStart);
+		float cosThetaStart = math<float>::cos(thetaStart);
+		float sinThetaEnd	= math<float>::sin(thetaEnd);
+		float cosThetaEnd	= math<float>::cos(thetaEnd);
+
+		vec2 startPoint			 = vec2(cosThetaStart - t * sinThetaStart, sinThetaStart + t * cosThetaStart) + center;
+		startPoint				 = vec2(cosXAxisRotation * startPoint.x * rx - sinXAxisRotation * startPoint.y * ry,
+										sinXAxisRotation * startPoint.x * rx + cosXAxisRotation * startPoint.y * ry);
+		vec2 endPoint			 = vec2(cosThetaEnd, sinThetaEnd) + center;
+		vec2 transformedEndPoint = vec2(cosXAxisRotation * endPoint.x * rx - sinXAxisRotation * endPoint.y * ry,
+										sinXAxisRotation * endPoint.x * rx + cosXAxisRotation * endPoint.y * ry);
+		vec2 midPoint			 = endPoint + vec2(t * sinThetaEnd, -t * cosThetaEnd);
+		midPoint				 = vec2(cosXAxisRotation * midPoint.x * rx - sinXAxisRotation * midPoint.y * ry,
+										sinXAxisRotation * midPoint.x * rx + cosXAxisRotation * midPoint.y * ry);
+		path.curveTo(startPoint, midPoint, transformedEndPoint);
+	}
+}
+
+static const char* getNextPathItem(const char* s, char it[64]) {
+	int i = 0;
+	it[0] = '\0';
+	// Skip white spaces and commas
+	while (*s && (isspace(*s) || *s == ','))
+		s++;
+	if (!*s) return s;
+	if (ds::isNumeric(*s)) {
+		while (*s == '-' || *s == '+') {
+			if (i < 63) it[i++] = *s;
+			s++;
+		}
+		bool parsingExponent = false;
+		while (*s && (parsingExponent || (*s != '-' && *s != '+')) && ds::isNumeric(*s)) {
+			if (i < 63) it[i++] = *s;
+			if (*s == 'e' || *s == 'E')
+				parsingExponent = true;
+			else
+				parsingExponent = false;
+			s++;
+		}
+		it[i] = '\0';
+	} else {
+		it[0] = *s++;
+		it[1] = '\0';
+		return s;
+	}
+
+	return s;
+}
+
+char readNextCommand(const char** sInOut) {
+	const char* s = *sInOut;
+	while (*s && (isspace(*s) || *s == ','))
+		s++;
+	*sInOut = s + 1;
+	return *s;
+}
+
+bool readFlag(const char** sInOut) {
+	const char* s = *sInOut;
+	while (*s && (isspace(*s) || *s == ',' || *s == '-' || *s == '+'))
+		s++;
+	*sInOut = s + 1;
+	return *s != '0';
+}
+
+bool nextItemIsFloat(const char* s) {
+	while (*s && (isspace(*s) || *s == ','))
+		s++;
+	return ds::isNumeric(*s);
+}
+
+Shape2d parsePath(const std::string& p) {
+	const char* s = p.c_str();
+	vec2		v0;
+	vec2		v1;
+	vec2		v2;
+	vec2		lastPoint;
+	vec2		lastPoint2;
+
+	Shape2d result;
+	try {
+		bool done	  = false;
+		bool firstCmd = true;
+		char prevCmd  = '\0';
+		while (!done) {
+			char cmd = readNextCommand(&s);
+			switch (cmd) {
+			case 'm':
+			case 'M':
+				v0.x = ds::parseFloat(&s);
+				v0.y = ds::parseFloat(&s);
+				if ((!firstCmd) && (cmd == 'm')) v0 += lastPoint;
+				result.moveTo(v0);
+				lastPoint2 = lastPoint;
+				lastPoint  = v0;
+				while (nextItemIsFloat(s)) {
+					v0.x = ds::parseFloat(&s);
+					v0.y = ds::parseFloat(&s);
+					if (cmd == 'm') v0 += lastPoint;
+					result.lineTo(v0);
+					lastPoint2 = lastPoint;
+					lastPoint  = v0;
+				}
+				break;
+			case 'l':
+			case 'L':
+				do {
+					v0.x = ds::parseFloat(&s);
+					v0.y = ds::parseFloat(&s);
+					if (cmd == 'l') v0 += lastPoint;
+					result.lineTo(v0);
+					lastPoint2 = lastPoint;
+					lastPoint  = v0;
+				} while (nextItemIsFloat(s));
+				break;
+			case 'H':
+			case 'h':
+				do {
+					float x = ds::parseFloat(&s);
+					v0		= vec2((cmd == 'h') ? (lastPoint.x + x) : x, lastPoint.y);
+					result.lineTo(v0);
+					lastPoint2 = lastPoint;
+					lastPoint  = v0;
+				} while (nextItemIsFloat(s));
+				break;
+			case 'V':
+			case 'v':
+				do {
+					float y = ds::parseFloat(&s);
+					v0		= vec2(lastPoint.x, (cmd == 'v') ? (lastPoint.y + y) : (y));
+					result.lineTo(v0);
+					lastPoint2 = lastPoint;
+					lastPoint  = v0;
+				} while (nextItemIsFloat(s));
+				break;
+			case 'C':
+			case 'c':
+				do {
+					v0.x = ds::parseFloat(&s);
+					v0.y = ds::parseFloat(&s);
+					v1.x = ds::parseFloat(&s);
+					v1.y = ds::parseFloat(&s);
+					v2.x = ds::parseFloat(&s);
+					v2.y = ds::parseFloat(&s);
+					if (cmd == 'c') { // relative
+						v0 += lastPoint;
+						v1 += lastPoint;
+						v2 += lastPoint;
+					}
+					result.curveTo(v0, v1, v2);
+					lastPoint2 = v1;
+					lastPoint  = v2;
+				} while (nextItemIsFloat(s));
+				break;
+			case 'S':
+			case 's':
+				do {
+					if (prevCmd == 's' || prevCmd == 'S' || prevCmd == 'c' || prevCmd == 'C')
+						v0 = lastPoint * 2.0f - lastPoint2;
+					else
+						v0 = lastPoint;
+					prevCmd = cmd; // set this now in case we loop
+					v1.x	= ds::parseFloat(&s);
+					v1.y	= ds::parseFloat(&s);
+					v2.x	= ds::parseFloat(&s);
+					v2.y	= ds::parseFloat(&s);
+					if (cmd == 's') { // relative
+						v1 += lastPoint;
+						v2 += lastPoint;
+					}
+					result.curveTo(v0, v1, v2);
+					lastPoint2 = v1;
+					lastPoint  = v2;
+				} while (nextItemIsFloat(s));
+				break;
+			case 'Q':
+			case 'q':
+				do {
+					v0.x = ds::parseFloat(&s);
+					v0.y = ds::parseFloat(&s);
+					v1.x = ds::parseFloat(&s);
+					v1.y = ds::parseFloat(&s);
+					if (cmd == 'q') { // relative
+						v0 += lastPoint;
+						v1 += lastPoint;
+					}
+					result.quadTo(v0, v1);
+					lastPoint2 = v0;
+					lastPoint  = v1;
+				} while (nextItemIsFloat(s));
+				break;
+			case 'T':
+			case 't':
+				do {
+					if (prevCmd == 't' || prevCmd == 'T' || prevCmd == 'q' || prevCmd == 'Q')
+						v0 = lastPoint * 2.0f - lastPoint2;
+					else
+						v0 = lastPoint;
+					prevCmd = cmd; // set this now in case we loop
+					v1.x	= ds::parseFloat(&s);
+					v1.y	= ds::parseFloat(&s);
+					if (cmd == 't') { // relative
+						v1 += lastPoint;
+					}
+					result.quadTo(v0, v1);
+					lastPoint2 = v0;
+					lastPoint  = v1;
+				} while (nextItemIsFloat(s));
+				break;
+			case 'a':
+			case 'A': {
+				do {
+					float ra			= ds::parseFloat(&s);
+					float rb			= ds::parseFloat(&s);
+					float xAxisRotation = ds::parseFloat(&s) * float(M_PI) / 180.0f;
+					bool  largeArc		= readFlag(&s);
+					bool  sweepFlag		= readFlag(&s);
+					v0.x				= ds::parseFloat(&s);
+					v0.y				= ds::parseFloat(&s);
+					if (cmd == 'a') { // relative
+						v0 += lastPoint;
+					}
+					ellipticalArc(result, lastPoint.x, lastPoint.y, v0.x, v0.y, ra, rb, xAxisRotation, largeArc,
+								  sweepFlag);
+					lastPoint2 = lastPoint;
+					lastPoint  = v0;
+				} while (nextItemIsFloat(s));
+			} break;
+			case 'z':
+			case 'Z':
+				result.close();
+				lastPoint2 = lastPoint;
+				lastPoint  = (result.empty() || result.getContours().back().empty())
+								 ? vec2()
+								 : result.getContours().back().getPoint(0);
+				break;
+			case '\0':
+			default: // technically noise at the end of the string is acceptable according to the spec; see
+					 // W3C_SVG_11/paths-data-18.svg
+				done = true;
+				break;
+			}
+			firstCmd = false;
+			prevCmd	 = cmd;
+		}
+	} catch (...) {}
+
+	//// TODO For consistency, make sure paths are defined in CCW order for filled sections, CW for holes.
+	//// This is especially important when using instanced rendering.
+	// bool isClockwise = result.getContour(0).calcClockwise();
+	// if (isClockwise) result.reverse();
+
+	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Path
+SvgPath::SvgPath(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml) {
+	const auto p = xml.getAttributeValue<string>("d", "");
+	if (!p.empty()) {
+		mPath = parsePath(p);
+	}
+}
+
+void SvgPath::appendShape2d(Shape2d* appendTo) const {
+	for (const auto& contour : mPath.getContours()) {
+		appendTo->appendContour(contour);
+	}
+}
+
+void SvgPath::renderSelf(Renderer& renderer) const {
+	renderer.drawPath(*this);
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Line
+SvgLine::SvgLine(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml) {
+	const auto doc	 = getDoc();
+	const auto style = calcInheritedStyle();
+
+	// If the attribute is not specified, the effect is as if a value of "0" were specified.
+	if (xml.hasAttribute("x1")) mPoint1.x = Value::parse(xml.getAttributeValue<string>("x1")).asUserWidth(doc, style);
+	if (xml.hasAttribute("y1")) mPoint1.y = Value::parse(xml.getAttributeValue<string>("y1")).asUserHeight(doc, style);
+	if (xml.hasAttribute("x2")) mPoint2.x = Value::parse(xml.getAttributeValue<string>("x2")).asUserWidth(doc, style);
+	if (xml.hasAttribute("y2")) mPoint2.y = Value::parse(xml.getAttributeValue<string>("y2")).asUserHeight(doc, style);
+}
+
+void SvgLine::renderSelf(Renderer& renderer) const {
+	renderer.drawLine(*this);
+}
+
+Shape2d SvgLine::getShape() const {
+	Shape2d result;
+	result.moveTo(mPoint1);
+	result.lineTo(mPoint2);
+	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Rect
+SvgRect::SvgRect(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml) {
+	const auto doc	 = getDoc();
+	const auto style = calcInheritedStyle();
+
+	if (xml.hasAttribute("x"))
+		mRect.x1 = Value::parse(xml["x"]).asUserWidth(doc, style);
+	else
+		mRect.x1 = 0;
+	if (xml.hasAttribute("y"))
+		mRect.y1 = Value::parse(xml["y"]).asUserHeight(doc, style);
+	else
+		mRect.y1 = 0;
+
+	float width	 = 0;
+	float height = 0;
+	if (xml.hasAttribute("width")) width = Value::parse(xml["width"]).asUserWidth(doc, style);
+	if (xml.hasAttribute("height")) height = Value::parse(xml["height"]).asUserHeight(doc, style);
+	mRect.x2 = mRect.x1 + width;
+	mRect.y2 = mRect.y1 + height;
+
+	if (xml.hasAttribute("rx")) mRx = Value::parse(xml["rx"]);
+	if (xml.hasAttribute("ry")) mRy = Value::parse(xml["ry"]);
+
+	// See: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx
+	if (!xml.hasAttribute("rx")) mRx = mRy;
+	if (!xml.hasAttribute("ry")) mRy = mRx;
+
+	if (mRx.isPercent())
+		mRx = Value(glm::clamp(mRx.asUser(), 0.0f, 50.0f), Value::PERCENT);
+	else
+		mRx = Value(glm::clamp(mRx.asUser(), 0.0f, 0.5f * width));
+	if (mRy.isPercent())
+		mRy = Value(glm::clamp(mRy.asUser(), 0.0f, 50.0f), Value::PERCENT);
+	else
+		mRy = Value(glm::clamp(mRy.asUser(), 0.0f, 0.5f * height));
+
+	mBoundingBox = mRect;
+}
+
+void SvgRect::renderSelf(Renderer& renderer) const {
+	if (mRect.getWidth() > 0 && mRect.getHeight() > 0) // Zero-width or height rectangles should never be drawn.
+		renderer.drawRect(*this);
+}
+
+float SvgRect::getRx() const {
+	if (mRx.isPercent())
+		return mRx.asUser(1) * mRect.getWidth(); // Percentages will be converted to decimals, where 100% = 1.0f
+	return mRx.asUser();
+}
+
+float SvgRect::getRy() const {
+	if (mRy.isPercent())
+		return mRy.asUser(1) * mRect.getHeight(); // Percentages will be converted to decimals, where 100% = 1.0f
+	return mRy.asUser();
+}
+
+Shape2d SvgRect::getShape() const {
+	Shape2d result;
+
+	const float rx = getRx();
+	const float ry = getRy();
+	if (rx > 0 || ry > 0)
+		throw std::runtime_error("Rounded rectangles are not supported yet");
+	else {
+		result.moveTo(mRect.getUpperLeft());
+		result.lineTo(mRect.getUpperRight());
+		result.lineTo(mRect.getLowerRight());
+		result.lineTo(mRect.getLowerLeft());
+		result.close();
+	}
+
+	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Polygon
+vector<vec2> parsePointList(const std::string& p) {
+	vector<vec2> result;
+
+	if (!p.empty()) {
+		char		item[64];
+		const char* s	= p.c_str();
+		bool		odd = false;
+		float		lastVal;
+		while (*s) {
+			s = getNextPathItem(s, item);
+			if (!odd)
+				lastVal = float(strtod(item, nullptr));
+			else
+				result.emplace_back(lastVal, float(strtod(item, nullptr)));
+			odd = !odd;
+		}
+	}
+
+	return result;
+}
+
+SvgPolygon::SvgPolygon(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml) {
+	mPolyLine = PolyLine2f(parsePointList(xml.getAttributeValue<string>("points", "")));
+	mPolyLine.setClosed(true);
+}
+
+void SvgPolygon::renderSelf(Renderer& renderer) const {
+	renderer.drawPolygon(*this);
+}
+
+Shape2d SvgPolygon::getShape() const {
+	Shape2d result;
+
+	if (mPolyLine.getPoints().size() <= 1) return result;
+
+	result.moveTo(mPolyLine.getPoints()[0]);
+	for (auto ptIt = mPolyLine.getPoints().begin() + 1; ptIt != mPolyLine.getPoints().end(); ++ptIt)
+		result.lineTo(*ptIt);
+
+	result.close();
+
+	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Polyline
+SvgPolyline::SvgPolyline(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml) {
+	mPolyLine = PolyLine2f(parsePointList(xml.getAttributeValue<string>("points", "")));
+	mPolyLine.setClosed(false);
+}
+
+void SvgPolyline::renderSelf(Renderer& renderer) const {
+	renderer.drawPolyline(*this);
+}
+
+Shape2d SvgPolyline::getShape() const {
+	Shape2d result;
+
+	if (mPolyLine.getPoints().size() <= 1) return result;
+
+	result.moveTo(mPolyLine.getPoints()[0]);
+	for (auto ptIt = mPolyLine.getPoints().begin() + 1; ptIt != mPolyLine.getPoints().end(); ++ptIt)
+		result.lineTo(*ptIt);
+
+	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Group
+SvgGroup::SvgGroup(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml) {
+	SvgGroup::parse(xml);
+}
+
+SvgGroup::~SvgGroup() {
+	for (const auto& child : mChildren)
+		delete child;
+}
+
+void SvgGroup::parse(const XmlTree& xml) {
+	if (!ds::approxEqual(getOpacity(), 1.0f))
+		CI_LOG_W("Group '" << getId() << "' opacity of " << getOpacity()
+						   << " is currently not supported. A work-around is provided, but results may vary.");
+
+	for (XmlTree::ConstIter treeIt = xml.begin(); treeIt != xml.end(); ++treeIt) {
+		SvgNode* node = create(this, *treeIt);
+		if (node) mChildren.push_back(node);
+	}
+
+	if (xml.hasAttribute("clip-path")) {
+		const auto value = xml.getAttributeValue<std::string>("clip-path");
+
+		if (!strncmp(value.c_str(), "url", 3)) {
+			char		id[1024];
+			const char* hash	   = strchr(value.c_str(), '#');
+			const char* closeParen = strchr(value.c_str(), ')');
+			if ((closeParen) && (hash) && (closeParen - hash < 1024)) {
+				strncpy(id, hash + 1, closeParen - hash - 1);
+				id[closeParen - hash - 1] = 0;
+
+				mStyle.setClipPath(id);
+			}
+		}
+	}
+}
+
+SvgNode* SvgGroup::create(SvgNode* parent, const XmlTree& xml) {
+	if (xml.getTag() == "clipPath") return new SvgClipPath(parent, xml);
+	if (xml.getTag() == "defs") return new SvgDefs(parent, xml);
+	if (xml.getTag() == "g") return new SvgGroup(parent, xml);
+	if (xml.getTag() == "svg") return new SvgDoc(parent, xml);
+	if (xml.getTag() == "path") return new SvgPath(parent, xml);
+	if (xml.getTag() == "polygon") return new SvgPolygon(parent, xml);
+	if (xml.getTag() == "polyline") return new SvgPolyline(parent, xml);
+	if (xml.getTag() == "line") return new SvgLine(parent, xml);
+	if (xml.getTag() == "rect") return new SvgRect(parent, xml);
+	if (xml.getTag() == "circle") return new SvgCircle(parent, xml);
+	if (xml.getTag() == "ellipse") return new SvgEllipse(parent, xml);
+	if (xml.getTag() == "use") return new SvgUse(parent, xml);
+	if (xml.getTag() == "image") return new SvgImage(parent, xml);
+	if (xml.getTag() == "linearGradient") return new SvgLinearGradient(parent, xml);
+	if (xml.getTag() == "radialGradient") return new SvgRadialGradient(parent, xml);
+	if (xml.getTag() == "style") return new SvgStyles(parent, xml);
+	if (xml.getTag() == "text") return new SvgText(parent, xml);
+
+	// Treat <switch> tags as normal groups and parse their contents.
+	if (xml.getTag() == "switch") {
+		CI_LOG_W("The `switch` tag is currently not supported and will be treated as a normal group.");
+		return new SvgGroup(parent, xml);
+	}
+
+	CI_LOG_W("The `" << xml.getTag() << "` tag is currently not supported or recognized.");
+
+	return nullptr;
+}
+
+const SvgNode* SvgGroup::findNodeByIdContains(const std::string& idPartial, bool recurse) const {
+	for (const auto& child : mChildren) {
+		if (child->getId().find(idPartial) != string::npos) {
+			return child;
+		}
+	}
+
+	if (recurse) {
+		for (const auto child : mChildren) {
+			const auto group = dynamic_cast<SvgGroup*>(child);
+			if (group) {
+				const SvgNode* result = group->findNodeByIdContains(idPartial);
+				if (result) return result;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+const SvgNode* SvgGroup::findNodeByTag(const std::string& tag, bool recurse) const {
+	// see if any immediate children have tag 'tag'
+	for (const auto child : mChildren) {
+		if (child->getTag() == tag) {
+			return child;
+		}
+	}
+
+	// see if any groups contain children with tag 'tag'
+	if (recurse) {
+		for (const auto child : mChildren) {
+			const auto group = dynamic_cast<SvgGroup*>(child);
+			if (group) {
+				const SvgNode* result = group->findNodeByTag(tag);
+				if (result) return result;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+const SvgNode* SvgGroup::findNode(const std::string& id, bool recurse) const {
+	// see if any immediate children are named 'id'
+	for (const auto child : mChildren) {
+		if (child->getId() == id) {
+			return child;
+		}
+	}
+
+	// see if any groups contain children named 'id'
+	if (recurse) {
+		for (const auto child : mChildren) {
+			const auto group = dynamic_cast<SvgGroup*>(child);
+			if (group) {
+				const SvgNode* result = group->findNode(id);
+				if (result) return result;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+SvgNode* SvgGroup::nodeUnderPoint(const vec2& absolutePoint, const mat3& parentInverseMatrix) const {
+	mat3 invTransform = parentInverseMatrix;
+	if (mSpecifiesTransform) invTransform = inverse(mTransform) * invTransform;
+	const vec2 localPt = vec2(invTransform * vec3(absolutePoint, 1));
+
+	for (auto nodeIt = mChildren.rbegin(); nodeIt != mChildren.rend(); ++nodeIt) {
+		const auto group = dynamic_cast<SvgGroup*>(*nodeIt);
+		if (group) {
+			SvgNode* node = group->nodeUnderPoint(absolutePoint, invTransform);
+			if (node) return node;
+		} else {
+			if ((*nodeIt)->specifiesTransform()) {
+				mat3 childInvTransform = (*nodeIt)->getTransformInverse() * invTransform;
+				if ((*nodeIt)->containsPoint(vec2(childInvTransform * vec3(absolutePoint, 1)))) return *nodeIt;
+			} else if ((*nodeIt)->containsPoint(localPt))
+				return *nodeIt;
+		}
+	}
+
+	return nullptr;
+}
+
+const SvgNode* SvgGroup::findInAncestors(const std::string& elementId) const {
+	if (elementId.empty()) return nullptr;
+
+	const SvgNode* result;
+
+	if (getId() == elementId)
+		return this;
+	else if ((result = findNode(elementId, true)) != nullptr)
+		return result;
+	else if (getParent())
+		return getParent()->findInAncestors(elementId);
+	else
+		return nullptr;
+}
+
+const SvgNode* SvgGroup::findTagInAncestors(const std::string& elementTag) const {
+	const SvgNode* result;
+
+	if (getTag() == elementTag)
+		return this;
+	else if ((result = findNodeByTag(elementTag, true)) != nullptr)
+		return result;
+	else if (getParent())
+		return getParent()->findTagInAncestors(elementTag);
+	else
+		return nullptr;
+}
+
+const SvgNode& SvgGroup::getChild(const std::string& id) const {
+	const SvgNode* result = findNode(id, false);
+	if (!result)
+		throw SvgChildNotFoundExc(id);
+	else
+		return *result;
+}
+
+Shape2d SvgGroup::getMergedShape2d() const {
+	Shape2d result;
+	appendMergedShape2d(&result);
+	return result;
+}
+
+void SvgGroup::appendMergedShape2d(Shape2d* appendTo) const {
+	for (const auto child : mChildren) {
+		const auto* group = dynamic_cast<const SvgGroup*>(child);
+		if (group)
+			group->appendMergedShape2d(appendTo);
+		else
+			appendTo->append(child->getShape().transformed(child->getTransform()));
+	}
+}
+
+const SvgNode& SvgGroup::getChild(size_t index) const {
+	const auto childIt = mChildren.begin();
+	while (index) {
+		--index;
+		if (childIt == mChildren.end()) break;
+	}
+
+	if (childIt == mChildren.end()) throw SvgChildNotFoundExc("index " + to_string(index));
+
+	return **childIt;
+}
+
+void SvgGroup::renderSelf(Renderer& renderer) const {
+	renderer.pushGroup(*this, getStyle().getOpacity());
+
+	for (auto child : mChildren) {
+		Style style = child->getStyle();
+		if (!renderer.visit(*child, &style)) continue;
+		if (child->getStyle().isDisplayNone()) // display: none we don't even descend groups
+			continue;
+		if ((!child->isVisible()) &&
+			(typeid(SvgGroup) != typeid(*child))) // if this isn't visible and isn't a group, just move along
+			continue;
+		child->startRender(renderer, style);
+		child->renderSelf(renderer);
+		child->finishRender(renderer, style);
+	}
+
+	renderer.popGroup();
+}
+
+Rectf SvgGroup::calcBoundingBox() const {
+	bool  empty = true;
+	Rectf result(0, 0, 0, 0);
+	for (const auto child : mChildren) {
+		Rectf childBounds = child->getBoundingBox().transformed(child->getTransform());
+		// only use child area if it exists (text nodes return [0,0,0,0])
+		if ((childBounds.getWidth() > 0) || (childBounds.getHeight() > 0)) {
+			if (empty) {
+				result = childBounds;
+				empty  = false;
+			} else {
+				result.include(childBounds);
+			}
+		}
+	}
+	return result;
+}
+
+void SvgGroup::iterate(const std::function<void(SvgNode*)>& fn) {
+	for (auto& child : mChildren) {
+		fn(child);
+		if (typeid(*child) == typeid(SvgGroup)) static_cast<SvgGroup*>(child)->iterate(fn);
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Use
+SvgUse::SvgUse(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml)
+  , mReferenced(nullptr) {
+	parse(xml);
+}
+
+void SvgUse::parse(const XmlTree& xml) {
+	const auto doc	 = getDoc();
+	const auto style = calcInheritedStyle();
+
+	std::string ref;
+	if (xml.hasAttribute("xlink:href"))
+		ref = xml.getAttributeValue<string>("xlink:href");
+	else if (xml.hasAttribute("href"))
+		ref = xml.getAttributeValue<string>("href");
+
+	vec2 translate{0};
+	if (xml.hasAttribute("x")) {
+		translate.x			= Value::parse(xml.getAttributeValue<std::string>("x")).asUserWidth(doc, style);
+		mSpecifiesTransform = true;
+	}
+	if (xml.hasAttribute("y")) {
+		translate.y			= Value::parse(xml.getAttributeValue<std::string>("y")).asUserHeight(doc, style);
+		mSpecifiesTransform = true;
+	}
+	mTransform = glm::translate(mTransform, translate);
+
+	if (ref.size() > 1) {
+		if (ref[0] == '#') {
+			const string elementId = ref.substr(1, string::npos);
+			mReferenced			   = findInAncestors(elementId);
+		}
+	}
+}
+
+void SvgUse::renderSelf(Renderer& renderer) const {
+	if (mReferenced) {
+		Style style = mReferenced->getStyle();
+		if (!renderer.visit(*mReferenced, &style)) return;
+		mReferenced->startRender(renderer, style);
+		mReferenced->renderSelf(renderer);
+		mReferenced->finishRender(renderer, style);
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// PreserveAspectRatio
+PreserveAspectRatio::PreserveAspectRatio(const std::string& str) {
+	const char* sInOut = str.c_str();
+	parse(&sInOut);
+}
+
+PreserveAspectRatio::PreserveAspectRatio(const char** sInOut) {
+	parse(sInOut);
+}
+
+glm::mat3x2 PreserveAspectRatio::calcTransform(const Rectf& element, const Rectf& viewBox, bool normalized) const {
+	// See: https://svgwg.org/svg2-draft/coords.html#ComputingAViewportsTransform
+	glm::mat3x2 m32;
+
+	if (viewBox.getWidth() > 0 && viewBox.getHeight() > 0) {
+		m32[0][0] = element.getWidth() / viewBox.getWidth();		// scale-x
+		m32[1][1] = element.getHeight() / viewBox.getHeight();		// scale-y
+		if (align != ALIGN_NONE && meetOrSlice == MEET)				//
+			m32[0][0] = m32[1][1] = glm::min(m32[0][0], m32[1][1]); //
+		else if (align != ALIGN_NONE && meetOrSlice == SLICE)		//
+			m32[0][0] = m32[1][1] = glm::max(m32[0][0], m32[1][1]); //
+		m32[2][0] = element.x1 - (viewBox.x1 * m32[0][0]);			// translate-x
+		m32[2][1] = element.y1 - (viewBox.y1 * m32[1][1]);			// translate-y
+
+		if (align == ALIGN_X_MID_Y_MIN || align == ALIGN_X_MID_Y_MID || align == ALIGN_X_MID_Y_MAX)
+			m32[2][0] += (element.getWidth() - viewBox.getWidth() * m32[0][0]) * 0.5f;
+		else if (align == ALIGN_X_MAX_Y_MIN || align == ALIGN_X_MAX_Y_MID || align == ALIGN_X_MAX_Y_MAX)
+			m32[2][0] += element.getWidth() - viewBox.getWidth() * m32[0][0];
+		if (align == ALIGN_X_MIN_Y_MID || align == ALIGN_X_MID_Y_MID || align == ALIGN_X_MAX_Y_MID)
+			m32[2][1] += (element.getHeight() - viewBox.getHeight() * m32[1][1]) * 0.5f;
+		else if (align == ALIGN_X_MIN_Y_MAX || align == ALIGN_X_MID_Y_MAX || align == ALIGN_X_MAX_Y_MAX)
+			m32[2][1] += element.getHeight() - viewBox.getHeight() * m32[1][1];
+	}
+
+	// Normalize.
+	if (normalized && element.getWidth() > 0 && element.getHeight() > 0) {
+		m32[0][0] = float(viewBox.getWidth()) * m32[0][0] / element.getWidth();
+		m32[1][1] = float(viewBox.getHeight()) * m32[1][1] / element.getHeight();
+		m32[2][0] /= element.getWidth();
+		m32[2][1] /= element.getHeight();
+	}
+
+	return m32;
+}
+
+void PreserveAspectRatio::parse(const char** sInOut) {
+	ds::skipSpace(sInOut);
+
+	const auto a = ds::fetchWord(sInOut);
+	if (!asciiCaseCmp(a.c_str(), "none"))
+		align = ALIGN_NONE;
+	else if (!asciiCaseCmp(a.c_str(), "xminymin"))
+		align = ALIGN_X_MIN_Y_MIN;
+	else if (!asciiCaseCmp(a.c_str(), "xmidymin"))
+		align = ALIGN_X_MID_Y_MIN;
+	else if (!asciiCaseCmp(a.c_str(), "xmaxymin"))
+		align = ALIGN_X_MAX_Y_MIN;
+	else if (!asciiCaseCmp(a.c_str(), "xminymid"))
+		align = ALIGN_X_MIN_Y_MID;
+	else if (!asciiCaseCmp(a.c_str(), "xmidymid"))
+		align = ALIGN_X_MID_Y_MID;
+	else if (!asciiCaseCmp(a.c_str(), "xmaxymid"))
+		align = ALIGN_X_MAX_Y_MID;
+	else if (!asciiCaseCmp(a.c_str(), "xminymax"))
+		align = ALIGN_X_MIN_Y_MIN;
+	else if (!asciiCaseCmp(a.c_str(), "xmidymax"))
+		align = ALIGN_X_MID_Y_MAX;
+	else if (!asciiCaseCmp(a.c_str(), "xmaxymax"))
+		align = ALIGN_X_MAX_Y_MAX;
+
+	ds::skipSpace(sInOut);
+
+	const auto m = ds::fetchWord(sInOut);
+	if (!asciiCaseCmp(m.c_str(), "meet"))
+		meetOrSlice = MEET;
+	else if (!asciiCaseCmp(m.c_str(), "slice"))
+		meetOrSlice = SLICE;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Image
+SvgImage::SvgImage(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml)
+  , mBounds(0, 0, 0, 0) {
+	const auto doc	 = getDoc();
+	const auto style = calcInheritedStyle();
+
+	if (xml.hasAttribute("x")) mBounds.x1 = Value::parse(xml.getAttributeValue<string>("x")).asUserWidth(doc, style);
+	if (xml.hasAttribute("y")) mBounds.y1 = Value::parse(xml.getAttributeValue<string>("y")).asUserHeight(doc, style);
+	if (xml.hasAttribute("width"))
+		mBounds.x2 = mBounds.x1 + Value::parse(xml.getAttributeValue<string>("width")).asUserWidth(doc, style);
+	if (xml.hasAttribute("height"))
+		mBounds.y2 = mBounds.y1 + Value::parse(xml.getAttributeValue<string>("height")).asUserHeight(doc, style);
+
+	std::string ref;
+	if (xml.hasAttribute("xlink:href"))
+		ref = xml.getAttributeValue<string>("xlink:href");
+	else if (xml.hasAttribute("href"))
+		ref = xml.getAttributeValue<string>("href");
+
+	if (ref.find("data:") == 0) {
+		parseDataImage(ref);
+	} else if (!ref.empty()) {
+		const auto ext = fs::path(ref).extension().string();
+		if (ext == ".svg") {
+			const auto path = doc->getFilePath() / ref;
+			mSvg			= SvgDoc::create(this, loadFile(path), path);
+		} else
+			mImage = doc->loadImage(ref);
+	}
+
+	// Calculate texture transform matrix.
+	const Rectf element(0, 0, mBounds.getWidth(), mBounds.getHeight());
+	const Rectf viewBox = mImage ? Rectf(mImage->getBounds()) : mSvg ? mSvg->getBounds() : Rectf{};
+	if (xml.hasAttribute("preserveAspectRatio"))
+		mTextureMatrix = PreserveAspectRatio(xml.getAttributeValue<string>("preserveAspectRatio"))
+							 .calcTransform(element, viewBox, true);
+	else
+		mTextureMatrix = PreserveAspectRatio().calcTransform(element, viewBox, true);
+
+
+	if (xml.hasAttribute("clip-path")) {
+		const auto value = xml.getAttributeValue<std::string>("clip-path");
+
+		if (!strncmp(value.c_str(), "url", 3)) {
+			char		id[1024];
+			const char* hash	   = strchr(value.c_str(), '#');
+			const char* closeParen = strchr(value.c_str(), ')');
+			if (closeParen && hash && closeParen - hash < 1024) {
+				strncpy(id, hash + 1, closeParen - hash - 1);
+				id[closeParen - hash - 1] = 0;
+
+				mStyle.setClipPath(id);
+			}
+		}
+	}
+}
+
+bool SvgImage::parseDataImage(const string& data) {
+	mImage.reset();
+	mSvg.reset();
+
+	const size_t dataOffset = data.find("data:") + 5;
+	const size_t semi		= data.find(';');
+	const size_t comma		= data.find(',');
+	if (semi == string::npos || comma == string::npos) return false;
+
+	const size_t len = data.size() - comma - 1;
+	const auto	 buf = make_shared<Buffer>(fromBase64(&data[comma + 1], len));
+
+	const string mime = data.substr(dataOffset, semi - dataOffset);
+	if (mime == "image/svg+xml") {
+		// See also: https://www.w3.org/TR/SVG2/embedded.html#ImageElement
+		mSvg = SvgDoc::createFromSvgz(DataSourceBuffer::create(buf));
+
+		// To prevent breaking changes, use a placeholder image.
+		unsigned char bytes[4] = {255, 0, 0, 255};
+		mImage				   = std::make_shared<Surface8u>(bytes, 1, 1, 4, SurfaceChannelOrder::RGBA);
+
+		return true;
+	} else {
+		string extension;
+		if (mime == "image/png")
+			extension = "png";
+		else if (mime == "image/jpeg")
+			extension = "jpeg";
+
+		try {
+			mImage = std::make_shared<Surface8u>(
+				loadImage(DataSourceBuffer::create(buf), ImageSource::Options(), extension));
+			return true;
+		} catch (std::exception& exc) {
+			CI_LOG_W("failed to parse data image, what: " << exc.what());
+		}
+	}
+	return false;
+}
+
+void SvgImage::renderSelf(Renderer& renderer) const {
+	if (mImage || mSvg) renderer.drawImage(*this);
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Text
+SvgText::SvgText(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml)
+  , mAttributes(xml) {
+	for (XmlTree::ConstIter treeIt = xml.begin(); treeIt != xml.end(); ++treeIt) {
+		if (treeIt->getTag().empty()) { // data!
+			mSpans.push_back(std::make_shared<SvgTextSpan>(this, treeIt->getValue()));
+		} else if (treeIt->getTag() == "tspan") { // tspan!
+			mSpans.push_back(std::make_shared<SvgTextSpan>(this, *treeIt));
+		}
+	}
+}
+
+#if 0 
+Shape2d Text::getShape() const
+{
+	Shape2d result;	
+	for( vector<TextSpanRef>::const_iterator spanIt = mSpans.begin(); spanIt != mSpans.end(); ++spanIt )
+		result.append( (*spanIt)->getShape() );
+	
+	return result;
+}
+#endif
+
+vec2 SvgText::getTextPen() const {
+	if (!mAttributes.mX.isSet() || !mAttributes.mY.isSet()) {
+		return {};
+	}
+
+	return {mAttributes.mX.asUser(), mAttributes.mY.asUser()};
+}
+
+float SvgText::getRotation() const {
+	if (mAttributes.mRotate.size() != 1) {
+		return 0;
+	} else
+		return mAttributes.mRotate[0].asUser();
+}
+
+Value SvgText::getLetterSpacing() const {
+	if (mAttributes.mLetterSpacing.size() != 1) {
+		return {0};
+	} else
+		return mAttributes.mLetterSpacing[0];
+}
+
+void SvgText::renderSelf(Renderer& renderer) const {
+	renderer.pushTextPen(vec2()); // this may be overridden by the attributes, but that's ok
+	mAttributes.startRender(renderer);
+	for (const auto& span : mSpans) {
+		span->renderSelf(renderer);
+	}
+	mAttributes.finishRender(renderer);
+	renderer.popTextPen();
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// TextSpan
+SvgTextSpan::SvgTextSpan(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml)
+  , mIgnoreAttributes(false)
+  , mAttributes(xml)
+  , mFont(nullptr) {
+	for (XmlTree::ConstIter treeIt = xml.begin(); treeIt != xml.end(); ++treeIt) {
+		if (treeIt->getTag().empty()) { // data!
+			mSpans.push_back(std::make_shared<SvgTextSpan>(this, treeIt->getValue()));
+		} else if (treeIt->getTag() == "tspan") { // tspan!
+			mSpans.push_back(std::make_shared<SvgTextSpan>(this, *treeIt));
+		}
+	}
+}
+
+SvgTextSpan::SvgTextSpan(SvgNode* parent, const std::string& spanString)
+  : SvgNode(parent)
+  , mIgnoreAttributes(true)
+  , mFont(nullptr) {
+	// replace all multi-char whitespace with single space
+	/*size_t c = 0;
+	while( str[c] ) {
+		if( isspace(str[c]) ) mString += ' ';
+		while( str[c] && isspace(str[c]) )
+			nextCharUtf8( str.c_str(), &c );
+		while( str[c] && ( ! isspace(str[c]) ) ) // this is not really correct - does not work with UTF32 code
+	points that are >255 mString += nextCharUtf8( str.c_str(), &c );
+	}*/
+	// Technically multi-char whitespace should be reduced to single chars; needs to be revisited with unicode-aware
+	// version of this method
+	mString = spanString;
+}
+
+void SvgTextSpan::renderSelf(Renderer& renderer) const {
+	// Style style = getStyle(); // Resolves style if needed.
+	// if( !renderer.visit( *this, &style ) )
+	//	return;
+	// startRender( renderer, style );
+	// if( !mIgnoreAttributes ) // TextSpans that are actually the contents of Text's attributes should be ignored
+	//	mAttributes.startRender( renderer );
+	if (!mString.empty()) {
+		renderer.drawTextSpan(*this);
+	}
+	for (const auto& span : mSpans) {
+		span->renderSelf(renderer);
+	}
+	// if( !mIgnoreAttributes )
+	//	mAttributes.finishRender( renderer );
+	// finishRender( renderer, style );
+}
+
+std::vector<std::pair<uint16_t, vec2>> SvgTextSpan::getGlyphMeasures() const {
+	if (!mGlyphMeasures) {
+		TextBox tbox = TextBox().font(*getFont()).text(mString);
+#if defined(CINDER_ANDROID) || defined(CINDER_LINUX)
+		auto tmpGlyphs = tbox.measureGlyphs();
+		mGlyphMeasures = shared_ptr<std::vector<std::pair<uint16_t, vec2>>>(
+			new std::vector<std::pair<uint16_t, vec2>>(tmpGlyphs.size()));
+		for (size_t i = 0; i < tmpGlyphs.size(); ++i) {
+			const auto& src = tmpGlyphs[i];
+			auto&		dst = (*mGlyphMeasures)[i];
+			dst.first		= (uint16_t)src.first;
+			dst.second		= src.second;
+		}
+#else
+		mGlyphMeasures = std::make_shared<std::vector<std::pair<uint16_t, vec2>>>(tbox.measureGlyphs());
+#endif
+	}
+
+	return *mGlyphMeasures;
+}
+
+#if 0
+// This is not implemented
+Shape2d TextSpan::getShape() const
+{
+	if( ! mShape ) {
+		mShape = shared_ptr<Shape2d>( new Shape2d() );
+		
+		if( ! mString.empty() ) {
+			shared_ptr<Font> font = getFont();
+			if( ! font )
+				return Shape2d();
+			TextBox tbox = TextBox().font( *font ).text( mString );
+			vector<pair<uint16_t,vec2> > glyphs = getGlyphMeasures();
+			vec2 textPen = getTextPen();
+			float rotation = getRotation();
+			bool shouldRotate = fabs( rotation ) > 0.0001f;
+			MatrixAffine2f rotationMatrix = MatrixAffine2f::makeRotate( toRadians( rotation ) );
+			for( size_t g = 0; g < glyphs.size(); ++g ) {
+				MatrixAffine2f m = MatrixAffine2f::makeTranslate( textPen + vec2( glyphs[g].second.x, 0 ) );
+				if( shouldRotate )
+					m *= rotationMatrix;
+				mShape->append( font->getGlyphShape( glyphs[g].first ).getTransform( m ) );
+			}
+		}
+
+		for( vector<TextSpanRef>::const_iterator spanIt = mSpans.begin(); spanIt != mSpans.end(); ++spanIt )
+			mShape->append( (*spanIt)->getShape() );
+	}
+		
+	return *mShape;
+}
+#endif
+
+// TextSpan::Atributes
+SvgTextSpan::Attributes::Attributes(const XmlTree& xml) {
+	if (xml.hasAttribute("x")) mX = readValue(xml["x"]);
+	if (xml.hasAttribute("y")) mY = readValue(xml["y"]);
+	if (xml.hasAttribute("rotate")) mRotate = readValueList(xml["rotate"], false);
+	if (xml.hasAttribute("letter-spacing")) mLetterSpacing = readValueList(xml["letter-spacing"], false);
+}
+
+std::shared_ptr<Font> SvgTextSpan::getFont() const {
+	if (!mFont) {
+		const vector<string>& fontFamilies = getFontFamilies();
+		float				  fontSize	   = getFontSize().asUser();
+		for (vector<string>::const_iterator familyIt = fontFamilies.begin(); familyIt != fontFamilies.end();
+			 ++familyIt) {
+			try {
+				mFont = std::make_shared<Font>(*familyIt, fontSize);
+				break;
+			} catch (Exception& exc) {
+				CI_LOG_W("failed to load font with name: " << *familyIt << ", size: " << fontSize
+														   << ". what: " << exc.what() << "\t - loading default font.");
+				mFont = std::make_shared<Font>(Font::getDefault());
+			}
+		}
+	}
+
+	return mFont;
+}
+
+vec2 SvgTextSpan::getTextPen() const {
+	if (mIgnoreAttributes || (!mAttributes.mX.isSet()) || (!mAttributes.mY.isSet())) {
+		if (!mParent)
+			return {};
+		else if (typeid(*mParent) == typeid(SvgTextSpan))
+			return reinterpret_cast<const SvgTextSpan*>(mParent)->getTextPen();
+		else if (typeid(*mParent) == typeid(SvgText))
+			return reinterpret_cast<const SvgText*>(mParent)->getTextPen();
+		else
+			return {};
+	} else
+		return {mAttributes.mX.asUser(), mAttributes.mY.asUser()};
+}
+
+void SvgTextSpan::setTextPen(const vec2& textPen) {
+	if (mIgnoreAttributes) {
+		if (!mParent)
+			return;
+		else if (typeid(*mParent) == typeid(SvgTextSpan))
+			return reinterpret_cast<SvgTextSpan*>(mParent)->setTextPen(textPen);
+		else if (typeid(*mParent) == typeid(SvgText))
+			return reinterpret_cast<SvgText*>(mParent)->setTextPen(textPen);
+	} else
+		mAttributes.setTextPen(textPen);
+}
+
+float SvgTextSpan::getRotation() const {
+	if (mIgnoreAttributes || (mAttributes.mRotate.size() != 1)) {
+		if (!mParent)
+			return 0;
+		else if (typeid(*mParent) == typeid(SvgTextSpan))
+			return reinterpret_cast<const SvgTextSpan*>(mParent)->getRotation();
+		else if (typeid(*mParent) == typeid(SvgText))
+			return reinterpret_cast<const SvgText*>(mParent)->getRotation();
+		else
+			return 0;
+	} else
+		return mAttributes.mRotate[0].asUser();
+}
+
+Value SvgTextSpan::getLetterSpacing() const {
+	if (mIgnoreAttributes || (mAttributes.mLetterSpacing.size() != 1)) {
+		if (!mParent)
+			return 0;
+		else if (typeid(*mParent) == typeid(SvgTextSpan))
+			return reinterpret_cast<const SvgTextSpan*>(mParent)->getLetterSpacing();
+		else if (typeid(*mParent) == typeid(SvgText))
+			return reinterpret_cast<const SvgText*>(mParent)->getLetterSpacing();
+		else
+			return 0;
+	} else
+		return mAttributes.mLetterSpacing[0];
+}
+
+void SvgTextSpan::Attributes::startRender(Renderer& renderer) const {
+	if (mX.isSet() && mY.isSet()) renderer.pushTextPen(vec2(mX.asUser(), mY.asUser()));
+	if (mRotate.size() == 1)
+		renderer.pushTextRotation(mRotate[0].asUser());
+	else
+		renderer.pushTextRotation(0);
+}
+
+void SvgTextSpan::Attributes::finishRender(Renderer& renderer) const {
+	if (mX.isSet() && mY.isSet()) renderer.popTextPen();
+	renderer.popTextRotation();
+}
+
+void SvgTextSpan::Attributes::setTextPen(const vec2& textPen) {
+	mX = Value(textPen.x);
+	mY = Value(textPen.y);
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Defs
+SvgDefs::SvgDefs(SvgNode* parent, const XmlTree& xml)
+  : SvgGroup(parent)
+  , mXml(xml) {
+	parse(xml);
+}
+
+const SvgNode* SvgDefs::findNode(const std::string& id, bool recurse) const {
+	const SvgNode* result = SvgGroup::findNode(id, recurse);
+	if (!result) {
+		// see if any immediate non-instantiated children are named 'id'
+		for (XmlTree::ConstIter treeIt = mXml.begin(); treeIt != mXml.end(); ++treeIt) {
+			if (!treeIt->hasAttribute("id")) continue;
+			if (treeIt->getAttributeValue<std::string>("id") != id) continue;
+
+			// instantiate the requested node and return it
+			SvgDefs* self = const_cast<SvgDefs*>(this);
+			SvgNode* node = create(self, *treeIt);
+			if (node) self->mChildren.push_back(node);
+
+			return node;
+		}
+	}
+
+	return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// ClipPath
+SvgClipPath::SvgClipPath(SvgNode* parent, const XmlTree& xml)
+  : SvgGroup(parent, xml) {
+	if (xml.hasAttribute("clipPathUnits")) {
+		mUseObjectBoundingBox = xml.getAttributeValue<string>("clipPathUnits") != string("userSpaceOnUse");
+	}
+
+	for (const auto& child : mChildren) {
+		if (!child->isDisplayNone() && child->isVisible()) {
+			mIsDisplayNone = false;
+			break;
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Styles
+SvgStyles::SvgStyles(SvgNode* parent, const XmlTree& xml)
+  : SvgNode(parent, xml) {
+	const auto value = trim(xml.getValue());
+
+	throw std::runtime_error("Not implemented");
+
+	// css::Parser parser;
+	// parser.parse(value);
+
+	//{
+	//	Style					 style;
+	//	std::vector<std::string> selectors;
+	//	std::string				 key;
+	//	std::string				 value;
+
+	//	css::Parser::Token token = parser.getNextToken();
+	//	while (token.type != css::Parser::CSS_END) {
+	//		switch (token.type) {
+	//		case css::Parser::SEL_START:
+	//			selectors = split(token.data, ',', true);
+	//			style.clear();
+	//			break;
+	//		case css::Parser::SEL_END:
+	//			for (const auto& selector : selectors) {
+	//				const auto id = ltrim_copy(selector, ".");
+	//				if (mStyleList.count(id) > 0)
+	//					mStyleList.at(id) += style;
+	//				else
+	//					mStyleList.insert_or_assign(id, style);
+	//			}
+	//			break;
+	//		case css::Parser::PROPERTY:
+	//			key = token.data;
+	//			break;
+	//		case css::Parser::VALUE:
+	//			value = token.data;
+	//			style.parseProperty(key, value, this);
+	//			break;
+	//		default:
+	//			break;
+	//		}
+
+	//		token = parser.getNextToken();
+	//	}
+	//}
+}
+
+Style SvgStyles::findStyle(const std::string& id) const {
+	if (mStyleList.count(id) > 0) return mStyleList.at(id);
+
+	return {};
+}
+
+////////////////////////////////////////////////////////////////////////////////////
+// Doc
+SvgDoc::SvgDoc()
+  : SvgGroup(nullptr)
+  , mBounds(0, 0, 0, 0) {}
+
+SvgDoc::SvgDoc(SvgNode* parent, const XmlTree& xml)
+  : SvgGroup(parent, xml)
+  , mBounds(0, 0, 0, 0) {
+	loadDoc(xml);
+}
+
+SvgDoc::SvgDoc(const fs::path& filePath)
+  : SvgGroup(nullptr)
+  , mBounds(0, 0, 0, 0) {
+	loadDoc(loadFile(filePath), filePath);
+}
+
+SvgDoc::SvgDoc(const DataSourceRef& dataSource, const fs::path& filePath)
+  : SvgDoc(nullptr, dataSource, filePath) {}
+
+SvgDoc::SvgDoc(SvgNode* parent, const DataSourceRef& dataSource, const fs::path& filePath)
+  : SvgGroup(parent)
+  , mBounds(0, 0, 0, 0) {
+	fs::path relativePath = filePath;
+	if (filePath.empty()) relativePath = fs::path(dataSource->getFilePathHint());
+	loadDoc(dataSource, relativePath);
+}
+
+SvgDocRef SvgDoc::create(SvgNode* parent, const XmlTree& xml) {
+	return std::make_shared<SvgDoc>(parent, xml);
+}
+
+SvgDocRef SvgDoc::create(const fs::path& filePath) {
+	return std::make_shared<SvgDoc>(filePath);
+}
+
+SvgDocRef SvgDoc::create(const DataSourceRef& dataSource, const fs::path& filePath) {
+	return std::make_shared<SvgDoc>(dataSource, filePath);
+}
+
+SvgDocRef SvgDoc::create(SvgNode* parent, const DataSourceRef& dataSource, const fs::path& filePath) {
+	return std::make_shared<SvgDoc>(parent, dataSource, filePath);
+}
+
+SvgDocRef SvgDoc::createFromSvgz(const DataSourceRef& dataSource, const fs::path& filePath) {
+	fs::path relativePath = filePath;
+	if (filePath.empty()) relativePath = dataSource->getFilePathHint();
+
+	const Buffer	compressed(dataSource);
+	const BufferRef decompressed = make_shared<Buffer>(decompressBuffer(compressed, false, true));
+
+	return std::make_shared<SvgDoc>(DataSourceBuffer::create(decompressed, relativePath));
+}
+
+void SvgDoc::loadDoc(const XmlTree& xml) {
+	if (xml.hasAttribute("viewBox")) {
+		const auto	vbox   = xml.getAttributeValue<string>("viewBox");
+		const char* vbCPtr = vbox.c_str();
+		mViewBox.x1		   = ds::parseFloat(&vbCPtr);
+		mViewBox.y1		   = ds::parseFloat(&vbCPtr);
+		mViewBox.x2		   = mViewBox.x1 + ds::parseFloat(&vbCPtr);
+		mViewBox.y2		   = mViewBox.y1 + ds::parseFloat(&vbCPtr);
+	} else {
+		const SvgDoc* doc = getDoc();
+		if (doc)
+			mViewBox = doc->mViewBox;
+		else
+			mViewBox = getBoundingBox().transformed(getTransform()).scaledCentered(1.1f);
+	}
+	if (xml.hasAttribute("x")) {
+		const Value val = Value::parse(xml.getAttributeValue<string>("x"));
+		if (val.isPercent())
+			mBounds.x1 = val.asUser(1) * mViewBox.getWidth();
+		else
+			mBounds.x1 = val.asUser(100, getDpi());
+	}
+	if (xml.hasAttribute("y")) {
+		const Value val = Value::parse(xml.getAttributeValue<string>("y"));
+		if (val.isPercent())
+			mBounds.y1 = val.asUser(1) * mViewBox.getHeight();
+		else
+			mBounds.y1 = val.asUser(100, getDpi());
+	}
+	if (xml.hasAttribute("width")) {
+		const Value val = Value::parse(xml.getAttributeValue<string>("width"));
+		if (val.isPercent())
+			mBounds.x2 = mBounds.x1 + val.asUser(1) * mViewBox.getWidth();
+		else
+			mBounds.x2 = mBounds.x1 + val.asUser(100, getDpi());
+	} else
+		mBounds.x2 = mBounds.x1 + mViewBox.getWidth();
+	if (xml.hasAttribute("height")) {
+		const Value val = Value::parse(xml.getAttributeValue<string>("height"));
+		if (val.isPercent())
+			mBounds.y2 = mBounds.y1 + val.asUser(1) * mViewBox.getHeight();
+		else
+			mBounds.y2 = mBounds.y1 + val.asUser(100, getDpi());
+	} else
+		mBounds.y2 = mBounds.y1 + mViewBox.getHeight();
+
+	parseStyle(xml);
+	SvgGroup::parse(xml);
+
+	// If no viewBox was specified, make sure we calculate the bounds now that all children have been created.
+	if (ds::approxZero(mViewBox.calcArea())) {
+		mBoundingBoxCached = false;
+		mViewBox		   = getBoundingBox().transformed(getTransform()).scaledCentered(1.1f);
+		if (ds::approxZero(mBounds.getWidth())) mBounds.x2 = mBounds.x1 + mViewBox.getWidth();
+		if (ds::approxZero(mBounds.getHeight())) mBounds.y2 = mBounds.y1 + mViewBox.getHeight();
+	}
+
+	const bool needsViewBoxMapping =
+		mViewBox.getWidth() > 0 && mViewBox.getHeight() > 0 && getWidth() > 0 && getHeight() > 0;
+	if (needsViewBoxMapping) {
+		if (xml.hasAttribute("preserveAspectRatio"))
+			setTransform(PreserveAspectRatio(xml.getAttributeValue<string>("preserveAspectRatio"))
+							 .calcTransform(mBounds, mViewBox));
+		else
+			setTransform(PreserveAspectRatio().calcTransform(mBounds, mViewBox));
+	}
+}
+
+void SvgDoc::loadDoc(const DataSourceRef& source, const fs::path& filePath) {
+	if (!filePath.empty()) mFilePath = filePath.parent_path();
+
+	const auto xml = std::make_shared<XmlTree>(source, XmlTree::ParseOptions().ignoreDataChildren(false));
+
+	loadDoc(xml->getChild("svg"));
+}
+
+shared_ptr<Surface8u> SvgDoc::loadImage(const fs::path& relativePath) const {
+	if (mImageCache.find(relativePath) == mImageCache.end()) {
+		try {
+			if (relativePath.string().substr(0, 4) == "http") {
+				mImageCache[relativePath] =
+					std::make_shared<Surface8u>(ci::loadImage(loadUrl(relativePath.string(), UrlOptions())));
+			} else {
+#if defined(CINDER_UWP)
+				fs::path fullPath = (mFilePath / relativePath);
+#else
+				fs::path fullPath = (mFilePath / relativePath).make_preferred();
+#endif
+
+				if (exists(fullPath)) mImageCache[relativePath] = std::make_shared<Surface8u>(ci::loadImage(fullPath));
+			}
+		} catch (...) {}
+	}
+
+	if (mImageCache.find(relativePath) != mImageCache.end())
+		return mImageCache[relativePath];
+	else
+		return {};
+}
+
+SvgNode* SvgDoc::nodeUnderPoint(const vec2& pt) const {
+	return SvgGroup::nodeUnderPoint(pt, mat3());
+}
+
+void SvgDoc::renderSelf(Renderer& renderer) const {
+	SvgGroup::renderSelf(renderer);
+}
+
+SvgChildNotFoundExc::SvgChildNotFoundExc(const string& child) {
+	setDescription("Could not find child: " + child);
+}
+
+} // namespace nvpath::svg
+
+#pragma warning(pop)

--- a/projects/nvpath/src/nvpath/NvPathSvg.h
+++ b/projects/nvpath/src/nvpath/NvPathSvg.h
@@ -1,0 +1,1505 @@
+/*
+Copyright (c) 2023, Paul Houx Creative Coding - All rights reserved.
+This code is intended for use with the Cinder C++ library: http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include "NvPath.h"
+
+#include <cinder/Cinder.h>
+#include <cinder/Color.h>
+#include <cinder/Exception.h>
+#include <cinder/Font.h>
+#include <cinder/Noncopyable.h>
+#include <cinder/PolyLine.h>
+#include <cinder/Shape2d.h>
+#include <cinder/Surface.h>
+#include <cinder/Xml.h>
+
+#include <ds/util/float_util.h>
+
+#include <functional>
+#include <map>
+
+namespace nvpath::svg {
+
+//
+using FillRule = enum { FILL_RULE_NONZERO, FILL_RULE_EVEN_ODD };
+//
+using LineCap = enum { LINE_CAP_BUTT, LINE_CAP_ROUND, LINE_CAP_SQUARE };
+//
+using LineJoin = enum { LINE_JOIN_MITER, LINE_JOIN_ROUND, LINE_JOIN_BEVEL };
+//
+using FontWeight = enum {
+	WEIGHT_100,
+	WEIGHT_200,
+	WEIGHT_300,
+	WEIGHT_400,
+	WEIGHT_NORMAL = WEIGHT_400,
+	WEIGHT_500,
+	WEIGHT_600,
+	WEIGHT_700,
+	WEIGHT_BOLD = WEIGHT_700,
+	WEIGHT_800,
+	WEIGHT_900
+};
+//
+using Align = enum {
+	ALIGN_NONE,
+	ALIGN_X_MIN_Y_MIN,
+	ALIGN_X_MID_Y_MIN,
+	ALIGN_X_MAX_Y_MIN,
+	ALIGN_X_MIN_Y_MID,
+	ALIGN_X_MID_Y_MID,
+	ALIGN_X_MAX_Y_MID,
+	ALIGN_X_MIN_Y_MAX,
+	ALIGN_X_MID_Y_MAX,
+	ALIGN_X_MAX_Y_MAX
+};
+//
+using MeetOrSlice = enum { MEET, SLICE };
+// Defines the coordinate system used by gradients and images.
+using TextAnchor = enum { TEXT_ANCHOR_START, TEXT_ANCHOR_MIDDLE, TEXT_ANCHOR_END };
+
+// Forward declarations.
+class SvgCircle;
+class SvgClipPath;
+class SvgDefs;
+class SvgDoc;
+class SvgEllipse;
+class ExcChildNotFound;
+class SvgGradient;
+class SvgGroup;
+class SvgImage;
+class SvgLine;
+class SvgNode;
+class SvgPath;
+class SvgPolygon;
+class SvgPolyline;
+class PreserveAspectRatio;
+class SvgRect;
+class Style;
+class SvgStyles;
+class SvgText;
+class SvgTextSpan;
+class SvgUse;
+
+using SvgDocRef = std::shared_ptr<SvgDoc>;
+
+//!
+static CapsStyle toCapsStyle(LineCap lineCap);
+//!
+static JoinStyle toJoinStyle(LineJoin lineJoin);
+//!
+static SpreadMethod toSpreadMethod(std::string style);
+//!
+static CoordinateSpace toGradientUnits(std::string style);
+
+//!
+class PreserveAspectRatio {
+  public:
+	PreserveAspectRatio() = default;
+
+	explicit PreserveAspectRatio(Align align, MeetOrSlice meetOrSlice = MEET)
+	  : align(align)
+	  , meetOrSlice(meetOrSlice) {}
+
+	explicit PreserveAspectRatio(const std::string& str);
+	explicit PreserveAspectRatio(const char** sInOut);
+
+	glm::mat3x2 calcTransform(const ci::Rectf& element, const ci::Rectf& viewBox, bool normalized = false) const;
+
+	void parse(const char** sInOut);
+
+	Align		align{ALIGN_X_MID_Y_MID};
+	MeetOrSlice meetOrSlice{MEET};
+};
+
+//! SVG Value/Unit pair
+class Value {
+  public:
+	enum Unit { USER, PX, PERCENT, PT, PC, MM, CM, INCH, EM, EX, AUTO };
+
+	Value() = default;
+	Value(float value, Unit unit = USER)
+	  : mUnit(unit)
+	  , mValue(value)
+	  , mIsSet(true) {}
+
+	[[nodiscard]] float asUser(float percentOf = 100, float dpi = 72, float fontSize = 12, float fontXHeight = 7) const;
+	[[nodiscard]] float asUser(const SvgDoc* doc, const Style& style) const;
+	[[nodiscard]] float asUserWidth(const SvgDoc* doc, const Style& style) const;
+	[[nodiscard]] float asUserHeight(const SvgDoc* doc, const Style& style) const;
+
+	float value() const { return mValue; }
+	Unit  unit() const { return mUnit; }
+
+	bool isSet() const { return mIsSet; }
+	bool isUser() const { return mUnit == USER; }
+	bool isPercent() const { return mUnit == PERCENT; }
+	bool isPixels() const { return mUnit == PX; }
+	bool isAuto() const { return mUnit == AUTO; }
+
+	[[nodiscard]] static Value parse(const char** sInOut);
+	[[nodiscard]] static Value parse(const std::string& s);
+
+  private:
+	Unit  mUnit{USER};
+	float mValue{};
+	bool  mIsSet{false};
+};
+
+using RenderVisitor = std::function<bool(const SvgNode&, Style*)>;
+
+//! Base class from which Renderers are derived.
+class Renderer {
+  public:
+	Renderer()			= default;
+	virtual ~Renderer() = default;
+
+	Renderer(const Renderer&)			 = default;
+	Renderer(Renderer&&)				 = default;
+	Renderer& operator=(const Renderer&) = default;
+	Renderer& operator=(Renderer&&)		 = default;
+
+	void setVisitor(const std::function<bool(const SvgNode&, Style*)>& visitor);
+
+	virtual void start() {}
+	virtual void finish() {}
+
+	//! Clears rendering cache.
+	virtual void clear() {}
+
+	virtual void pushGroup(const SvgGroup& /*group*/, float /*opacity*/) {}
+	virtual void popGroup() {}
+	virtual void pushClipPath(const SvgClipPath& /* clippath */) {}
+	virtual void popClipPath() {}
+	virtual void drawPath(const SvgPath& /*path*/) {}
+	virtual void drawPolyline(const SvgPolyline& /*polyline*/) {}
+	virtual void drawPolygon(const SvgPolygon& /*polygon*/) {}
+	virtual void drawLine(const SvgLine& /*line*/) {}
+	virtual void drawRect(const SvgRect& /*rect*/) {}
+	virtual void drawCircle(const SvgCircle& /*circle*/) {}
+	virtual void drawEllipse(const SvgEllipse& /*ellipse*/) {}
+	virtual void drawImage(const SvgImage& /*image*/) {}
+	virtual void drawTextSpan(const SvgTextSpan& /*span*/) {}
+
+	virtual void pushMatrix(const glm::mat3& /*m*/) {}
+	virtual void popMatrix() {}
+	virtual void pushStyle(const Style& /*style*/) {}
+	virtual void popStyle() {}
+	virtual void pushFill(const Paint& /*paint*/) {}
+	virtual void popFill() {}
+	virtual void pushStroke(const Paint& /*paint*/) {}
+	virtual void popStroke() {}
+	virtual void pushFillOpacity(float /*opacity*/) {}
+	virtual void popFillOpacity() {}
+	virtual void pushStrokeOpacity(float /*opacity*/) {}
+	virtual void popStrokeOpacity() {}
+	virtual void pushStrokeWidth(float /*width*/) {}
+	virtual void popStrokeWidth() {}
+	virtual void pushFillRule(FillRule /*rule*/) {}
+	virtual void popFillRule() {}
+	virtual void pushLineCap(LineCap /*lineCap*/) {}
+	virtual void popLineCap() {}
+	virtual void pushLineJoin(LineJoin /*lineJoin*/) {}
+	virtual void popLineJoin() {}
+	virtual void pushMiterLimit(float /*miterLimit*/) {}
+	virtual void popMiterLimit() {}
+	virtual void pushDashArray(const std::vector<float>& /*dashArray*/) {}
+	virtual void popDashArray() {}
+	virtual void pushDashOffset(float /*dashOffset*/) {}
+	virtual void popDashOffset() {}
+	virtual void pushTextPen(const glm::vec2& /*penPos*/) {}
+	virtual void popTextPen() {}
+	virtual void pushTextRotation(float /*rotation*/) {}
+	virtual void popTextRotation() {}
+
+	bool visit(const SvgNode& node, Style* style) const {
+		if (mVisitor) return (*mVisitor)(node, style);
+		return true;
+	}
+
+	struct Stacks {
+		std::vector<glm::mat3>			matrix;
+		std::vector<Paint>				fill;
+		std::vector<Paint>				stroke;
+		std::vector<float>				fillOpacity;
+		std::vector<float>				strokeOpacity;
+		std::vector<float>				groupOpacity;
+		std::vector<float>				strokeWidth;
+		std::vector<FillRule>			fillRule;
+		std::vector<LineCap>			lineCap;
+		std::vector<LineJoin>			lineJoin;
+		std::vector<float>				miterLimit;
+		std::vector<std::vector<float>> dashArray;
+		std::vector<float>				dashOffset;
+		std::vector<glm::vec2>			textPen;
+		std::vector<float>				textRotation;
+		std::vector<const SvgClipPath*> clipPath;
+
+		void clear() {
+			matrix.clear();
+			fill.clear();
+			stroke.clear();
+			fillOpacity.clear();
+			strokeOpacity.clear();
+			groupOpacity.clear();
+			strokeWidth.clear();
+			fillRule.clear();
+			lineCap.clear();
+			lineJoin.clear();
+			miterLimit.clear();
+			dashArray.clear();
+			dashOffset.clear();
+			textPen.clear();
+			textRotation.clear();
+			clipPath.clear();
+		}
+
+		void defaults() {
+			clear();
+
+			matrix.emplace_back();
+			fill.emplace_back(ci::Color::black());
+			stroke.emplace_back();
+			fillOpacity.push_back(1.0f);
+			strokeOpacity.push_back(1.0f);
+			groupOpacity.push_back(1.0f);
+			strokeWidth.push_back(1.0f);
+			fillRule.push_back(FILL_RULE_NONZERO);
+			lineCap.push_back(LINE_CAP_BUTT);
+			lineJoin.push_back(LINE_JOIN_MITER);
+			miterLimit.push_back(4.0f);
+			dashArray.emplace_back();
+			dashOffset.push_back(0.0f);
+			textPen.emplace_back(0.0f, 0.0f);
+			textRotation.push_back(0.0f);
+		}
+
+		//! Work-around for missing support of group opacity: this combines all opacities into a single value.
+		[[nodiscard]] float calcGroupOpacity() const {
+			float result = 1;
+			for (const auto opacity : groupOpacity)
+				result *= opacity;
+			return result;
+		}
+	};
+
+  protected:
+	// this is a shared_ptr to work around a bug in Clang 4.0
+	std::shared_ptr<std::function<bool(const SvgNode&, Style*)>> mVisitor;
+
+	friend class SvgNode;
+};
+
+//! SVG Style for a node. Corresponds to SVG Styling: http://www.w3.org/TR/SVG/styling.html
+class Style {
+  public:
+	Style();
+	Style(const ci::XmlTree& xml, const SvgNode* parent);
+
+	//! Returns a Style set appropriately for global defaults
+	static Style makeGlobalDefaults();
+	//! Marks all styles as unspecified
+	void clear();
+
+	bool				specifiesColor() const { return mSpecifiesColor; }
+	void				unspecifyColor() { mSpecifiesColor = false; }
+	const ci::ColorA8u& getColor() const { return mColor; }
+	void				setColor(const ci::ColorA8u& color) {
+		   mSpecifiesColor = true;
+		   mColor		   = color;
+	}
+	[[nodiscard]] static const ci::ColorA8u& getColorDefault();
+
+	bool		 specifiesFill() const { return mSpecifiesFill; }
+	void		 unspecifyFill() { mSpecifiesFill = false; }
+	const Paint& getFill() const { return mFill; }
+	void		 setFill(const Paint& fill) {
+		mSpecifiesFill = true;
+		mFill		   = fill;
+	}
+	[[nodiscard]] static const Paint& getFillDefault();
+
+	bool		 specifiesStroke() const { return mSpecifiesStroke; }
+	void		 unspecifyStroke() { mSpecifiesStroke = false; }
+	const Paint& getStroke() const { return mStroke; }
+	void		 setStroke(const Paint& stroke) {
+		mSpecifiesStroke = true;
+		mStroke			 = stroke;
+	}
+	[[nodiscard]] static const Paint& getStrokeDefault();
+
+	bool  specifiesOpacity() const { return mSpecifiesOpacity; }
+	void  unspecifyOpacity() { mSpecifiesOpacity = false; }
+	float getOpacity() const { return mOpacity; }
+	void  setOpacity(float opacity) {
+		 mSpecifiesOpacity = true;
+		 mOpacity		   = opacity;
+	}
+	[[nodiscard]] static float getOpacityDefault() { return 1.0f; }
+
+	bool  specifiesStrokeOpacity() const { return mSpecifiesStrokeOpacity; }
+	void  unspecifyStrokeOpacity() { mSpecifiesStrokeOpacity = false; }
+	float getStrokeOpacity() const { return mStrokeOpacity; }
+	void  setStrokeOpacity(float strokeOpacity) {
+		 mSpecifiesStrokeOpacity = true;
+		 mStrokeOpacity			 = strokeOpacity;
+	}
+	[[nodiscard]] static float getStrokeOpacityDefault() { return 1.0f; }
+
+	bool  specifiesFillOpacity() const { return mSpecifiesFillOpacity; }
+	void  unspecifyFillOpacity() { mSpecifiesFillOpacity = false; }
+	float getFillOpacity() const { return mFillOpacity; }
+	void  setFillOpacity(float fillOpacity) {
+		 mSpecifiesFillOpacity = true;
+		 mFillOpacity		   = fillOpacity;
+	}
+	[[nodiscard]] static float getFillOpacityDefault() { return 1.0f; }
+
+	bool  specifiesStrokeWidth() const { return mSpecifiesStrokeWidth; }
+	void  unspecifyStrokeWidth() { mSpecifiesStrokeWidth = false; }
+	float getStrokeWidth() const { return mStrokeWidth; }
+	void  setStrokeWidth(float strokeWidth) {
+		 mSpecifiesStrokeWidth = true;
+		 mStrokeWidth		   = strokeWidth;
+	}
+	[[nodiscard]] static float getStrokeWidthDefault() { return 1.0f; }
+
+	bool	 specifiesFillRule() const { return mSpecifiesFillRule; }
+	void	 unspecifyFillRule() { mSpecifiesFillRule = false; }
+	FillRule getFillRule() const { return mFillRule; }
+	void	 setFillRule(FillRule fillRule) {
+		mSpecifiesFillRule = true;
+		mFillRule		   = fillRule;
+	}
+	[[nodiscard]] static FillRule getFillRuleDefault() { return FILL_RULE_NONZERO; }
+
+	bool	specifiesLineCap() const { return mSpecifiesLineCap; }
+	void	unspecifyLineCap() { mSpecifiesLineCap = false; }
+	LineCap getLineCap() const { return mLineCap; }
+	void	setLineCap(LineCap lineCap) {
+		   mSpecifiesLineCap = true;
+		   mLineCap			 = lineCap;
+	}
+	[[nodiscard]] static LineCap getLineCapDefault() { return LINE_CAP_BUTT; }
+
+	bool	 specifiesLineJoin() const { return mSpecifiesLineJoin; }
+	void	 unspecifyLineJoin() { mSpecifiesLineJoin = false; }
+	LineJoin getLineJoin() const { return mLineJoin; }
+	void	 setLineJoin(LineJoin lineJoin) {
+		mSpecifiesLineJoin = true;
+		mLineJoin		   = lineJoin;
+	}
+	[[nodiscard]] static LineJoin getLineJoinDefault() { return LINE_JOIN_MITER; }
+
+	bool  specifiesMiterLimit() const { return mSpecifiesMiterLimit; }
+	void  unspecifyMiterLimit() { mSpecifiesMiterLimit = false; }
+	float getMiterLimit() const { return mMiterLimit; }
+	void  setMiterLimit(float miterLimit) {
+		 mSpecifiesMiterLimit = true;
+		 mMiterLimit		  = miterLimit;
+	}
+	[[nodiscard]] static float getMiterLimitDefault() { return 4; }
+
+	bool					  specifiesDashArray() const { return mSpecifiesDashArray; }
+	void					  unspecifyDashArray() { mSpecifiesDashArray = false; }
+	const std::vector<float>& getDashArray() const { return mDashArray; }
+	void					  setDashArray(const std::vector<float>& dashArray) {
+		 mSpecifiesDashArray = true;
+		 mDashArray			 = dashArray;
+	}
+	[[nodiscard]] static const std::vector<float>& getDashArrayDefault() {
+		static std::vector<float> sNone;
+		return sNone;
+	}
+
+	bool  specifiesDashOffset() const { return mSpecifiesDashOffset; }
+	void  unspecifyDashOffset() { mSpecifiesDashOffset = false; }
+	float getDashOffset() const { return mDashOffset; }
+	void  setDashOffset(float dashOffset) {
+		 mSpecifiesDashOffset = true;
+		 mDashOffset		  = dashOffset;
+	}
+	[[nodiscard]] static float getDashOffsetDefault() { return 0; }
+
+	// clip path
+	bool			   specifiesClipPath() const { return mSpecifiesClipPath; }
+	void			   unspecifyClipPath() { mSpecifiesClipPath = false; }
+	const std::string& getClipPath() const { return mClipPathId; }
+	void			   setClipPath(const std::string& clipPath) {
+		  mSpecifiesClipPath = true;
+		  mClipPathId		 = clipPath;
+	}
+
+	// stops
+	bool				specifiesStopColor() const { return mSpecifiesStopColor; }
+	void				unspecifyStopColor() { mSpecifiesStopColor = false; }
+	const ci::ColorA8u& getStopColor() const { return mStopColor; }
+	void				setStopColor(const ci::ColorA8u& stopColor) {
+		   mSpecifiesStopColor = true;
+		   mStopColor		   = stopColor;
+	}
+	[[nodiscard]] static ci::ColorA8u getStopColorDefault() { return {0, 0, 0, 255}; }
+
+	bool  specifiesStopOpacity() const { return mSpecifiesStopOpacity; }
+	void  unspecifyStopOpacity() { mSpecifiesStopOpacity = false; }
+	float getStopOpacity() const { return mStopOpacity; }
+	void  setStopOpacity(float stopOpacity) {
+		 mSpecifiesStopOpacity = true;
+		 mStopOpacity		   = stopOpacity;
+	}
+	[[nodiscard]] static float getStopOpacityDefault() { return 1; }
+
+	// fonts
+	bool							specifiesFontFamilies() const { return mSpecifiesFontFamilies; }
+	void							unspecifyFontFamilies() { mSpecifiesFontFamilies = false; }
+	const std::vector<std::string>& getFontFamilies() const { return mFontFamilies; }
+	std::vector<std::string>&		getFontFamilies() { return mFontFamilies; }
+	void							setFontFamily(const std::string& family) {
+		   mSpecifiesFontFamilies = true;
+		   mFontFamilies.clear();
+		   mFontFamilies.push_back(family);
+	}
+	void setFontFamilies(const std::vector<std::string>& families) {
+		mSpecifiesFontFamilies = true;
+		mFontFamilies		   = families;
+	}
+	[[nodiscard]] static const std::vector<std::string>& getFontFamiliesDefault();
+
+	bool  specifiesFontSize() const { return mSpecifiesFontSize; }
+	void  unspecifyFontSize() { mSpecifiesFontSize = false; }
+	Value getFontSize() const { return mFontSize; }
+	void  setFontSize(const Value& fontSize) {
+		 mSpecifiesFontSize = true;
+		 mFontSize			= fontSize;
+	}
+	[[nodiscard]] static Value getFontSizeDefault() { return {12}; }
+
+	bool	   specifiesFontWeight() const { return mSpecifiesFontWeight; }
+	void	   unspecifyFontWeight() { mSpecifiesFontWeight = false; }
+	FontWeight getFontWeight() const { return mFontWeight; }
+	void	   setFontWeight(FontWeight weight) {
+		  mSpecifiesFontWeight = true;
+		  mFontWeight		   = weight;
+	}
+	[[nodiscard]] static FontWeight getFontWeightDefault() { return WEIGHT_NORMAL; }
+
+	bool	   specifiesTextAnchor() const { return mSpecifiesTextAnchor; }
+	void	   unspecifyTextAnchor() { mSpecifiesTextAnchor = false; }
+	TextAnchor getTextAnchor() const { return mTextAnchor; }
+	void	   setTextAnchor(TextAnchor anchor) {
+		  mSpecifiesTextAnchor = true;
+		  mTextAnchor		   = anchor;
+	}
+	[[nodiscard]] static TextAnchor getTextAnchorDefault() { return TEXT_ANCHOR_START; }
+
+	bool specifiesVisible() const { return mSpecifiesVisible; }
+	bool isVisible() const { return mVisible; }
+	void setVisible(bool visible) {
+		mSpecifiesVisible = true;
+		mVisible		  = visible;
+	}
+	void unspecifyVisible() { mSpecifiesVisible = false; }
+
+	bool isDisplayNone() const { return mDisplayNone; }
+	void setDisplayNone(bool displayNone) { mDisplayNone = displayNone; }
+
+	void startRender(Renderer& renderer, const SvgNode* node) const;
+	void finishRender(Renderer& renderer, const SvgNode* node) const;
+
+	void parseClassAttribute(const std::string& stylePropertyString, const SvgNode* parent);
+	void parseStyleAttribute(const std::string& stylePropertyString, const SvgNode* parent);
+	bool parseProperty(const std::string& key, const std::string& value, const SvgNode* parent);
+
+	Paint parsePaint(const char* value, bool* specified, const SvgNode* parent) const;
+
+	// Attempts to find a Style definition in one of its parents for the value stored in mId.
+	void resolve(const SvgNode* node) const;
+
+	bool operator==(const Style& other) const;
+	bool operator!=(const Style& other) const { return !(*this == other); }
+
+	// Merges the right-hand Style into the left-hand one.
+	void operator+=(const Style& other);
+	// Merges the two styles.
+	Style operator+(const Style& other) const;
+
+  protected:
+	bool  mSpecifiesOpacity;
+	float mOpacity;
+	bool  mSpecifiesFillOpacity, mSpecifiesStrokeOpacity;
+	float mFillOpacity, mStrokeOpacity;
+
+	bool			   mSpecifiesColor;
+	ci::ColorA8u	   mColor;
+	bool			   mSpecifiesFill, mSpecifiesStroke;
+	mutable Paint	   mFill, mStroke; // Paint might need to be resolved from a 'const' method.
+	bool			   mSpecifiesStrokeWidth;
+	float			   mStrokeWidth;
+	bool			   mSpecifiesFillRule;
+	FillRule		   mFillRule;
+	bool			   mSpecifiesLineCap;
+	LineCap			   mLineCap;
+	bool			   mSpecifiesLineJoin;
+	LineJoin		   mLineJoin;
+	bool			   mSpecifiesMiterLimit;
+	float			   mMiterLimit;
+	bool			   mSpecifiesDashArray;
+	std::vector<float> mDashArray;
+	bool			   mSpecifiesDashOffset;
+	float			   mDashOffset;
+	bool			   mSpecifiesClipPath;
+	std::string		   mClipPathId;
+	bool			   mSpecifiesStopColor;
+	ci::ColorA8u	   mStopColor;
+	bool			   mSpecifiesStopOpacity;
+	float			   mStopOpacity;
+
+	// cached clip-path
+	mutable const SvgClipPath* mClipPath = nullptr;
+
+	// fonts
+	bool					 mSpecifiesFontFamilies, mSpecifiesFontSize, mSpecifiesFontWeight, mSpecifiesTextAnchor;
+	std::vector<std::string> mFontFamilies;
+	Value					 mFontSize;
+	FontWeight				 mFontWeight;
+	TextAnchor				 mTextAnchor;
+
+	// visibility
+	bool mSpecifiesVisible, mVisible, mDisplayNone;
+};
+
+//! Base class for an element of an SVG Document
+class SvgNode {
+  public:
+	explicit SvgNode(SvgNode* parent)
+	  : mParent(parent)
+	  , mSpecifiesTransform(false)
+	  , mBoundingBoxCached(false) {
+		mUuid = nextUuid();
+	}
+	virtual ~SvgNode() = default;
+
+	SvgNode(const SvgNode&)			   = delete;
+	SvgNode(SvgNode&&)				   = delete;
+	SvgNode& operator=(const SvgNode&) = delete;
+	SvgNode& operator=(SvgNode&&)	   = delete;
+
+	//! Returns the unique id for this node.
+	size_t getUuid() const { return mUuid; }
+	//! Returns the svg::Doc this Node is an element of
+	[[nodiscard]] const SvgDoc* getDoc() const;
+	//! Returns the immediate parent of this node
+	const SvgNode* getParent() const { return mParent; }
+	//! Returns the tag of this Node when present (e.g. 'svg').
+	const std::string& getTag() const { return mTag; }
+	//! Returns the ID of this Node when present.
+	const std::string& getId() const { return mId; }
+	//! Returns a DOM-style path to this node.
+	[[nodiscard]] std::string getDomPath() const;
+	//! Returns the style elements defined on this Node but not inherited from ancestors.
+	[[nodiscard]] const Style& getStyle() const {
+		mStyle.resolve(this);
+		return mStyle;
+	}
+	//! Sets the style defined on this Node but not inherited from ancestors.
+	void setStyle(const Style& style) { mStyle = style; }
+	//! Returns the node's Style, including attributes inherited from its ancestors for attributes it does not
+	//! specify
+	[[nodiscard]] Style calcInheritedStyle() const;
+
+	//! Returns the ClipPath for this node. Returns NULL on failure.
+	[[nodiscard]] virtual const SvgClipPath* getClipPath() const;
+	//! Returns the ClipPath for the specified \a style. Returns NULL on failure.
+	[[nodiscard]] virtual const SvgClipPath* getClipPath(const Style& style) const;
+
+	//! Returns whether the point \a pt is inside of the Node's shape.
+	virtual bool containsPoint(const glm::vec2& /*pt*/) const { return false; }
+
+	//! Renders the node and its descendants.
+	void render(Renderer& renderer) const;
+
+	//! Finds the node with ID \a elementId amongst this Node's ancestors. Returns NULL on failure.
+	[[nodiscard]] virtual const SvgNode* findInAncestors(const std::string& elementId) const;
+	//! Finds the svg::Paint node with ID \a elementId amongst this Node's ancestors. Returns a default svg::Paint
+	//! instance on failure.
+	[[nodiscard]] Paint findPaintInAncestors(const std::string& paintName) const;
+	//! Recursively searches for a <tag> node and returns the first it finds. Returns NULL on failure.
+	[[nodiscard]] virtual const SvgNode* findTagInAncestors(const std::string& tag) const;
+
+	//! Returns whether this Node specifies a transformation
+	bool specifiesTransform() const { return mSpecifiesTransform; }
+	//! Returns the local transformation of this node. Returns identity if the Node's transform isn't specified.
+	glm::mat3 getTransform() const { return mTransform; }
+	//! Sets the local transformation of this node.
+	void setTransform(const glm::mat3& transform) {
+		mTransform			= transform;
+		mSpecifiesTransform = true;
+	}
+	//! Removes the local transformation of this node, effectively making it the identity matrix.
+	void unspecifyTransform() { mSpecifiesTransform = false; }
+	//! Returns the inverse of the local transformation of this node. Returns identity if the Node's transform isn't
+	//! specified.
+	[[nodiscard]] glm::mat3 getTransformInverse() const {
+		return (mSpecifiesTransform) ? inverse(mTransform) : glm::mat3();
+	}
+	//! Returns the absolute transformation of this node, which includes inherited transformations.
+	[[nodiscard]] glm::mat3 getTransformAbsolute() const;
+	//! Returns the inverse of the absolute transformation of this node, which includes inherited transformations.
+	[[nodiscard]] glm::mat3 getTransformAbsoluteInverse() const { return inverse(getTransformAbsolute()); }
+
+	//! Returns the local bounding box of the Node. Calculated and cached the first time it is requested.
+	[[nodiscard]] ci::Rectf getBoundingBox() const {
+		if (!mBoundingBoxCached) {
+			mBoundingBox	   = calcBoundingBox();
+			mBoundingBoxCached = true;
+		}
+		return mBoundingBox;
+	}
+	//! Returns the absolute bounding box of the Node. Calculated and cached the first time it is requested.
+	[[nodiscard]] ci::Rectf getBoundingBoxAbsolute() const {
+		return getBoundingBox().transformed(getTransformAbsolute());
+	}
+
+	//! Returns a Shape2d representing the node in local coordinates. Not supported for Text.
+	virtual ci::Shape2d getShape() const { return {}; }
+	//! Returns a Shape2d representing the node in absolute coordinates. Not supported for Text.
+	[[nodiscard]] ci::Shape2d getShapeAbsolute() const { return getShape().transformed(getTransformAbsolute()); }
+
+	//! Returns node's color, or the first among its ancestors when it has none
+	const ci::ColorA8u& getColor() const;
+	//! Returns node's fill, or the first among its ancestors when it has none
+	const Paint& getFill() const;
+	//! Returns node's stroke, or the first among its ancestors when it has none
+	const Paint& getStroke() const;
+	//! Returns node's opacity, or the first among its ancestors when it has none
+	float getOpacity() const;
+	//! Returns node's fill opacity, or the first among its ancestors when it has none
+	float getFillOpacity() const;
+	//! Returns node's stroke opacity, or the first among its ancestors when it has none
+	float getStrokeOpacity() const;
+	//! Returns node's fill rule, or the first among its ancestors when it has none
+	FillRule getFillRule() const;
+	//! Returns node's line cap, or the first among its ancestors when it has none
+	LineCap getLineCap() const;
+	//! Returns node's line join, or the first among its ancestors when it has none
+	LineJoin getLineJoin() const;
+	//! Returns node's miter limit, or the first among its ancestors when it has none
+	float getMiterLimit() const;
+	//! Returns node's dash array, or the first among its ancestors when it has none
+	const std::vector<float>& getDashArray() const;
+	//! Returns node's dash offset, or the first among its ancestors when it has none
+	float getDashOffset() const;
+	//! Returns node's stop color, or the first among its ancestors when it has none
+	ci::ColorA8u getStopColor() const;
+	//! Returns node's stop opacity, or the first among its ancestors when it has none
+	float getStopOpacity() const;
+	//! Returns node's stroke width, or the first among its ancestors when it has none
+	float getStrokeWidth() const;
+	//! Returns node's font families, or the first among its ancestors when it has none
+	const std::vector<std::string>& getFontFamilies() const;
+	//! Returns node's font size, or the first among its ancestors when it has none
+	Value getFontSize() const;
+	//! Returns node's text anchor, or the first among its ancestors when it has none
+	TextAnchor getTextAnchor() const;
+	//! Returns whether this Node is visible, or the first among its ancestors when unspecified
+	virtual bool isVisible() const;
+	//! Returns whether the Display property of this Node is set to 'None', preventing rendering of the node and its
+	//! children
+	virtual bool isDisplayNone() const { return getStyle().isDisplayNone(); }
+	//! Returns whether this type of node directly renders anything. Everything but groups and gradients.
+	virtual bool isDrawable() const { return true; }
+
+	//
+	static size_t nextUuid() {
+		static size_t uuid = 0;
+		return ++uuid;
+	}
+
+  protected:
+	SvgNode(SvgNode* parent, const ci::XmlTree& xml);
+
+	void		 startRender(Renderer& renderer, const Style& style) const;
+	void		 finishRender(Renderer& renderer, const Style& style) const;
+	virtual void renderSelf(Renderer& renderer) const = 0;
+
+	virtual ci::Rectf calcBoundingBox() const { return {0, 0, 0, 0}; }
+
+	static Paint	 parsePaint(const char* value, bool* specified, const SvgNode* parentNode);
+	static glm::mat3 parseTransform(const std::string& value);
+	static bool		 parseTransformComponent(const char** c, glm::mat3* result);
+
+	static std::string findStyleValue(const std::string& styleString, const std::string& key);
+	void			   parseStyle(const ci::XmlTree& xml);
+
+	size_t			  mUuid;
+	SvgNode*		  mParent;
+	std::string		  mTag;
+	std::string		  mId;
+	bool			  mSpecifiesTransform;
+	glm::mat3		  mTransform;
+	mutable bool	  mBoundingBoxCached;
+	mutable ci::Rectf mBoundingBox;
+	Style			  mStyle; // Try avoiding directly accessing this variable, use getStyle() instead if possible.
+
+  private:
+	void firstStartRender(Renderer& renderer) const;
+
+	friend class SvgGroup;
+	friend class SvgUse;
+};
+
+//! Base class for SVG Gradients. See SVG Gradients: http://www.w3.org/TR/SVG/pservers.html#Gradients
+class SvgGradient : public SvgNode {
+  public:
+	SvgGradient(SvgNode* parent, const ci::XmlTree& xml);
+
+	class Stop {
+	  public:
+		Stop() = default;
+		Stop(const SvgNode* parent, const ci::XmlTree& xml);
+
+		bool operator<(const Stop& rhs) const { return offset < rhs.offset; }
+
+		float		 offset{0}; // normalized 0-1
+		ci::ColorA8u color{0, 0, 0, 255};
+		float		 opacity{1};
+		bool		 specifiesColor{true};
+		bool		 specifiesOpacity{true};
+	};
+
+	bool useObjectBoundingBox() const { return mUseObjectBoundingBox; }
+
+	SpreadMethod getSpreadMethod() const { return mSpreadMethod; }
+
+	virtual Paint::Type getType() const { return Paint::Type::NONE; }
+
+	//!
+	virtual Paint asPaint() const;
+
+	virtual void parse(const ci::XmlTree& xml);
+
+  protected:
+	void renderSelf(Renderer& /*renderer*/) const override {}
+
+	void copyAttributesFrom(const SvgGradient& rhs);
+
+	std::vector<Stop> mStops;
+	bool			  mUseObjectBoundingBox{true};
+	bool			  mSpecifiesSpreadMethod{false};
+	SpreadMethod	  mSpreadMethod{SpreadMethod::PAD};
+};
+
+//! SVG Linear gradient
+class SvgLinearGradient : public SvgGradient {
+  public:
+	SvgLinearGradient(SvgNode* parent, const ci::XmlTree& xml);
+
+	bool isDrawable() const override { return false; }
+
+	Paint::Type getType() const override { return Paint::Type::LINEAR_GRADIENT; }
+
+	Paint asPaint() const override;
+
+	void parse(const ci::XmlTree& xml) override;
+
+  protected:
+	void copyAttributesFrom(const SvgLinearGradient& rhs);
+
+	Value mX1{0, Value::PERCENT};
+	Value mY1{0, Value::PERCENT};
+	Value mX2{100, Value::PERCENT};
+	Value mY2{0, Value::PERCENT};
+
+	friend class SvgGradient;
+};
+
+//! SVG Radial gradient
+class SvgRadialGradient : public SvgGradient {
+  public:
+	SvgRadialGradient(SvgNode* parent, const ci::XmlTree& xml);
+
+	bool isDrawable() const override { return false; }
+
+	Paint::Type getType() const override { return Paint::Type::RADIAL_GRADIENT; }
+
+	Paint asPaint() const override;
+
+	void parse(const ci::XmlTree& xml) override;
+
+  protected:
+	void copyAttributesFrom(const SvgRadialGradient& rhs);
+
+	Value mCx{50, Value::PERCENT};
+	Value mCy{50, Value::PERCENT};
+	Value mR{50, Value::PERCENT};
+	Value mFx{mCx};
+	Value mFy{mCy};
+	Value mFr{0, Value::PERCENT};
+
+	friend class SvgGradient;
+};
+
+class Svg : public Renderer {
+  public:
+	Svg() = default;
+
+	explicit Svg(const ci::DataSourceRef& src);
+	explicit Svg(const SvgDocRef& svg);
+
+	float			 getWidth() const { return mBounds.getWidth(); }
+	float			 getHeight() const { return mBounds.getHeight(); }
+	ci::vec2		 getSize() const { return mBounds.getSize(); }
+	const ci::Rectf& getBounds() const { return mBounds; }
+
+	float getOpacity() const { return mOpacity; }
+	void  setOpacity(float opacity) { mOpacity = opacity; }
+
+	//! Clears rendering cache.
+	void clear() override;
+
+  private:
+	// svg::Renderer callbacks.
+
+	void start() override;
+	void finish() override;
+	void pushGroup(const SvgGroup& group, float opacity) override;
+	void popGroup() override;
+	void pushClipPath(const SvgClipPath& clippath) override;
+	void popClipPath() override;
+	void drawPath(const SvgPath&) override;
+	void drawPolyline(const SvgPolyline&) override;
+	void drawPolygon(const SvgPolygon&) override;
+	void drawLine(const SvgLine&) override;
+	void drawRect(const SvgRect&) override;
+	void drawCircle(const SvgCircle&) override;
+	void drawEllipse(const SvgEllipse&) override;
+	void drawImage(const SvgImage&) override;
+	void drawTextSpan(const SvgTextSpan&) override { /* currently not implemented */
+	}
+	void pushMatrix(const glm::mat3&) override;
+	void popMatrix() override;
+	void pushFill(const Paint&) override;
+	void popFill() override;
+	void pushStroke(const Paint&) override;
+	void popStroke() override;
+	void pushFillOpacity(float) override;
+	void popFillOpacity() override;
+	void pushStrokeOpacity(float) override;
+	void popStrokeOpacity() override;
+	void pushStrokeWidth(float) override;
+	void popStrokeWidth() override;
+	void pushFillRule(FillRule) override;
+	void popFillRule() override;
+	void pushLineCap(LineCap) override;
+	void popLineCap() override;
+	void pushLineJoin(LineJoin) override;
+	void popLineJoin() override;
+	void pushMiterLimit(float miterLimit) override;
+	void popMiterLimit() override;
+	void pushDashArray(const std::vector<float>& dashArray) override;
+	void popDashArray() override;
+	void pushDashOffset(float dashOffset) override;
+	void popDashOffset() override;
+	void pushTextPen(const ci::vec2&) override;
+	void popTextPen() override;
+	void pushTextRotation(float) override;
+	void popTextRotation() override;
+
+	//! Returns whether the current style has fill or stroke enabled.
+	bool shouldRender() const { return !(mStacks.fill.back().isNone() && mStacks.stroke.back().isNone()); }
+	//! Generates a draw call for visible paths.
+	void render(const Path& path);
+	//! Fills the path with the specified \a paint and \a opacity.
+	void fill(GLuint pathId, const Paint& paint, float opacity);
+	//! Strokes the path with the specified \a paint and \a opacity.
+	void stroke(GLuint pathId, const Paint& paint, float opacity);
+	//! Strokes the instances with the specified \a paint and \a opacity.
+	void fillInstanced(GLuint baseId, GLsizei count, const glm::mat3x2* transforms, const uint32_t* indices,
+					   const Paint& paint, float opacity);
+	//! Strokes the instances with the specified \a paint and \a opacity.
+	void strokeInstanced(GLuint baseId, GLsizei count, const glm::mat3x2* transforms, const uint32_t* indices,
+						 const Paint& paint, float opacity);
+
+	//! Returns whether the path with the specified \a uuid exists and returns a pointer to the path if it exists.
+	const Path* findPath(size_t uuid) const;
+	//! Caches a clone of the path using the specified \a uuid and \a path. Returns a pointer to the new path.
+	const Path* insertPath(size_t uuid, const Path& path, bool isClipPath = false);
+	//! Caches a path using the specified \a uuid and SVG \a path. Returns a pointer to the new path.
+	const Path* insertPath(size_t uuid, const std::string& path, bool isClipPath = false);
+	//! Caches a path using the specified \a uuid and \a path. Returns a pointer to the new path.
+	const Path* insertPath(size_t uuid, const ci::Path2d& path, bool isClipPath = false);
+	//! Caches a path using the specified \a uuid and \a shape. Returns a pointer to the new path.
+	const Path* insertPath(size_t uuid, const ci::Shape2d& shape, bool isClipPath = false);
+
+	//! Returns the stencil mask based on the current fill rule.
+	GLuint getStencilMask() const { return mStacks.fillRule.back() == FILL_RULE_EVEN_ODD ? 0x01 : 0xFF; }
+
+	SvgDocRef                                        mDoc;
+	ci::gl::Context*                                 mCtx = nullptr;
+	Stacks                                           mStacks;
+	ci::Rectf                                        mBounds{0, 0, 0, 0};
+	Paints                                           mPaints;
+	std::unordered_map<GLuint, ci::gl::Texture2dRef> mTextures;
+	std::unordered_map<GLuint, Path>                 mPaths;
+	float                                            mOpacity{1};
+};
+
+//! SVG Circle element: http://www.w3.org/TR/SVG/shapes.html#CircleElement
+class SvgCircle : public SvgNode {
+  public:
+	SvgCircle(SvgNode* parent)
+	  : SvgNode(parent) {}
+	SvgCircle(SvgNode* parent, const ci::XmlTree& xml);
+
+	glm::vec2 getCenter() const { return mCenter; }
+	void	  setCenter(const glm::vec2& center) { mCenter = center; }
+	float	  getRadius() const { return mRadius; }
+	void	  setRadius(float radius) { mRadius = radius; }
+
+	bool isVisible() const override {
+		// A value of zero disables rendering of the element.
+		if (mRadius <= 0) return false;
+		return SvgNode::isVisible();
+	}
+
+	[[nodiscard]] bool containsPoint(const glm::vec2& pt) const override {
+		return distance2(pt, mCenter) < mRadius * mRadius;
+	}
+
+	[[nodiscard]] ci::Shape2d getShape() const override;
+
+  protected:
+	void renderSelf(Renderer& renderer) const override;
+
+	[[nodiscard]] ci::Rectf calcBoundingBox() const override {
+		return {mCenter.x - mRadius, mCenter.y - mRadius, mCenter.x + mRadius, mCenter.y + mRadius};
+	}
+
+	glm::vec2 mCenter{0};
+	float	  mRadius{1};
+};
+
+//! SVG Ellipse element: http://www.w3.org/TR/SVG/shapes.html#EllipseElement
+class SvgEllipse : public SvgNode {
+  public:
+	explicit SvgEllipse(SvgNode* parent)
+	  : SvgNode(parent) {}
+	SvgEllipse(SvgNode* parent, const ci::XmlTree& xml);
+
+	glm::vec2 getCenter() const { return mCenter; }
+	void	  setCenter(const glm::vec2& center) { mCenter = center; }
+	float	  getRadiusX() const { return mRadiusX; }
+	void	  setRadiusX(float radiusX) { mRadiusX = radiusX; }
+	float	  getRadiusY() const { return mRadiusY; }
+	void	  setRadiusY(float radiusY) { mRadiusY = radiusY; }
+
+	bool isVisible() const override {
+		// A value of zero disables rendering of the element.
+		if (mRadiusX <= 0 || mRadiusY <= 0) return false;
+		return SvgNode::isVisible();
+	}
+
+	bool containsPoint(const glm::vec2& pt) const override;
+
+	ci::Shape2d getShape() const override;
+
+  protected:
+	void renderSelf(Renderer& renderer) const override;
+
+	ci::Rectf calcBoundingBox() const override {
+		return {mCenter.x - mRadiusX, mCenter.y - mRadiusY, mCenter.x + mRadiusX, mCenter.y + mRadiusY};
+	}
+
+	glm::vec2 mCenter{0};
+	float	  mRadiusX{1}, mRadiusY{1};
+};
+
+//! SVG Path element: http://www.w3.org/TR/SVG/paths.html#PathElement
+class SvgPath : public SvgNode {
+  public:
+	SvgPath(SvgNode* parent)
+	  : SvgNode(parent) {}
+	SvgPath(SvgNode* parent, const ci::XmlTree& xml);
+
+	const ci::Shape2d& getShape2d() const { return mPath; }
+	void			   appendShape2d(ci::Shape2d* appendTo) const;
+
+	bool containsPoint(const glm::vec2& pt) const override { return mPath.contains(pt); }
+
+	ci::Shape2d getShape() const override { return mPath; }
+	void		setShape(const ci::Shape2d& shape) { mPath = shape; }
+
+  protected:
+	void	  renderSelf(Renderer& renderer) const override;
+	ci::Rectf calcBoundingBox() const override { return mPath.calcPreciseBoundingBox(); }
+
+	ci::Shape2d mPath;
+};
+
+//! SVG Line element: http://www.w3.org/TR/SVG/shapes.html#LineElement
+class SvgLine : public SvgNode {
+  public:
+	SvgLine(SvgNode* parent)
+	  : SvgNode(parent) {}
+	SvgLine(SvgNode* parent, const ci::XmlTree& xml);
+
+	const glm::vec2& getPoint1() const { return mPoint1; }
+	const glm::vec2& getPoint2() const { return mPoint2; }
+
+	ci::Shape2d getShape() const override;
+
+  protected:
+	void renderSelf(Renderer& renderer) const override;
+
+	ci::Rectf calcBoundingBox() const override {
+		return {std::min(mPoint1.x, mPoint2.x), std::min(mPoint1.y, mPoint2.y), std::max(mPoint1.x, mPoint2.x),
+				std::max(mPoint1.y, mPoint2.y)};
+	}
+
+	glm::vec2 mPoint1{0}, mPoint2{0};
+};
+
+//! SVG Rect element: http://www.w3.org/TR/SVG/shapes.html#RectElement
+class SvgRect : public SvgNode {
+  public:
+	SvgRect(SvgNode* parent)
+	  : SvgNode(parent) {}
+	SvgRect(SvgNode* parent, const ci::XmlTree& xml);
+
+	const ci::Rectf& getRect() const { return mRect; }
+	void			 setRect(const ci::Rectf& rect) { mRect = rect; }
+	void			 setWidth(float width) { mRect = ci::Rectf(mRect.x1, mRect.y1, mRect.x1 + width, mRect.y2); }
+	void			 setHeight(float height) { mRect = ci::Rectf(mRect.x1, mRect.y1, mRect.x2, mRect.y1 + height); }
+
+	float getRx() const;
+	float getRy() const;
+
+	bool isVisible() const override {
+		// A value of zero disables rendering of the element.
+		if (mRect.getWidth() <= 0 || mRect.getHeight() <= 0) return false;
+		return SvgNode::isVisible();
+	}
+
+	bool containsPoint(const glm::vec2& pt) const override { return mRect.contains(pt); }
+
+	ci::Shape2d getShape() const override;
+
+  protected:
+	void	  renderSelf(Renderer& renderer) const override;
+	ci::Rectf calcBoundingBox() const override { return mRect; }
+
+	ci::Rectf mRect;
+	Value	  mRx{0}; // Defaults to 'auto'.
+	Value	  mRy{0}; // Defaults to 'auto'.
+};
+
+//! SVG Polygon Element: http://www.w3.org/TR/SVG/shapes.html#PolygonElement
+class SvgPolygon : public SvgNode {
+  public:
+	explicit SvgPolygon(SvgNode* parent)
+	  : SvgNode(parent) {}
+	SvgPolygon(SvgNode* parent, const ci::XmlTree& xml);
+
+	const ci::PolyLine2f& getPolyLine() const { return mPolyLine; }
+	ci::PolyLine2f&		  getPolyLine() { return mPolyLine; }
+
+	bool containsPoint(const glm::vec2& pt) const override { return mPolyLine.contains(pt); }
+
+	ci::Shape2d getShape() const override;
+
+  protected:
+	void	  renderSelf(Renderer& renderer) const override;
+	ci::Rectf calcBoundingBox() const override { return ci::Rectf(mPolyLine.getPoints()); }
+
+	ci::PolyLine2f mPolyLine;
+};
+
+//! SVG Polyline Element: http://www.w3.org/TR/SVG/shapes.html#PolylineElement
+class SvgPolyline : public SvgNode {
+  public:
+	explicit SvgPolyline(SvgNode* parent)
+	  : SvgNode(parent) {}
+	SvgPolyline(SvgNode* parent, const ci::XmlTree& xml);
+
+	const ci::PolyLine2f& getPolyLine() const { return mPolyLine; }
+	ci::PolyLine2f&		  getPolyLine() { return mPolyLine; }
+
+	bool containsPoint(const glm::vec2& pt) const override { return mPolyLine.contains(pt); }
+
+	ci::Shape2d getShape() const override;
+
+  protected:
+	void	  renderSelf(Renderer& renderer) const override;
+	ci::Rectf calcBoundingBox() const override { return ci::Rectf(mPolyLine.getPoints()); }
+
+	ci::PolyLine2f mPolyLine;
+};
+
+//! SVG Use Element, which instantiates a different element: http://www.w3.org/TR/SVG/struct.html#UseElement
+class SvgUse : public SvgNode {
+  public:
+	SvgUse(SvgNode* parent, const ci::XmlTree& xml);
+
+	bool isDrawable() const override { return false; }
+
+	bool isDisplayNone() const override {
+		return SvgNode::isDisplayNone() || (mReferenced ? mReferenced->isDisplayNone() : false);
+	}
+
+	ci::Shape2d getShape() const override {
+		if (mReferenced) return mReferenced->getShape();
+		return {};
+	}
+
+  protected:
+	void renderSelf(Renderer& renderer) const override;
+
+	ci::Rectf calcBoundingBox() const override {
+		if (mReferenced) return mReferenced->getBoundingBox();
+		return {0, 0, 0, 0};
+	}
+
+	void parse(const ci::XmlTree& xml);
+
+	const SvgNode* mReferenced = nullptr;
+};
+
+//! SVG Image Element. Represents an unpremultiplied bitmap. http://www.w3.org/TR/SVG/struct.html#ImageElement
+class SvgImage : public SvgNode {
+  public:
+	SvgImage()
+	  : SvgNode(nullptr) {}
+	SvgImage(SvgNode* parent, const ci::XmlTree& xml);
+
+	operator bool() const { return bool(mImage) || bool(mSvg); }
+
+	const ci::Rectf& getRect() const { return mBounds; }
+
+	std::shared_ptr<ci::Surface8u> getSurface() const { return mImage; }
+	std::shared_ptr<SvgDoc>		   getSvg() const { return mSvg; }
+
+	bool containsPoint(const glm::vec2& pt) const override { return mBounds.contains(pt); }
+
+	//! Returns a transformation matrix for the texture coordinates.
+	const glm::mat3& getTextureMatrix() const { return mTextureMatrix; }
+
+  protected:
+	void	  renderSelf(Renderer& renderer) const override;
+	ci::Rectf calcBoundingBox() const override { return mBounds; }
+
+	bool parseDataImage(const std::string& data);
+
+	ci::Rectf					   mBounds;
+	std::shared_ptr<SvgDoc>		   mSvg;
+	std::shared_ptr<ci::Surface8u> mImage;
+	glm::mat3					   mTextureMatrix;
+};
+
+using TextSpanRef = std::shared_ptr<SvgTextSpan>;
+
+//! SVG tspan Element. Generally owned by a svg::Text Node. http://www.w3.org/TR/SVG/text.html#TSpanElement
+class SvgTextSpan : public SvgNode {
+  public:
+	class Attributes {
+	  public:
+		Attributes() = default;
+		Attributes(const ci::XmlTree& xml);
+
+		void startRender(Renderer& renderer) const;
+		void finishRender(Renderer& renderer) const;
+
+		void setTextPen(const glm::vec2& textPen);
+
+		Value			   mX{0}, mY{0};
+		float			   mDx{}, mDy{};
+		std::vector<Value> mRotate;
+		float			   mTextLength{};
+		float			   mLengthAdjust{};
+		std::vector<Value> mLetterSpacing;
+	};
+
+	SvgTextSpan(SvgNode* parent, const ci::XmlTree& xml);
+	SvgTextSpan(SvgNode* parent, const std::string& spanString);
+
+	const std::string&		  getString() const { return mString; }
+	void					  setString(const std::string& s) { mString = s; }
+	std::shared_ptr<ci::Font> getFont() const;
+	//! Returns a vector of glyph IDs and positions for the string, ignoring rotation. Cached and lazily calculated.
+	std::vector<std::pair<uint16_t, glm::vec2>> getGlyphMeasures() const;
+	glm::vec2									getTextPen() const;
+	void										setTextPen(const glm::vec2& textPen);
+	float										getRotation() const;
+	Value										getLetterSpacing() const;
+
+	std::vector<TextSpanRef>&		getSpans() { return mSpans; }
+	const std::vector<TextSpanRef>& getSpans() const { return mSpans; }
+
+  protected:
+	void renderSelf(Renderer& renderer) const override;
+
+	bool		mIgnoreAttributes; // TextSpans that are actually the contents of Text's attributes should be ignored
+	Attributes	mAttributes;
+	std::string mString;
+	mutable std::shared_ptr<ci::Font>									 mFont;
+	mutable std::shared_ptr<std::vector<std::pair<uint16_t, glm::vec2>>> mGlyphMeasures;
+	mutable std::shared_ptr<ci::Shape2d>								 mShape;
+
+	std::vector<TextSpanRef> mSpans;
+
+	friend class SvgText;
+};
+
+//! SVG Text element. http://www.w3.org/TR/SVG/text.html#TextElement
+class SvgText : public SvgNode {
+  public:
+	SvgText(SvgNode* parent, const ci::XmlTree& xml);
+
+	glm::vec2 getTextPen() const;
+	void	  setTextPen(const glm::vec2& textPen) { mAttributes.setTextPen(textPen); }
+	float	  getRotation() const;
+	Value	  getLetterSpacing() const;
+
+	std::vector<TextSpanRef>&		getSpans() { return mSpans; }
+	const std::vector<TextSpanRef>& getSpans() const { return mSpans; }
+
+  protected:
+	void renderSelf(Renderer& renderer) const override;
+
+	SvgTextSpan::Attributes	 mAttributes;
+	std::vector<TextSpanRef> mSpans;
+};
+
+//! Represents a group of SVG elements. http://www.w3.org/TR/SVG/struct.html#Groups
+class SvgGroup : public SvgNode, private ci::Noncopyable {
+  public:
+	explicit SvgGroup(SvgNode* parent)
+	  : SvgNode(parent) {}
+	SvgGroup(SvgNode* parent, const ci::XmlTree& xml);
+	~SvgGroup() override;
+
+	//! Recursively searches for a child element of type <tt>svg::T</tt> named \a id. Returns NULL on failure to
+	//! find the object or if it is not of type T.
+	template <typename T>
+	const T* find(const std::string& id) const {
+		return dynamic_cast<const T*>(findNode(id));
+	}
+	//! Recursively searches for a child element of type <tt>svg::T</tt> named \a id. Returns NULL on failure to
+	//! find the object or if it is not of type T.
+	template <typename T>
+	T* find(const std::string& id) {
+		return dynamic_cast<T*>(findNode(id));
+	}
+	//! Recursively searches for a child element named \a id. Returns NULL on failure.
+	virtual const SvgNode* findNode(const std::string& id, bool recurse = true) const;
+	//! Recursively searches for a child element named \a id. Returns NULL on failure.
+	SvgNode* findNode(const std::string& id, bool recurse = true) {
+		return const_cast<SvgNode*>(const_cast<const SvgGroup*>(this)->findNode(id, recurse));
+	}
+	//! Recursively searches for a child element of type <tt>svg::T</tt> whose name contains \a idPartial. Returns
+	//! NULL on failure to find the object or if it is not of type T.
+	template <typename T>
+	const T* findByIdContains(const std::string& idPartial) const {
+		return dynamic_cast<const T*>(findNodeByIdContains(idPartial));
+	}
+	//! Recursively searches for a child element whose name contains \a idPartial. Returns NULL on failure.
+	//! (null_ptr later?)
+	const SvgNode* findNodeByIdContains(const std::string& idPartial, bool recurse = true) const;
+	//! Recursively searches for a child element with the specified \a tag. Returns NULL on failure.
+	virtual const SvgNode* findNodeByTag(const std::string& tag, bool recurse = true) const;
+	//! Finds the node with ID \a elementId amongst this Node's ancestors. Returns NULL on failure.
+	const SvgNode* findInAncestors(const std::string& elementId) const override;
+	//! Recursively searches for a <tag> node and returns the first it finds. Returns NULL on failure.
+	const SvgNode* findTagInAncestors(const std::string& elementTag) const override;
+	//! Returns a reference to the child named \a id. Throws svg::ExcChildNotFound if not found.
+	const SvgNode& getChild(const std::string& id) const;
+	//! Returns a reference to the child named \a id. Throws svg::ExcChildNotFound if not found.
+	SvgNode& getChild(const std::string& id) {
+		return const_cast<SvgNode&>(const_cast<const SvgGroup*>(this)->getChild(id));
+	}
+	//! Returns a reference to the child named \a id. Throws svg::ExcChildNotFound if not found.
+	const SvgNode& operator/(const std::string& id) const { return getChild(id); }
+
+	//! Returns the merged Shape2d for all children of the group
+	ci::Shape2d getShape() const override { return getMergedShape2d(); }
+
+	//! Appends the merged Shape2d for the group to \a appentTo.
+	void appendMergedShape2d(ci::Shape2d* appendTo) const;
+
+	//! Returns a reference to the list of the Group's children.
+	const std::list<SvgNode*>& getChildren() const { return mChildren; }
+	//! Returns a reference to the list of the Group's children.
+	std::list<SvgNode*>& getChildren() { return mChildren; }
+	//! Returns a reference to the child at \a index. Throws svg::ExcChildNotFound if \a index is out of range.
+	const SvgNode& getChild(size_t index) const;
+	//! Returns a reference to the child at \a index. Throws svg::ExcChildNotFound if \a index is out of range.
+	SvgNode& getChild(size_t index) { return const_cast<SvgNode&>(const_cast<const SvgGroup*>(this)->getChild(index)); }
+
+	//! Recursively iterates all Nodes in Group or Doc, passing each to \a fn to be optionally manipulated
+	virtual void iterate(const std::function<void(SvgNode*)>& fn);
+
+	//!
+	static SvgNode* create(SvgNode* parent, const ci::XmlTree& xml);
+
+	bool isDrawable() const override { return false; }
+
+  protected:
+	SvgNode*	nodeUnderPoint(const glm::vec2& absolutePoint, const glm::mat3& parentInverseMatrix) const;
+	ci::Shape2d getMergedShape2d() const;
+
+	void	  renderSelf(Renderer& renderer) const override;
+	ci::Rectf calcBoundingBox() const override;
+
+	virtual void parse(const ci::XmlTree& xml);
+
+	std::list<SvgNode*> mChildren;
+
+	friend class SvgNode;
+};
+
+//!
+class SvgDefs : public SvgGroup {
+  public:
+	SvgDefs(SvgNode* parent)
+	  : SvgGroup(parent) {}
+	SvgDefs(SvgNode* parent, const ci::XmlTree& xml);
+
+	const SvgNode* findNode(const std::string& id, bool recurse) const override;
+
+  protected:
+	void renderSelf(Renderer& renderer) const override { /* never render */
+	}
+
+	ci::Rectf calcBoundingBox() const override { return {0, 0, 0, 0}; }
+
+	ci::XmlTree mXml;
+};
+
+//! SVG ClipPath element: https://www.w3.org/TR/SVG/render.html#ClippingAndMasking
+class SvgClipPath : public SvgGroup {
+  public:
+	explicit SvgClipPath(SvgNode* parent)
+	  : SvgGroup(parent) {}
+	SvgClipPath(SvgNode* parent, const ci::XmlTree& xml);
+
+	bool useObjectBoundingBox() const { return mUseObjectBoundingBox; }
+
+	//! Returns whether all children are set to 'display="none"'.
+	bool isDisplayNone() const override { return mIsDisplayNone; }
+
+  protected:
+	void renderSelf(Renderer& renderer) const override { /* never render */
+	}
+
+	bool mUseObjectBoundingBox = false;
+	bool mIsDisplayNone		   = true;
+};
+
+//!
+class SvgStyles : public SvgNode {
+  public:
+	explicit SvgStyles(SvgNode* parent)
+	  : SvgNode(parent) {}
+	SvgStyles(SvgNode* parent, const ci::XmlTree& xml);
+
+	bool   empty() const { return mStyleList.empty(); }
+	size_t size() const { return mStyleList.size(); }
+
+	Style findStyle(const std::string& id) const;
+
+	void renderSelf(Renderer& renderer) const override {}
+
+  protected:
+	std::unordered_map<std::string, Style> mStyleList;
+};
+
+//! Represents an SVG Document. See SVG Document Structure http://www.w3.org/TR/SVG/struct.html
+class SvgDoc : public SvgGroup {
+  public:
+	SvgDoc();
+	SvgDoc(SvgNode* parent, const ci::XmlTree& xml);
+	SvgDoc(const ci::fs::path& filePath);
+	SvgDoc(const ci::DataSourceRef& dataSource, const ci::fs::path& filePath = ci::fs::path());
+	SvgDoc(SvgNode* parent, const ci::DataSourceRef& dataSource, const ci::fs::path& filePath = ci::fs::path());
+
+	static SvgDocRef create(SvgNode* parent, const ci::XmlTree& xml);
+	static SvgDocRef create(const ci::fs::path& filePath);
+	static SvgDocRef create(const ci::DataSourceRef& dataSource, const ci::fs::path& filePath = ci::fs::path());
+	static SvgDocRef create(SvgNode* parent, const ci::DataSourceRef& dataSource,
+							const ci::fs::path& filePath = ci::fs::path());
+	static SvgDocRef createFromSvgz(const ci::DataSourceRef& dataSource, const ci::fs::path& filePath = ci::fs::path());
+
+	//! Returns the file path of the document. Can be relative or empty.
+	const ci::fs::path& getFilePath() const { return mFilePath; }
+
+	//! Returns the width of the document in pixels
+	float getWidth() const { return mBounds.getWidth(); }
+	//! Returns the height of the document in pixels
+	float getHeight() const { return mBounds.getHeight(); }
+	//! Returns the size of the document in pixels
+	glm::vec2 getSize() const { return {getWidth(), getHeight()}; }
+	//! Returns the aspect ratio of the Doc (width / height)
+	float getAspectRatio() const { return getWidth() / getHeight(); }
+	//! Returns the bounds of the Doc (0,0,width,height)
+	const ci::Rectf& getBounds() const { return mBounds; }
+
+	//! Returns the document's dots-per-inch. Currently hardcoded to 72.
+	static float getDpi() { return 72.0f; }
+
+	//! Returns the top-most Node which contains \a pt. Returns NULL if no Node contains the point.
+	SvgNode* nodeUnderPoint(const glm::vec2& pt) const;
+
+	//! Utility function to load an image relative to the document. Caches results.
+	std::shared_ptr<ci::Surface8u> loadImage(const ci::fs::path& relativePath) const;
+
+  private:
+	void loadDoc(const ci::XmlTree& xml);
+	void loadDoc(const ci::DataSourceRef& source, const ci::fs::path& filePath);
+
+	void renderSelf(Renderer& renderer) const override;
+
+	mutable std::map<ci::fs::path, std::shared_ptr<ci::Surface8u>> mImageCache;
+
+	ci::fs::path mFilePath;
+	ci::Rectf	 mBounds;
+	ci::Rectf	 mViewBox;
+};
+
+//! SVG Exception base-class
+class SvgExc : public ci::Exception {};
+
+class SvgValueExc : public SvgExc {};
+
+class SvgFloatParseExc : public SvgExc {};
+
+class SvgPathParseExc : public SvgExc {};
+
+class SvgTransformParseExc : public SvgExc {};
+
+class SvgChildNotFoundExc : public SvgExc {
+  public:
+	SvgChildNotFoundExc(const std::string& child);
+};
+
+
+} // namespace nvpath::svg

--- a/projects/nvpath/src/nvpath/NvPathUtil.h
+++ b/projects/nvpath/src/nvpath/NvPathUtil.h
@@ -1,0 +1,377 @@
+/*
+Copyright (c) 2023, Paul Houx Creative Coding - All rights reserved.
+This code is intended for use with the Cinder C++ library: http://libcinder.org
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+ the following conditions are met:
+
+	* Redistributions of source code must retain the above copyright notice, this list of conditions and
+	the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+	the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+ WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+#include <ds/util/float_util.h> // for approxEqual method.
+
+#include "cy/cyPolynomial.h"
+
+namespace nvpath::util {
+
+template <typename T = float>
+glm::vec<2, T> rotate(const glm::vec<2, T>& point, T angle) {
+	T cosA = std::cos(angle);
+	T sinA = std::sin(angle);
+	return {point.x * cosA - point.y * sinA, point.x * sinA + point.y * cosA};
+}
+
+template <typename T = float>
+T normalizeAngle(T angle, T range = T{2 * M_PI}, T offset = T{0}) {
+	return glm::fract((angle - offset) / range) * range + offset;
+}
+
+// Check if angle is within the given range.
+template <typename T = float>
+bool angleInRange(T angle, T startAngle, T diffAngle) {
+	const T delta = normalizeAngle(angle - startAngle);
+	if (diffAngle < 0) return normalizeAngle(diffAngle) <= delta;
+	return delta >= 0 && delta <= diffAngle;
+}
+
+/// Equation 5.4 of the SVG 2.0 specification: https://www.w3.org/TR/SVG/implnote.html#ArcImplementationNotes
+template <typename T = float>
+T arcHelper(const glm::vec<2, T>& a, const glm::vec<2, T>& b) {
+	const T sign = a.x * b.y - a.y * b.x < T{0} ? T{-1} : T{1};
+	return sign * glm::acos(glm::clamp(glm::dot(glm::normalize(a), glm::normalize(b)), T{-1}, T{1}));
+}
+
+template <typename T = float>
+struct Line {
+	glm::vec<2, T> p0{};
+	glm::vec<2, T> p1{};
+
+	Line() = default;
+	Line(const glm::vec<2, T>& p0, const glm::vec<2, T>& p1)
+		: p0(p0)
+		, p1(p1) {}
+	explicit Line(const float params[4])
+		: Line({params[0], params[1]}, {params[2], params[3]}) {}
+
+	[[nodiscard]] glm::vec<2, T> evaluate(T t) const { return p0 * (T{1} - t) + p1 * t; }
+
+	[[nodiscard]] glm::vec<2, T> normal() const { return glm::normalize(glm::vec<2, T>{p1.y - p0.y, p0.x - p1.x}); }
+};
+
+template <typename T = float>
+struct QuadraticCurve {
+	glm::vec<2, T> p0{};
+	glm::vec<2, T> p1{};
+	glm::vec<2, T> p2{};
+
+	QuadraticCurve() = default;
+	QuadraticCurve(const glm::vec<2, T>& p0, const glm::vec<2, T>& p1, const glm::vec<2, T>& p2)
+		: p0(p0)
+		, p1(p1)
+		, p2(p2) {}
+	explicit QuadraticCurve(const float params[6])
+		: QuadraticCurve({params[0], params[1]}, {params[2], params[3]}, {params[4], params[5]}) {}
+
+	[[nodiscard]] glm::vec<2, T> evaluate(T t) const {
+		const T t1 = T{1} - t;
+		return p0 * t1 * t1 + p1 * T{2} * t1 * t + p2 * t * t;
+	}
+};
+
+template <typename T = float>
+struct CubicCurve {
+	glm::vec<2, T> p0{};
+	glm::vec<2, T> p1{};
+	glm::vec<2, T> p2{};
+	glm::vec<2, T> p3{};
+
+	CubicCurve() = default;
+	CubicCurve(const glm::vec<2, T>& p0, const glm::vec<2, T>& p1, const glm::vec<2, T>& p2, const glm::vec<2, T>& p3)
+		: p0(p0)
+		, p1(p1)
+		, p2(p2)
+		, p3(p3) {}
+	explicit CubicCurve(const float params[8])
+		: CubicCurve({params[0], params[1]}, {params[2], params[3]}, {params[4], params[5]}, {params[6], params[7]}) {}
+
+	[[nodiscard]] glm::vec<2, T> evaluate(T t) const {
+		const T t1 = T{1} - t;
+		return p0 * t1 * t1 * t1 + p1 * T{3} * t1 * t1 * t + p2 * T{3} * t1 * t * t + p3 * t * t * t;
+	}
+};
+
+template <typename T = float>
+struct Arc {
+	glm::vec<2, T> center{};
+	T			   rx;
+	T			   ry;
+	T			   xAxisRotation;
+	T			   startAngle;
+	T			   diffAngle;
+
+	Arc() = default;
+	Arc(const glm::vec<2, T>& center, float radiusX, float radiusY, float xAxisRotation, float startAngle,
+		float diffAngle)
+		: center(center)
+		, rx(glm::abs(radiusX))
+		, ry(glm::abs(radiusY))
+		, xAxisRotation(xAxisRotation)
+		, startAngle(startAngle)
+		, diffAngle(diffAngle) {}
+	Arc(const glm::vec<2, T>& p0, float radiusX, float radiusY, float xAxisRotation, bool largeFlag, bool sweepFlag,
+		const glm::vec<2, T>& p1)
+		: rx(glm::abs(radiusX))
+		, ry(glm::abs(radiusY))
+		, xAxisRotation(xAxisRotation) {
+		// Implementation of https://www.w3.org/TR/SVG/implnote.html#ArcCorrectionOutOfRangeRadii
+		const T				 theta = glm::radians(xAxisRotation);
+		const glm::vec<2, T> p	   = rotate((p0 - p1) / T{2}, -theta);
+		const glm::vec<2, T> pSqr  = p * p;
+
+		const T sqrtLambda = glm::sqrt(glm::max(T{1}, pSqr.x / (rx * rx) + pSqr.y / (ry * ry)));
+		rx *= sqrtLambda;
+		ry *= sqrtLambda;
+
+		// Implementation of https://www.w3.org/TR/SVG/implnote.html#ArcConversionEndpointToCenter
+
+		// Equation 5.2.
+		T rxSqr		  = rx * rx;
+		T rySqr		  = ry * ry;
+		T nominator	  = glm::max(T{0}, rxSqr * rySqr - rxSqr * pSqr.y - rySqr * pSqr.x);
+		T denominator = rxSqr * pSqr.y + rySqr * pSqr.x;
+		T f			  = std::sqrt(nominator / denominator);
+		if (largeFlag == sweepFlag) f = -f;
+
+		glm::vec<2, T> c = {f * rx * p.y / ry, f * -ry * p.x / rx};
+
+		// Equation 5.3.
+		center = rotate(c, theta) + (p0 + p1) / T{2};
+
+		// Equations 5.5 and 5.6.
+		startAngle = arcHelper({1, 0}, {(p.x - c.x) / rx, (p.y - c.y) / ry});
+		diffAngle  = arcHelper({(p.x - c.x) / rx, (p.y - c.y) / ry}, {(-p.x - c.x) / rx, (-p.y - c.y) / ry});
+
+		if (!sweepFlag && diffAngle > 0)
+			diffAngle -= T{2.0 * M_PI};
+		else if (sweepFlag && diffAngle < 0)
+			diffAngle += T{2.0 * M_PI};
+	}
+	explicit Arc(const float params[9])
+		: Arc({params[0], params[1]}, params[2], params[3], params[4], params[5], params[6], {params[7], params[8]}) {}
+
+	[[nodiscard]] glm::vec<2, T> evaluate(T t) const {
+		const T phi = startAngle + t * diffAngle;
+		return center + rotate({rx * std::cos(phi), ry * std::sin(phi)}, xAxisRotation);
+	}
+};
+
+template <typename T = float>
+std::vector<T> solveQuadratic(T a, T b, T c) {
+	T		  roots[2];
+	const T	  coefficients[] = {a, b, c};
+	const int count			 = cy::QuadraticRoots<T>(roots, coefficients);
+
+	if (count) return {roots, roots + count};
+	return {};
+}
+
+template <typename T = float>
+std::vector<T> solveCubic(T a, T b, T c, T d) {
+	T		  roots[3];
+	const T	  coefficients[] = {a, b, c, d};
+	const int count			 = cy::CubicRoots<T>(roots, coefficients);
+
+	if (count) return {roots, roots + count};
+	return {};
+}
+
+template <typename T = float>
+std::vector<T> solveQuartic(T a, T b, T c, T d, T e) {
+	T		  roots[4];
+	const T	  coefficients[] = {a, b, c, d, e};
+	const int count			 = cy::PolynomialRoots<4>(roots, coefficients);
+
+	if (count) return {roots, roots + count};
+	return {};
+}
+
+template <typename T = float>
+T distanceLineLine(const Line<T>& lineA, const Line<T>& lineB) {
+	const glm::vec<2, T> v0 = lineA.p0 - lineA.p1;
+	const glm::vec<2, T> v1 = lineB.p0 - lineB.p1;
+
+	const T det = v0.x * v1.y - v0.y * v1.x;
+	if (ds::approxZero(det)) return glm::distance(lineA.p0, lineB.p0);
+
+	const glm::vec<2, T> v2 = lineA.p0 - lineB.p0;
+
+	const T t = (v2.x * v1.y - v2.y * v1.x) / det;
+	const T u = (v2.x * v0.y - v2.y * v0.x) / det;
+
+	if (t < 0 || t > 1 || u < 0 || u > 1) return glm::distance(lineA.p0, lineB.p0);
+
+	return T{0};
+}
+
+/// \brief Intersect 2 lines and return the intersection points.
+template <typename T = float>
+std::vector<glm::vec<2, T>> intersectLineLine(const Line<T>& lineA, const Line<T>& lineB) {
+	const glm::vec<2, T> v0 = lineA.p0 - lineA.p1;
+	const glm::vec<2, T> v1 = lineB.p0 - lineB.p1;
+	const glm::vec<2, T> v2 = lineA.p0 - lineB.p0;
+
+	const T det = v0.x * v1.y - v0.y * v1.x;
+	if (ds::approxZero(det)) { // Lines are parallel or coincident.
+		const T distance = glm::dot(lineA.normal(), v2);
+		if (ds::approxZero(distance)) return {lineA.p0, lineA.p1, lineB.p0, lineB.p1}; // Lines are coincident.
+		return {};																	   // Lines are parallel.
+	}
+
+	const T t = (v2.x * v1.y - v2.y * v1.x) / det;
+	if (t < 0 || t > 1) return {};
+
+	const T u = (v2.x * v0.y - v2.y * v0.x) / det;
+	if (u < 0 || u > 1) return {};
+
+	return {lineA.evaluate(t)};
+}
+
+/// \brief Intersect a line with a quadratic curve segment and return the intersection points.
+template <typename T = float>
+std::vector<glm::vec<2, T>> intersectLineQuad(const Line<T>& line, const QuadraticCurve<T>& quad) {
+	// Coefficients of the quadratic equation.
+	glm::vec<2, T> d  = line.p1 - line.p0;
+	glm::vec<2, T> va = quad.p0 - line.p0;
+	glm::vec<2, T> vb = (quad.p1 - quad.p0) * T{2};
+	glm::vec<2, T> vc = quad.p0 - quad.p1 * T{2} + quad.p2;
+
+	T a = va.x * d.y - va.y * d.x;
+	T b = vb.x * d.y - vb.y * d.x;
+	T c = vc.x * d.y - vc.y * d.x;
+
+	// Find roots.
+	auto roots = solveQuadratic(a, b, c);
+
+	// Find intersection points.
+	const bool isVertical = glm::abs(d.x) < glm::abs(d.y);
+
+	std::vector<glm::vec<2, T>> intersections;
+	for (T u : roots) {
+		if (u < 0 || u > 1) continue; // Ensure valid u
+		const glm::vec<2, T> point = quad.evaluate(u);
+
+		const T t = isVertical ? (point.y - line.p0.y) / d.y : (point.x - line.p0.x) / d.x; // Solve for t
+		if (t >= 0 && t <= 1) {
+			intersections.push_back(point);
+		}
+	}
+
+	return intersections;
+}
+
+/// \brief Intersect a line with a cubic curve segment and return the intersection points.
+template <typename T = float>
+std::vector<glm::vec<2, T>> intersectLineCubic(const Line<T>& line, const CubicCurve<T>& cubic) {
+	// Coefficients of the cubic equation.
+	glm::vec<2, T> n(line.p1.y - line.p0.y, line.p0.x - line.p1.x);
+
+	T a = glm::dot(n, cubic.p0 - line.p0);
+	T b = glm::dot(n, cubic.p1 * T{3} - cubic.p0 * T{3});
+	T c = glm::dot(n, cubic.p2 * T{3} - cubic.p1 * T{6} + cubic.p0 * T{3});
+	T d = glm::dot(n, cubic.p3 - cubic.p2 * T{3} + cubic.p1 * T{3} - cubic.p0);
+
+	// Find roots.
+	auto roots = solveCubic(a, b, c, d);
+
+	// Find intersection points.
+	const bool isVertical = glm::abs(line.p1.x - line.p0.x) < glm::abs(line.p1.y - line.p0.y);
+
+	std::vector<glm::vec<2, T>> intersections;
+	for (T u : roots) {
+		if (u < 0 || u > 1) continue; // Ensure valid u.
+		const glm::vec<2, T> point = cubic.evaluate(u);
+
+		// Solve for t.
+		const T t = isVertical ? (point.y - line.p0.y) / (line.p1.y - line.p0.y)
+							   : (point.x - line.p0.x) / (line.p1.x - line.p0.x);
+		if (t >= 0 && t <= 1) {
+			intersections.push_back(point);
+		}
+	}
+	return intersections;
+}
+
+///
+template <typename T = float>
+std::vector<glm::vec<2, T>> intersectLineArc(const Line<T>& line, const Arc<T>& arc) {
+	// Convert degrees to radians.
+	T theta = glm::radians(arc.xAxisRotation);
+
+	// Normalize to unit circle.
+	glm::vec<2, T> scale{arc.rx, arc.ry};
+	glm::vec<2, T> normOrigin	 = rotate(line.p0 - arc.center, -theta) / scale; // Offset from circle center.
+	glm::vec<2, T> normDirection = rotate(line.p1 - line.p0, -theta) / scale;	 // Direction of the line.
+
+	// Coefficients of the quadratic equation.
+	T a = glm::dot(normOrigin, normOrigin) - 1;
+	T b = T{2} * glm::dot(normOrigin, normDirection);
+	T c = glm::dot(normDirection, normDirection);
+
+	// Find roots.
+	auto roots = solveQuadratic(a, b, c);
+
+	// Find intersection points.
+	std::vector<glm::vec<2, T>> intersections;
+	for (T t : roots) {
+		if (t < 0 || t > 1) continue; // Ensure t is within the line segment.
+		glm::vec<2, T> point = normOrigin + normDirection * t;
+
+		// Check if the point is within the arc's angular range.
+		const T angle = std::atan2(point.y, point.x);
+		if (angleInRange(angle, arc.startAngle, arc.diffAngle)) {
+			intersections.push_back(arc.center + rotate(point * scale, theta));
+		}
+	}
+	return intersections;
+}
+
+///
+template <typename T = float>
+std::vector<glm::vec<2, T>> intersectArcArc(const Arc<T>& arcA, const Arc<T>& arcB) {
+	constexpr int n = 30;
+
+	// For now, approximate the arcs using line segments and intersect them.
+	glm::vec<2, T> a0, a1;
+	glm::vec<2, T> b0, b1;
+
+	std::vector<glm::vec<2, T>> intersections;
+	for (int i = 0; i < n; ++i) {
+		a0 = arcA.evaluate(T(i) / T{n});
+		a1 = arcA.evaluate(T(i + 1) / T{n});
+		for (int j = 0; j < n; ++j) {
+			b0 = arcB.evaluate(T(j) / T{n});
+			b1 = arcB.evaluate(T(j + 1) / T{n});
+
+			if (auto result = intersectLineLine(Line<T>{a0, a1}, Line<T>{b0, b1}); !result.empty()) {
+				intersections.insert(intersections.end(), result.begin(), result.end());
+			}
+		}
+	}
+	return intersections;
+}
+
+} // namespace nvpath::util


### PR DESCRIPTION
Hi,

due to the success of using path rendering in the Zoom EBC project, I have gone ahead and created a separate project (just like CEF and gstreamer) which makes it easy to add path rendering support to your application.

All code can be found in the `projects/nvpath` folder and it compiles to a static library that can be included in your projects by adding these lines to your `.vcxproj` file:

```
  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
    <Import Project="$(DS_PLATFORM_093)\vs2015\PropertySheets\Platform64.props" />
    <Import Project="$(DS_PLATFORM_093)\projects\nvpath\PropertySheets\NvPath64.props" />
  </ImportGroup>
  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
    <Import Project="$(DS_PLATFORM_093)\vs2015\PropertySheets\Platform64_d.props" />
    <Import Project="$(DS_PLATFORM_093)\projects\nvpath\PropertySheets\NvPath64_d.props" />
  </ImportGroup>
```

A full overview of all features would be too lengthy for this PR, but to give an example of how to use it, here is how you'd create a sprite that renders a red heart:
```
#include "nvpath/NvPath.h"

class Heart : public ds::ui::Sprite {
  public:
	Heart(ds::ui::SpriteEngine& engine)
		: Sprite(engine) {
		setTransparent(false);
		setSize(130, 130);
		enableMultiTouch(ds::ui::MULTITOUCH_CAN_SCALE | ds::ui::MULTITOUCH_CAN_ROTATE |
						 ds::ui::MULTITOUCH_CAN_POSITION);
		enable(true);

		// Path defined by SVG string taken from https://en.m.wikipedia.org/wiki/File:Heart_coraz%C3%B3n.svg
		mPath = nvpath::Path("M 65,29 C 59,19 49,12 37,12 20,12 7,25 7,42 7,75 25,80 65,118 105,80 123,75 123,42 "
							 "123,25 110,12 93,12 81,12 71,19 65,29 z");
	}

	void drawLocalClient() override {
		// Set OpenGL state to enable path rendering.
		nvpath::ScopedPathRendering sp;
		// Fill the path using a solid red.
		mPath.fill(Color(1, 0, 0));
	}

  private:
	nvpath::Path mPath;
};
```
![image](https://github.com/user-attachments/assets/394529c3-89af-418c-9799-65ff84e2769d)

Just make sure your OpenGL back buffer has a stencil buffer:
```
CINDER_APP( MyApp, ci::app::RendererGl( ci::app::RendererGl::Options().stencil() ) )
```

Paths can be defined using SVG commands like above, using a `ci::Path2d` or `ci::Shape2d` or by using `nvpath::PathHelper` to construct it. Finally, there are a few helper functions like `nvpath::circle` to more easily create basic shapes.

Paths can be filled with solid colors, linear gradients, radial gradients and textures. Paths can also be stroked with solid or dashed lines. You have full control over the line caps and joins. 

There is also (limited but still quite powerful) support for loading SVG files and displaying them as a group of paths. You can also use instanced rendering for maximum performance, supplying a list of transform matrices to render a single path multiple times. This way, you can easily draw hundreds or even thousands of copies at high frame rates. 

Paths itself are very light-weight (just an `int`) as they are stored on the GPU. 

That's it for now. Let me know what you think.