### PR TITLE
Added functions to ContentHelper and BaseContentHelper that were originally in Platform.

### DIFF
--- a/src/ds/content/base_content_helper.cpp
+++ b/src/ds/content/base_content_helper.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 
 #include "ds/content/base_content_helper.h"
-#include "ds/content/platform.h"
 
 namespace ds::model {
 
@@ -69,25 +68,34 @@ BaseContentHelper::BaseContentHelper(ui::SpriteEngine& eng)
 	}
 }
 
+std::string BaseContentHelper::getPlatformKey() const {
+	return mEngine.getAppSettings().getString("platform:key", 0, "");
+}
+
+std::string BaseContentHelper::getPlatformType(const std::string& platformKey) const {
+	return getPlatformModel(platformKey).getPropertyString("type");
+}
+
+const std::vector<ContentModelRef>& BaseContentHelper::getPlatformEvents(const std::string& platformKey) const {
+	return getPlatformModel(platformKey).getChildByName("current_events").getChildren();
+}
+
 std::string BaseContentHelper::getCompositeKeyForPlatform() {
 	// TODO: get key value pairs from waffles_app.xml
 	auto key = mEngine.getWafflesSettings().getString("composite:key", 0, "");
 	return key;
 }
 
-ContentModelRef BaseContentHelper::getRecordByUid(const std::string& uid) {
+ContentModelRef BaseContentHelper::getRecordByUid(const std::string& uid) const {
 	return mEngine.mContent.getKeyReference(VALID_MAP, uid);
 }
 
 Resource BaseContentHelper::getBackgroundForPlatform() {
-	Platform platformObj(mEngine);
-	auto	 platform = platformObj.getPlatformModel();
+	auto platform = getPlatformModel();
 	if (platform.empty()) return {};
 
-	// get all the events scheduled for this platform, already sorted in order of importance
-	const auto& allPlatformEvents = platform.getChildByName("current_events").getChildren();
-
 	// check if events have playlists
+	const auto& allPlatformEvents = getPlatformEvents();
 	if (!allPlatformEvents.empty()) {
 		for (const auto& event : allPlatformEvents) {
 			if (event.getPropertyString("type_key") == "some_event" && !event.getPropertyResource("content-browsing-background").empty()) {
@@ -147,16 +155,15 @@ std::string BaseContentHelper::getInitialPresentationUid() {
 }
 
 std::vector<ContentModelRef> BaseContentHelper::getContentForPlatform() {
-	Platform platformObj(mEngine);
-	auto	 allValid	= mEngine.mContent.getChildByName(CONTENT).getChildren();
-	auto	 allContent = std::vector<ContentModelRef>();
+	auto allValid	= mEngine.mContent.getChildByName(CONTENT).getChildren();
+	auto allContent = std::vector<ContentModelRef>();
 
 	for (const auto& value : allValid) {
 		allContent.push_back(value);
 	}
 
 
-	auto platformChildren = platformObj.getPlatformModel().getChildren();
+	auto platformChildren = getPlatformModel().getChildren();
 	for (const auto& value : platformChildren) {
 		allContent.push_back(value);
 	}
@@ -171,17 +178,14 @@ std::vector<ContentModelRef> BaseContentHelper::getFilteredPlaylists(const Playl
 	auto eventPropName	  = filter.eventPropertyName.empty() ? "playlist" : filter.eventPropertyName;
 	auto platformPropName = filter.platformPropertyName.empty() ? "default_playlist" : filter.platformPropertyName;
 
-	Platform platformObj(mEngine);
-	auto	 platform = platformObj.getPlatformModel();
+	auto platform = getPlatformModel();
 	if (platform.empty()) return {};
 
-	ContentModelRef thePlaylist;
-
-	// get all the events scheduled for this platform, already sorted in order of importance
-	const auto&					 allPlatformEvents = platform.getChildByName("current_events").getChildren();
+	ContentModelRef				 thePlaylist;
 	std::vector<ContentModelRef> thePlaylists;
 
 	// check if events have playlists
+	const auto& allPlatformEvents = getPlatformEvents();
 	if (!allPlatformEvents.empty()) {
 		for (const auto& event : allPlatformEvents) {
 			auto eventTypeKey = event.getPropertyString("type_key");
@@ -304,9 +308,7 @@ std::string BaseContentHelper::getMediaPropertyKey(ContentModelRef model, const 
 }
 
 std::vector<ContentModelRef> BaseContentHelper::getStreamSources(const std::string& category) {
-	Platform platform(mEngine);
-
-	auto						 platformModel = platform.getPlatformModel();
+	auto						 platformModel = getPlatformModel();
 	auto						 kids		   = platformModel.getChildren();
 	std::vector<ContentModelRef> sources;
 	for (const auto& submodel : kids) {

--- a/src/ds/content/base_content_helper.h
+++ b/src/ds/content/base_content_helper.h
@@ -8,9 +8,22 @@ class BaseContentHelper : public ContentHelper {
   public:
 	BaseContentHelper(ui::SpriteEngine& eng);
 
-	// Inherited via ContentHelper
+	//! Returns the platform key for the current platform.
+	std::string getPlatformKey() const override;
+	//! Returns the platform type for the current platform, which is a human-readable string defined in the CMS schema.
+	std::string getPlatformType() const override { return getPlatformType(getPlatformKey()); }
+	//! Returns the platform type for the specified \a platformKey, which is a human-readable string defined in the CMS
+	//! schema.
+	std::string getPlatformType(const std::string& platformKey) const override;
+	//! Returns all the events scheduled for the current platform, already sorted in order of importance.
+	const std::vector<ContentModelRef>& getPlatformEvents() const override {
+		return getPlatformEvents(getPlatformKey());
+	}
+	//! Returns all the events scheduled for this platform, already sorted in order of importance.
+	const std::vector<ContentModelRef>& getPlatformEvents(const std::string& platformKey) const override;
+
 	std::string					 getCompositeKeyForPlatform() override;
-	ContentModelRef				 getRecordByUid(const std::string& uid) override;
+	ContentModelRef				 getRecordByUid(const std::string& uid) const override;
 	Resource					 getBackgroundForPlatform() override;
 	ContentModelRef				 getPresentation() override;
 	ContentModelRef				 getAmbientPlaylist() override;

--- a/src/ds/content/content_helper.h
+++ b/src/ds/content/content_helper.h
@@ -31,18 +31,36 @@ class ContentHelper {
 	ContentHelper(ui::SpriteEngine& eng)
 	  : mEngine(eng) {}
 
-	virtual std::string		getCompositeKeyForPlatform()		   = 0;
-	virtual ContentModelRef getRecordByUid(const std::string& uid) = 0;
-	virtual Resource		getBackgroundForPlatform()			   = 0;
+	//! Returns the platform model for the current platform.
+	ContentModelRef getPlatformModel() const { return getRecordByUid(getPlatformKey()); }
+	//! Returns the platform model for the specified \a platformKey.
+	ContentModelRef getPlatformModel(const std::string& platformKey) const { return getRecordByUid(platformKey); }
+
+	//! Returns the platform key for the current platform.
+	virtual std::string getPlatformKey() const = 0;
+	//! Returns the platform type for the current platform, which is a human-readable string defined in the CMS schema.
+	virtual std::string getPlatformType() const = 0;
+	//! Returns the platform type for the specified \a platformKey, which is a human-readable string defined in the CMS
+	//! schema.
+	virtual std::string getPlatformType(const std::string& platformKey) const = 0;
+	//! Returns all the events scheduled for the current platform, already sorted in order of importance.
+	virtual const std::vector<ContentModelRef>& getPlatformEvents() const = 0;
+	//! Returns all the events scheduled for the specified \a platformKey, already sorted in order of importance.
+	virtual const std::vector<ContentModelRef>& getPlatformEvents(const std::string& platformKey) const = 0;
+
+	virtual std::string		getCompositeKeyForPlatform()				 = 0;
+	virtual ContentModelRef getRecordByUid(const std::string& uid) const = 0;
+	virtual Resource		getBackgroundForPlatform()					 = 0;
 
 	virtual ContentModelRef getPresentation()			= 0; // getInteractivePlaylist
 	virtual ContentModelRef getAmbientPlaylist()		= 0;
 	virtual std::string		getInitialPresentationUid() = 0;
 
-	virtual std::vector<ContentModelRef> getFilteredPlaylists(const PlaylistFilter& filter)				 = 0;
-	virtual std::vector<ContentModelRef> getContentForPlatform()										 = 0; // getAssets
-	virtual std::vector<ContentModelRef> getStreamSources(const std::string& category = DEFAULTCATEGORY) = 0;
-	virtual ContentModelRef				 getStreamSourceForStream(ContentModelRef stream, const std::string& category = DEFAULTCATEGORY) = 0;
+	virtual std::vector<ContentModelRef> getFilteredPlaylists(const PlaylistFilter& filter) = 0;
+	virtual std::vector<ContentModelRef> getContentForPlatform()							= 0; // getAssets
+	virtual std::vector<ContentModelRef> getStreamSources(const std::string& category = DEFAULTCATEGORY)		 = 0;
+	virtual ContentModelRef				 getStreamSourceForStream(ContentModelRef	 stream,
+																  const std::string& category = DEFAULTCATEGORY) = 0;
 
 	virtual std::vector<Resource> findMediaResources() = 0;
 
@@ -52,16 +70,18 @@ class ContentHelper {
 	virtual bool isValidStream(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)	   = 0;
 	virtual bool isValidPlaylist(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)	   = 0;
 
-	virtual std::string getMediaPropertyKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)		= 0;
-	virtual std::string getStreamMatchKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)			= 0;
-	virtual std::string getStreamSourceAddressKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY) = 0;
-	virtual std::string getStreamSourceTypeKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)	= 0;
-	
+	virtual std::string getMediaPropertyKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY) = 0;
+	virtual std::string getStreamMatchKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)	  = 0;
+	virtual std::string getStreamSourceAddressKey(ContentModelRef	 model,
+												  const std::string& category = DEFAULTCATEGORY)				  = 0;
+	virtual std::string getStreamSourceTypeKey(ContentModelRef	  model,
+											   const std::string& category = DEFAULTCATEGORY)					  = 0;
+
 	virtual std::vector<ContentModelRef> getRecordsOfType(const std::vector<ContentModelRef>& records,
 														  const std::string&				  type);
 
 	virtual std::vector<ContentProperty> findAllProperties(const std::vector<ContentModelRef>& records,
-	                                                      const std::string&				   propertyName);
+														   const std::string&				   propertyName);
 
   protected:
 	static void getRecordsByUid(const std::vector<ContentModelRef>& records, const std::string& uid,
@@ -69,7 +89,7 @@ class ContentHelper {
 	static void getRecordsByType(const std::vector<ContentModelRef>& records, const std::string& type,
 								 std::vector<ContentModelRef>& result);
 	static void getPropertyByName(const std::vector<ContentModelRef>& records, const std::string& propertyName,
-								 std::vector<ContentProperty>& result);
+								  std::vector<ContentProperty>& result);
 
 	ui::SpriteEngine& mEngine;
 };


### PR DESCRIPTION
The platform class encapsulates platform specific data from the content database. By design, this content is initialized on construction, but after that needs to be manually refreshed (either by calling `refreshContent` or by listening to content update events). If used as a member variable, Platform is not reliable in any way, unless the user remembers to refresh it. This leads to the question: why use it at all? Instead, it may be better to use the ContentHelper class and its derivatives to access the content directly when querying for platform specific data. That way you can at least be sure you're always using the most recent data.