### PR TITLE
Content helper refactor

### DIFF
--- a/projects/waffles/src/waffles/util/base_waffles_helper.cpp
+++ b/projects/waffles/src/waffles/util/base_waffles_helper.cpp
@@ -15,46 +15,12 @@
 namespace waffles {
 
 BaseWafflesHelper::BaseWafflesHelper(ds::ui::SpriteEngine& eng)
-  : WafflesHelper(eng)
-  , mBaseContentHelper(eng) {
-	BaseWafflesHelper::loadIntegration();
-
-	auto foldersCount = mEngine.getAppSettings().countSetting("content:folder:key");
-
-	for (int i = 0; i < foldersCount; ++i) {
-		auto folder	  = mEngine.getAppSettings().getString("content:folder:key", i, "");
-		auto category = mEngine.getAppSettings().getAttribute("content:folder:key", 0, "category", DEFAULTCATEGORY);
-		mAcceptableFolders[category].push_back(folder);
-		if (mAcceptableFolders[DEFAULTCATEGORY].empty()) mAcceptableFolders[DEFAULTCATEGORY].push_back(folder);
-	}
-
-	auto mediaCount = mEngine.getAppSettings().countSetting("content:media:key");
-	for (int i = 0; i < mediaCount; ++i) {
-		auto media					 = mEngine.getAppSettings().getString("content:media:key", i);
-		auto mediaProp				 = mEngine.getAppSettings().getAttribute("content:media:key", i, "property_key", "");
-		auto category				 = mEngine.getAppSettings().getAttribute("content:media:key", i, "category", DEFAULTCATEGORY);
-		mMediaProps[category][media] = mediaProp;
-		if (mMediaProps[DEFAULTCATEGORY][media].empty()) mMediaProps[DEFAULTCATEGORY][media] = mediaProp;
-		mAcceptableMedia[category].push_back(media);
-		if (mAcceptableMedia[DEFAULTCATEGORY].empty()) mAcceptableMedia[DEFAULTCATEGORY].push_back(media);
-	}
-
-	auto playlistCount = mEngine.getAppSettings().countSetting("content:playlist:key");
-	for (int i = 0; i < playlistCount; ++i) {
-		auto playlist = mEngine.getAppSettings().getString("content:playlist:key", i, "");
-		auto category = mEngine.getAppSettings().getAttribute("content:playlist:key", i, "category", DEFAULTCATEGORY);
-		mAcceptablePlaylists[category].push_back(playlist);
-		if (mAcceptablePlaylists[DEFAULTCATEGORY].empty()) mAcceptablePlaylists[DEFAULTCATEGORY].push_back(playlist);
-	}
+  : WafflesHelper(eng) {
 }
 
 
-BaseWafflesHelper::~BaseWafflesHelper() = default;
-
-
 bool BaseWafflesHelper::getApplyParticles() {
-	Platform platformObj(mEngine);
-	auto	 platform = platformObj.getPlatformModel();
+	auto platform = getPlatformModel();
 	if (platform.empty()) return ContentModelRef();
 
 	// get all the events scheduled for this platform, already sorted in order of importance
@@ -92,8 +58,7 @@ ContentModelRef BaseWafflesHelper::getPinboard() {
 
 
 std::vector<ContentModelRef> BaseWafflesHelper::getValidPinboards() {
-	Platform platformObj(mEngine);
-	auto	 platform = platformObj.getPlatformModel();
+	auto platform = getPlatformModel();
 	if (platform.empty()) return {};
 
 	std::vector<ContentModelRef> pinboards;
@@ -116,7 +81,10 @@ std::vector<ContentModelRef> BaseWafflesHelper::getValidPinboards() {
 ContentModelRef BaseWafflesHelper::getAnnotationFolder() {
 	ContentModelRef result;
 
-	int count = 0;
+	if (mAnnotationFolderKeys.empty()) {
+		loadIntegration();
+	}
+	
 	for (const auto& record : mEngine.mContent.getChildByName(ALL_RECORDS).getChildren()) {
 		auto type  = record.getPropertyString("type_key");
 		auto valid = std::find(mAnnotationFolderKeys.begin(), mAnnotationFolderKeys.end(), type) != mAnnotationFolderKeys.end();
@@ -131,7 +99,7 @@ ContentModelRef BaseWafflesHelper::getAnnotationFolder() {
 }
 
 void BaseWafflesHelper::setKeyboardStyle(ds::ui::SoftKeyboard* keeb) {
-	// Note, this only somewhat works. If the keyboard is initalized with the wrong key size this will resize the keys
+	// Note, this only somewhat works. If the keyboard is initialized with the wrong key size this will resize the keys
 	// but not correctly re-size the keyboard. Leading to either overlaps or huge gaps
 	// More refinement needed
 	auto& setty = keeb->getSoftKeyboardSettings();
@@ -374,47 +342,23 @@ void BaseWafflesHelper::setMediaInterfaceStyle(ds::ui::MediaInterface* interface
 }
 
 // contentHelper functions
-std::string BaseWafflesHelper::getCompositeKeyForPlatform() {
-	return mBaseContentHelper.getCompositeKeyForPlatform();
-}
-
-ContentModelRef BaseWafflesHelper::getRecordByUid(const std::string& uid) {
-	return mBaseContentHelper.getRecordByUid(uid);
-}
 ds::Resource BaseWafflesHelper::getBackgroundForPlatform() {
-	// return mBaseContentHelper.getBackgroundForPlatform();
-
 	return {ds::Environment::expand("%APP%/data/images/waffles/default_background.jpg")};
 }
+
 int BaseWafflesHelper::getBackgroundPdfPage() {
 	return 0;
 }
 
-ContentModelRef BaseWafflesHelper::getPresentation() {
-	return mBaseContentHelper.getPresentation();
-}
-
-ContentModelRef BaseWafflesHelper::getAmbientPlaylist() {
-	return mBaseContentHelper.getAmbientPlaylist();
-}
-std::string BaseWafflesHelper::getInitialPresentationUid() {
-	return mBaseContentHelper.getInitialPresentationUid();
-}
-std::vector<ContentModelRef> BaseWafflesHelper::getFilteredPlaylists(const PlaylistFilter& filter) {
-	return mBaseContentHelper.getFilteredPlaylists(filter);
-}
 std::vector<ContentModelRef> BaseWafflesHelper::getContentForPlatform() {
-	Platform platformObj(mEngine);
-	auto	 platformCurrent = platformObj.getCurrentContent();
-	auto	 platform		 = platformObj.getPlatformModel();
-	// if (platformCurrent.empty()) return std::vector<ds::model::ContentModelRef>();
-
-	// get all the events scheduled for this platform
-	auto allPlatformEvents = platformCurrent.getChildByName("current_events").getChildren();
-
 	std::vector<ContentModelRef> theList;
 
+	if (mEventFieldKey.empty() || mPlatformFieldKey.empty()) {
+		loadIntegration();
+	}
+
 	// check if events have playlists
+	auto allPlatformEvents = mEngine.mContent.getChildByName("current_content.current_events").getChildren();
 	if (!allPlatformEvents.empty()) {
 		for (const auto& event : allPlatformEvents) {
 
@@ -433,7 +377,7 @@ std::vector<ContentModelRef> BaseWafflesHelper::getContentForPlatform() {
 		// DS_LOG_VERBOSE(1, "No scheduled ambient for platform" << myPlatform.getPropertyString("name"))
 	}
 
-
+	auto platform			= getPlatformModel();
 	auto defaultContentUids = ci::split(platform.getPropertyString(mPlatformFieldKey), ",");
 	for (auto& uid : defaultContentUids) {
 		auto content = getRecordByUid(uid);
@@ -443,16 +387,13 @@ std::vector<ContentModelRef> BaseWafflesHelper::getContentForPlatform() {
 	}
 
 	if (theList.empty() && mUseRoot) {
-		return mBaseContentHelper.getContentForPlatform();
+		return BaseContentHelper::getContentForPlatform();
 	}
 
 	return theList;
 }
-std::vector<ds::Resource> BaseWafflesHelper::findMediaResources() {
-	return mBaseContentHelper.findMediaResources();
-}
-void BaseWafflesHelper::loadIntegration() {
 
+void BaseWafflesHelper::loadIntegration() const {
 	mEventFieldKey	  = mEngine.getWafflesSettings().getString("waffles:content:event_field", 0, "additional_content");
 	mPlatformFieldKey = mEngine.getWafflesSettings().getString("waffles:content:platform_field", 0, "default_content");
 	mUseRoot		  = mEngine.getWafflesSettings().getBool("waffles:use_root_as_fallback", 0, false);
@@ -465,50 +406,6 @@ void BaseWafflesHelper::loadIntegration() {
 	}
 	// annotation_folder is always valid?
 	mAnnotationFolderKeys.emplace_back("annotation_folder");
-}
-
-std::vector<ContentModelRef> BaseWafflesHelper::getStreamSources(const std::string& category) {
-	return mBaseContentHelper.getStreamSources(category);
-}
-
-ContentModelRef BaseWafflesHelper::getStreamSourceForStream(ContentModelRef stream, const std::string& category) {
-	return mBaseContentHelper.getStreamSourceForStream(stream, category);
-}
-
-bool BaseWafflesHelper::isValidStreamSource(ContentModelRef model, const std::string& category) {
-	return mBaseContentHelper.isValidStreamSource(model, category);
-}
-
-bool BaseWafflesHelper::isValidStream(ContentModelRef model, const std::string& category) {
-	return mBaseContentHelper.isValidStream(model, category);
-}
-
-std::string BaseWafflesHelper::getStreamMatchKey(ContentModelRef model, const std::string& category) {
-	return mBaseContentHelper.getStreamMatchKey(model, category);
-}
-
-std::string BaseWafflesHelper::getStreamSourceAddressKey(ContentModelRef model, const std::string& category) {
-	return mBaseContentHelper.getStreamSourceAddressKey(model, category);
-}
-
-std::string BaseWafflesHelper::getStreamSourceTypeKey(ContentModelRef model, const std::string& category) {
-	return mBaseContentHelper.getStreamSourceTypeKey(model, category);
-}
-
-bool BaseWafflesHelper::isValidFolder(ContentModelRef model, const std::string& category) {
-	return mBaseContentHelper.isValidFolder(model, category);
-}
-
-bool BaseWafflesHelper::isValidMedia(ContentModelRef model, const std::string& category) {
-	return mBaseContentHelper.isValidMedia(model, category);
-}
-
-bool BaseWafflesHelper::isValidPlaylist(ContentModelRef model, const std::string& category) {
-	return mBaseContentHelper.isValidPlaylist(model, category);
-}
-
-std::string BaseWafflesHelper::getMediaPropertyKey(ContentModelRef model, const std::string& category) {
-	return mBaseContentHelper.getMediaPropertyKey(model, category);
 }
 
 void BaseWafflesHelper::setLauncherCustomFilters(CustomFilters cf) {

--- a/projects/waffles/src/waffles/util/base_waffles_helper.h
+++ b/projects/waffles/src/waffles/util/base_waffles_helper.h
@@ -1,7 +1,8 @@
 #pragma once
-#include <ds/content/base_content_helper.h>
+
 #include <ds/ui/media/media_interface.h>
 #include <waffles/util/waffles_helper.h>
+
 namespace waffles {
 
 using namespace ds::model;
@@ -9,10 +10,9 @@ using namespace ds::model;
 class BaseWafflesHelper : public WafflesHelper {
   public:
 	BaseWafflesHelper(ds::ui::SpriteEngine& eng);
-	~BaseWafflesHelper() override;
 
 	BaseWafflesHelper(const BaseWafflesHelper&)			   = delete;
-	BaseWafflesHelper(BaseWafflesHelper&&)				   = default;
+	BaseWafflesHelper(BaseWafflesHelper&&)				   = delete;
 	BaseWafflesHelper& operator=(const BaseWafflesHelper&) = delete;
 	BaseWafflesHelper& operator=(BaseWafflesHelper&&)	   = delete;
 
@@ -24,60 +24,25 @@ class BaseWafflesHelper : public WafflesHelper {
 	ContentModelRef				 getAnnotationFolder() override;
 	void						 setKeyboardStyle(ds::ui::SoftKeyboard* keeb) override;
 	void						 setMediaInterfaceStyle(ds::ui::MediaInterface* interfacey) override;
-
-
-	// Inherited via WafflesHelper these are from WaffleHelper's base class ContentHelper
-	std::string					 getCompositeKeyForPlatform() override;
-	ContentModelRef				 getRecordByUid(const std::string& uid) override;
 	ds::Resource				 getBackgroundForPlatform() override;
 	int							 getBackgroundPdfPage() override;
-	ContentModelRef				 getPresentation() override;
-	ContentModelRef				 getAmbientPlaylist() override;
-	std::string					 getInitialPresentationUid() override;
-	std::vector<ContentModelRef> getFilteredPlaylists(const PlaylistFilter& filter) override;
 	std::vector<ContentModelRef> getContentForPlatform() override;
-	std::vector<ds::Resource>	 findMediaResources() override;
 
-	bool				 isValidFolder(ContentModelRef model, const std::string& category = DEFAULTCATEGORY) override;
-	bool				 isValidMedia(ContentModelRef model, const std::string& category = DEFAULTCATEGORY) override;
-	bool				 isValidPlaylist(ContentModelRef model, const std::string& category = DEFAULTCATEGORY) override;
-	std::string			 getMediaPropertyKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY) override;
 	bool				 isValidForFilter(const std::string& filter, ContentModelRef model) override;
 	void				 setLauncherCustomFilters(CustomFilters cf) override;
 	const CustomFilters& getLauncherCustomFilters() override;
 	void				 setLauncherCustomContent(CustomContent cc) override;
 	const CustomContent& getLauncherCustomContent() override;
 
-	std::vector<ContentModelRef> getStreamSources(const std::string& category) override;
-	ContentModelRef				 getStreamSourceForStream(ContentModelRef stream, const std::string& category) override;
-	bool						 isValidStreamSource(ContentModelRef model, const std::string& category) override;
-	bool						 isValidStream(ContentModelRef model, const std::string& category) override;
-	std::string					 getStreamMatchKey(ContentModelRef model, const std::string& category) override;
-	std::string					 getStreamSourceAddressKey(ContentModelRef model, const std::string& category) override;
-	std::string					 getStreamSourceTypeKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY) override;
-
   protected:
-	std::unordered_map<std::string, std::vector<std::string>> mAcceptableFolders;
-	std::unordered_map<std::string, std::vector<std::string>> mAcceptableMedia;
-	// std::unordered_map<std::string, std::vector<std::string>> mAcceptablePresentations;
-	std::unordered_map<std::string, std::vector<std::string>>					  mAcceptablePlaylists;
-	std::unordered_map<std::string, std::vector<std::string>>					  mAcceptableStreamSources;
-	std::unordered_map<std::string, std::vector<std::string>>					  mAcceptableStreams;
-	std::unordered_map<std::string, std::unordered_map<std::string, std::string>> mStreamSourceAddressProps;
-	std::unordered_map<std::string, std::unordered_map<std::string, std::string>> mStreamSourceTypeProps;
-	std::unordered_map<std::string, std::unordered_map<std::string, std::string>> mStreamMatchProp;
-	std::unordered_map<std::string, std::unordered_map<std::string, std::string>> mMediaProps;
-
-  protected:
-	void loadIntegration();
+	void loadIntegration() const;
 
   private:
-	BaseContentHelper		 mBaseContentHelper;
-	std::string				 mEventFieldKey;
-	std::string				 mPlatformFieldKey;
-	std::vector<std::string> mAnnotationFolderKeys;
-	bool					 mUseRoot{};
-	CustomFilters			 mLauncherCustomFilters;
-	CustomContent			 mLauncherCustomContent;
+	mutable std::string				 mEventFieldKey;
+	mutable std::string				 mPlatformFieldKey;
+	mutable std::vector<std::string> mAnnotationFolderKeys;
+	mutable bool					 mUseRoot{false};
+	CustomFilters					 mLauncherCustomFilters;
+	CustomContent					 mLauncherCustomContent;
 };
 } // namespace waffles

--- a/projects/waffles/src/waffles/util/waffles_helper.h
+++ b/projects/waffles/src/waffles/util/waffles_helper.h
@@ -31,7 +31,6 @@ class WafflesHelper : public ds::model::BaseContentHelper {
 	virtual ds::model::ContentModelRef				getPinboard()											   = 0;
 	virtual ds::model::ContentModelRef				getAnnotationFolder()									   = 0;
 	virtual std::vector<ds::model::ContentModelRef> getValidPinboards()										   = 0;
-	virtual std::vector<ds::Resource>				findMediaResources()									   = 0;
 	virtual int										getBackgroundPdfPage()									   = 0;
 	virtual void									setKeyboardStyle(ds::ui::SoftKeyboard* keeb)			   = 0;
 	virtual void									setMediaInterfaceStyle(ds::ui::MediaInterface* interfacey) = 0;

--- a/projects/waffles/src/waffles/waffles_sprite.cpp
+++ b/projects/waffles/src/waffles/waffles_sprite.cpp
@@ -651,9 +651,8 @@ void WafflesSprite::setupTouchMenu() {
 
 //template <class VC>
 void WafflesSprite::setDefaultPresentation() {
-	auto				helper = ds::model::ContentHelperFactory::getDefault<WafflesHelper>();
-	ds::model::Platform platformObj(mEngine);
-	if (platformObj.getPlatformType() == ds::model::Platform::UNDEFINED) return;
+	auto helper = ds::model::ContentHelperFactory::getDefault<WafflesHelper>();
+	if (helper->getPlatformType() == ds::model::Platform::UNDEFINED) return;
 	auto thePlaylist = helper->getPresentation();
 	if (!thePlaylist.empty() && !thePlaylist.getChildren().empty()) {
 		mPlaylist	  = thePlaylist;

--- a/src/ds/content/base_content_helper.cpp
+++ b/src/ds/content/base_content_helper.cpp
@@ -5,68 +5,7 @@
 namespace ds::model {
 
 BaseContentHelper::BaseContentHelper(ui::SpriteEngine& eng)
-  : ContentHelper(eng) {
-	auto foldersCount = mEngine.getWafflesSettings().countSetting("content:folder:key");
-
-	for (int i = 0; i < foldersCount; ++i) {
-		auto folder	  = mEngine.getWafflesSettings().getString("content:folder:key", i, "");
-		auto category = mEngine.getWafflesSettings().getAttribute("content:folder:key", 0, "category", DEFAULTCATEGORY);
-		mAcceptableFolders[category].push_back(folder);
-		if (mAcceptableFolders[DEFAULTCATEGORY].empty()) mAcceptableFolders[DEFAULTCATEGORY].push_back(folder);
-	}
-
-	auto mediaCount = mEngine.getWafflesSettings().countSetting("content:media:key");
-	for (int i = 0; i < mediaCount; ++i) {
-		auto media					 = mEngine.getWafflesSettings().getString("content:media:key", i);
-		auto mediaProp				 = mEngine.getWafflesSettings().getAttribute("content:media:key", i, "property_key", "");
-		auto category				 = mEngine.getWafflesSettings().getAttribute("content:media:key", i, "category", DEFAULTCATEGORY);
-		mMediaProps[category][media] = mediaProp;
-		if (mMediaProps[DEFAULTCATEGORY][media].empty()) mMediaProps[DEFAULTCATEGORY][media] = mediaProp;
-		mAcceptableMedia[category].push_back(media);
-		if (mAcceptableMedia[DEFAULTCATEGORY].empty()) mAcceptableMedia[DEFAULTCATEGORY].push_back(media);
-	}
-
-	auto playlistCount = mEngine.getWafflesSettings().countSetting("content:playlist:key");
-	for (int i = 0; i < playlistCount; ++i) {
-		auto playlist = mEngine.getWafflesSettings().getString("content:playlist:key", i, "");
-		auto category = mEngine.getWafflesSettings().getAttribute("content:playlist:key", i, "category", DEFAULTCATEGORY);
-		if (!playlist.empty()) {
-			mAcceptablePlaylists[category].push_back(playlist);
-			if (mAcceptablePlaylists[DEFAULTCATEGORY].empty()) mAcceptablePlaylists[DEFAULTCATEGORY].push_back(playlist);
-		}
-	}
-
-	auto streamCount = mEngine.getWafflesSettings().countSetting("content:stream:key");
-	for (int i = 0; i < streamCount; ++i) {
-		auto stream			 = mEngine.getWafflesSettings().getString("content:stream:key", i, "");
-		auto streamMatchProp = mEngine.getWafflesSettings().getAttribute("content:stream:key", i, "match_key", "");
-
-		auto category					   = mEngine.getWafflesSettings().getAttribute("content:stream:key", i, "category", DEFAULTCATEGORY);
-		mStreamMatchProp[category][stream] = streamMatchProp;
-		if (mStreamMatchProp[DEFAULTCATEGORY][stream].empty()) mStreamMatchProp[DEFAULTCATEGORY][stream] = streamMatchProp;
-		mAcceptableStreams[category].push_back(stream);
-		if (mAcceptableStreams[DEFAULTCATEGORY].empty()) mAcceptableStreams[DEFAULTCATEGORY].push_back(stream);
-	}
-
-	auto streamSourceCount = mEngine.getWafflesSettings().countSetting("content:stream_source:key");
-	for (int i = 0; i < streamSourceCount; ++i) {
-		auto streamSource			 = mEngine.getWafflesSettings().getString("content:stream_source:key", i, "");
-		auto streamSourceAddressProp = mEngine.getWafflesSettings().getAttribute("content:stream_source:key", i, "address_key", "");
-		auto streamSourceTypeProp	 = mEngine.getWafflesSettings().getAttribute("content:stream_source:key", i, "streamtype_key", "");
-		auto streamMatchProp		 = mEngine.getWafflesSettings().getAttribute("content:stream_source:key", i, "match_key", "");
-		auto category				 = mEngine.getWafflesSettings().getAttribute("content:stream_source:key", i, "category", DEFAULTCATEGORY);
-		mStreamSourceAddressProps[category][streamSource] = streamSourceAddressProp;
-		if (mStreamSourceAddressProps[DEFAULTCATEGORY][streamSource].empty())
-			mStreamSourceAddressProps[DEFAULTCATEGORY][streamSource] = streamSourceAddressProp;
-		mStreamSourceTypeProps[category][streamSource] = streamSourceTypeProp;
-		if (mStreamSourceTypeProps[DEFAULTCATEGORY][streamSource].empty())
-			mStreamSourceTypeProps[DEFAULTCATEGORY][streamSource] = streamSourceTypeProp;
-		mStreamMatchProp[category][streamSource] = streamMatchProp;
-		if (mStreamMatchProp[DEFAULTCATEGORY][streamSource].empty()) mStreamMatchProp[DEFAULTCATEGORY][streamSource] = streamMatchProp;
-		mAcceptableStreamSources[category].push_back(streamSource);
-		if (mAcceptableStreamSources[DEFAULTCATEGORY].empty()) mAcceptableStreamSources[DEFAULTCATEGORY].push_back(streamSource);
-	}
-}
+  : ContentHelper(eng) {}
 
 std::string BaseContentHelper::getPlatformKey() const {
 	return mEngine.getAppSettings().getString("platform:key", 0, "");
@@ -88,6 +27,10 @@ std::string BaseContentHelper::getCompositeKeyForPlatform() {
 
 ContentModelRef BaseContentHelper::getRecordByUid(const std::string& uid) const {
 	return mEngine.mContent.getKeyReference(VALID_MAP, uid);
+}
+
+ContentModelRef BaseContentHelper::getCurrentContent() const {
+	return mEngine.mContent.getChildByName(CURRENT_CONTENT);
 }
 
 Resource BaseContentHelper::getBackgroundForPlatform() {
@@ -245,7 +188,7 @@ bool BaseContentHelper::isValidFolder(ContentModelRef model, const std::string& 
 	for (auto& cat : categories) {
 		// trim whitespace from cat using std::find_not_last_of and std::find_not_first_of functions
 		auto cleanCat = trim(cat);
-		auto folders  = mAcceptableFolders[cleanCat];
+		auto folders  = getAcceptableFolders(cleanCat);
 
 		if (std::find(folders.begin(), folders.end(), key) != folders.end()) {
 			return true;
@@ -265,11 +208,12 @@ bool BaseContentHelper::isValidMedia(ContentModelRef model, const std::string& c
 	for (auto& cat : categories) {
 		// trim whitespace from cat using std::find_not_last_of and std::find_not_first_of functions
 		auto cleanCat = trim(cat);
+		auto media	  = getAcceptableMedia(cleanCat);
 
-		if (std::find(mAcceptableMedia[cleanCat].begin(), mAcceptableMedia[cleanCat].end(), key) != mAcceptableMedia[cleanCat].end()) {
+		if (std::find(media.begin(), media.end(), key) != media.end()) {
 			return true;
 		}
-		if (std::find(mAcceptableMedia[cleanCat].begin(), mAcceptableMedia[cleanCat].end(), type) != mAcceptableMedia[cleanCat].end()) {
+		if (std::find(media.begin(), media.end(), type) != media.end()) {
 			return true;
 		}
 	}
@@ -284,7 +228,7 @@ bool BaseContentHelper::isValidPlaylist(ContentModelRef model, const std::string
 	for (auto& cat : categories) {
 		// trim whitespace from cat using std::find_not_last_of and std::find_not_first_of functions
 		auto cleanCat  = trim(cat);
-		auto playlists = mAcceptablePlaylists[cleanCat];
+		auto playlists = getAcceptablePlaylists(cleanCat);
 
 		if (std::find(playlists.begin(), playlists.end(), key) != playlists.end()) {
 			return true;
@@ -298,12 +242,12 @@ bool BaseContentHelper::isValidPlaylist(ContentModelRef model, const std::string
 }
 
 std::string BaseContentHelper::getMediaPropertyKey(ContentModelRef model, const std::string& category) {
-	auto& props				 = mMediaProps[category.empty() ? DEFAULTCATEGORY : category];
-	auto  theType			 = model.getPropertyString("type_key");
-	auto  theTypeUid		 = model.getPropertyString("type_uid");
-	auto  media_property_key = props[theTypeUid];
-	media_property_key		 = media_property_key.empty() ? props[theType] : media_property_key;
-	media_property_key		 = media_property_key.empty() ? "media" : media_property_key;
+	auto props		= getMediaProps(category.empty() ? DEFAULTCATEGORY : category); // copy due to the use of operator[]
+	auto theType	= model.getPropertyString("type_key");
+	auto theTypeUid = model.getPropertyString("type_uid");
+	auto media_property_key = props[theTypeUid]; // here
+	media_property_key		= media_property_key.empty() ? props[theType] : media_property_key;
+	media_property_key		= media_property_key.empty() ? "media" : media_property_key;
 	return media_property_key;
 }
 
@@ -311,9 +255,9 @@ std::vector<ContentModelRef> BaseContentHelper::getStreamSources(const std::stri
 	auto						 platformModel = getPlatformModel();
 	auto						 kids		   = platformModel.getChildren();
 	std::vector<ContentModelRef> sources;
-	for (const auto& submodel : kids) {
-		if (isValidStreamSource(submodel, category)) {
-			sources.push_back(submodel);
+	for (const auto& model : kids) {
+		if (isValidStreamSource(model, category)) {
+			sources.push_back(model);
 		}
 	}
 	return sources;
@@ -342,7 +286,7 @@ bool BaseContentHelper::isValidStreamSource(ContentModelRef model, const std::st
 	for (auto& cat : categories) {
 		// trim whitespace from cat using std::find_not_last_of and std::find_not_first_of functions
 		auto cleanCat = trim(cat);
-		auto sources  = mAcceptableStreamSources[cleanCat];
+		auto sources  = getAcceptableStreamSources(cleanCat);
 		if (std::find(sources.begin(), sources.end(), key) != sources.end()) {
 			return true;
 		}
@@ -360,7 +304,7 @@ bool BaseContentHelper::isValidStream(ContentModelRef model, const std::string& 
 	for (auto& cat : categories) {
 		// trim whitespace from cat using std::find_not_last_of and std::find_not_first_of functions
 		auto cleanCat = trim(cat);
-		auto streams  = mAcceptableStreams[cleanCat];
+		auto streams  = getAcceptableStreams(cleanCat);
 		if (std::find(streams.begin(), streams.end(), key) != streams.end()) {
 			return true;
 		}
@@ -377,12 +321,13 @@ std::string BaseContentHelper::getStreamMatchKey(ContentModelRef model, const st
 	auto key		= model.getPropertyString("type_key");
 	for (auto& cat : categories) {
 		// trim whitespace from cat using std::find_not_last_of and std::find_not_first_of functions
-		auto cleanCat = trim(cat);
-		auto matchKey = mStreamMatchProp[cleanCat][key];
+		auto cleanCat	 = trim(cat);
+		auto streamProps = getStreamMatchProp(cleanCat);
+		auto matchKey	 = streamProps[key];
 		if (!matchKey.empty()) {
 			return matchKey;
 		}
-		matchKey = mStreamMatchProp[cleanCat][type];
+		matchKey = streamProps[type];
 		if (!matchKey.empty()) {
 			return matchKey;
 		}
@@ -396,12 +341,13 @@ std::string BaseContentHelper::getStreamSourceAddressKey(ContentModelRef model, 
 	auto key		= model.getPropertyString("type_key");
 	for (auto& cat : categories) {
 		// trim whitespace from cat using std::find_not_last_of and std::find_not_first_of functions
-		auto cleanCat  = trim(cat);
-		auto streamKey = mStreamSourceAddressProps[cleanCat][key];
+		auto cleanCat	 = trim(cat);
+		auto streamProps = getStreamSourceAddressProps(cleanCat);
+		auto streamKey	 = streamProps[key];
 		if (!streamKey.empty()) {
 			return streamKey;
 		}
-		streamKey = mStreamSourceAddressProps[cleanCat][type];
+		streamKey = streamProps[type];
 		if (!streamKey.empty()) {
 			return streamKey;
 		}
@@ -417,16 +363,160 @@ std::string BaseContentHelper::getStreamSourceTypeKey(ContentModelRef model, con
 	for (auto& cat : categories) {
 		// trim whitespace from cat using std::find_not_last_of and std::find_not_first_of functions
 		auto cleanCat	   = trim(cat);
-		auto streamTypeKey = mStreamSourceTypeProps[cleanCat][key];
+		auto streamProps   = getStreamSourceTypeProps(cleanCat);
+		auto streamTypeKey = streamProps[key];
 		if (!streamTypeKey.empty()) {
 			return streamTypeKey;
 		}
-		streamTypeKey = mStreamSourceTypeProps[cleanCat][type];
+		streamTypeKey = streamProps[type];
 		if (!streamTypeKey.empty()) {
 			return streamTypeKey;
 		}
 	}
 	return {};
+}
+
+const std::vector<std::string>& BaseContentHelper::getAcceptableFolders(const std::string& category) const {
+	if (mAcceptableFolders.empty()) {
+		auto foldersCount = mEngine.getWafflesSettings().countSetting("content:folder:key");
+
+		for (int i = 0; i < foldersCount; ++i) {
+			auto folder = mEngine.getWafflesSettings().getString("content:folder:key", i, "");
+			auto cat = mEngine.getWafflesSettings().getAttribute("content:folder:key", 0, "category", DEFAULTCATEGORY);
+			mAcceptableFolders[cat].push_back(folder);
+			if (mAcceptableFolders[DEFAULTCATEGORY].empty()) mAcceptableFolders[DEFAULTCATEGORY].push_back(folder);
+		}
+	}
+
+	return mAcceptableFolders[category];
+}
+
+const std::vector<std::string>& BaseContentHelper::getAcceptableMedia(const std::string& category) const {
+	if (mAcceptableMedia.empty()) {
+		initializeAcceptableMedia();
+	}
+
+	return mAcceptableMedia[category];
+}
+
+const std::vector<std::string>& BaseContentHelper::getAcceptablePlaylists(const std::string& category) const {
+	if (mAcceptablePlaylists.empty()) {
+		auto playlistCount = mEngine.getWafflesSettings().countSetting("content:playlist:key");
+		for (int i = 0; i < playlistCount; ++i) {
+			auto playlist = mEngine.getWafflesSettings().getString("content:playlist:key", i, "");
+			auto category =
+				mEngine.getWafflesSettings().getAttribute("content:playlist:key", i, "category", DEFAULTCATEGORY);
+			if (!playlist.empty()) {
+				mAcceptablePlaylists[category].push_back(playlist);
+				if (mAcceptablePlaylists[DEFAULTCATEGORY].empty())
+					mAcceptablePlaylists[DEFAULTCATEGORY].push_back(playlist);
+			}
+		}
+	}
+
+	return mAcceptablePlaylists[category];
+}
+
+const std::vector<std::string>& BaseContentHelper::getAcceptableStreamSources(const std::string& category) const {
+	if (mAcceptableStreamSources.empty()) {
+		initializeStreamSources();
+	}
+	return mAcceptableStreamSources[category];
+}
+
+const std::vector<std::string>& BaseContentHelper::getAcceptableStreams(const std::string& category) const {
+	if (mAcceptableStreams.empty()) {
+		initializeStreamSources();
+	}
+
+	return mAcceptableStreams[category];
+}
+
+const std::unordered_map<std::string, std::string>&
+BaseContentHelper::getStreamSourceAddressProps(const std::string& category) const {
+	if (mStreamSourceAddressProps.empty()) {
+		initializeStreamSources();
+	}
+	return mStreamSourceAddressProps[category];
+}
+
+const std::unordered_map<std::string, std::string>&
+BaseContentHelper::getStreamSourceTypeProps(const std::string& category) const {
+	if (mStreamSourceTypeProps.empty()) {
+		initializeStreamSources();
+	}
+	return mStreamSourceTypeProps[category];
+}
+
+const std::unordered_map<std::string, std::string>&
+BaseContentHelper::getStreamMatchProp(const std::string& category) const {
+	if (mStreamMatchProp.empty()) {
+		initializeStreamSources();
+	}
+
+	return mStreamMatchProp[category];
+}
+
+const std::unordered_map<std::string, std::string>&
+BaseContentHelper::getMediaProps(const std::string& category) const {
+	if (mMediaProps.empty()) {
+		initializeAcceptableMedia();
+	}
+
+	return mMediaProps[category];
+}
+
+void BaseContentHelper::initializeAcceptableMedia() const {
+	auto mediaCount = mEngine.getWafflesSettings().countSetting("content:media:key");
+	for (int i = 0; i < mediaCount; ++i) {
+		auto media	   = mEngine.getWafflesSettings().getString("content:media:key", i);
+		auto mediaProp = mEngine.getWafflesSettings().getAttribute("content:media:key", i, "property_key", "");
+		auto category  = mEngine.getWafflesSettings().getAttribute("content:media:key", i, "category", DEFAULTCATEGORY);
+		mMediaProps[category][media] = mediaProp;
+		if (mMediaProps[DEFAULTCATEGORY][media].empty()) mMediaProps[DEFAULTCATEGORY][media] = mediaProp;
+		mAcceptableMedia[category].push_back(media);
+		if (mAcceptableMedia[DEFAULTCATEGORY].empty()) mAcceptableMedia[DEFAULTCATEGORY].push_back(media);
+	}
+}
+
+void BaseContentHelper::initializeStreamSources() const {
+	auto streamCount = mEngine.getWafflesSettings().countSetting("content:stream:key");
+	for (int i = 0; i < streamCount; ++i) {
+		auto stream			 = mEngine.getWafflesSettings().getString("content:stream:key", i, "");
+		auto streamMatchProp = mEngine.getWafflesSettings().getAttribute("content:stream:key", i, "match_key", "");
+
+		auto category = mEngine.getWafflesSettings().getAttribute("content:stream:key", i, "category", DEFAULTCATEGORY);
+		mStreamMatchProp[category][stream] = streamMatchProp;
+		if (mStreamMatchProp[DEFAULTCATEGORY][stream].empty())
+			mStreamMatchProp[DEFAULTCATEGORY][stream] = streamMatchProp;
+		mAcceptableStreams[category].push_back(stream);
+		if (mAcceptableStreams[DEFAULTCATEGORY].empty()) mAcceptableStreams[DEFAULTCATEGORY].push_back(stream);
+	}
+
+	auto streamSourceCount = mEngine.getWafflesSettings().countSetting("content:stream_source:key");
+	for (int i = 0; i < streamSourceCount; ++i) {
+		auto streamSource = mEngine.getWafflesSettings().getString("content:stream_source:key", i, "");
+		auto streamSourceAddressProp =
+			mEngine.getWafflesSettings().getAttribute("content:stream_source:key", i, "address_key", "");
+		auto streamSourceTypeProp =
+			mEngine.getWafflesSettings().getAttribute("content:stream_source:key", i, "streamtype_key", "");
+		auto streamMatchProp =
+			mEngine.getWafflesSettings().getAttribute("content:stream_source:key", i, "match_key", "");
+		auto category =
+			mEngine.getWafflesSettings().getAttribute("content:stream_source:key", i, "category", DEFAULTCATEGORY);
+		mStreamSourceAddressProps[category][streamSource] = streamSourceAddressProp;
+		if (mStreamSourceAddressProps[DEFAULTCATEGORY][streamSource].empty())
+			mStreamSourceAddressProps[DEFAULTCATEGORY][streamSource] = streamSourceAddressProp;
+		mStreamSourceTypeProps[category][streamSource] = streamSourceTypeProp;
+		if (mStreamSourceTypeProps[DEFAULTCATEGORY][streamSource].empty())
+			mStreamSourceTypeProps[DEFAULTCATEGORY][streamSource] = streamSourceTypeProp;
+		mStreamMatchProp[category][streamSource] = streamMatchProp;
+		if (mStreamMatchProp[DEFAULTCATEGORY][streamSource].empty())
+			mStreamMatchProp[DEFAULTCATEGORY][streamSource] = streamMatchProp;
+		mAcceptableStreamSources[category].push_back(streamSource);
+		if (mAcceptableStreamSources[DEFAULTCATEGORY].empty())
+			mAcceptableStreamSources[DEFAULTCATEGORY].push_back(streamSource);
+	}
 }
 
 } // namespace ds::model

--- a/src/ds/content/base_content_helper.cpp
+++ b/src/ds/content/base_content_helper.cpp
@@ -1,7 +1,6 @@
 #include "stdafx.h"
 
 #include "ds/content/base_content_helper.h"
-#include "ds/content/platform.h"
 
 namespace ds::model {
 
@@ -69,6 +68,18 @@ BaseContentHelper::BaseContentHelper(ui::SpriteEngine& eng)
 	}
 }
 
+std::string BaseContentHelper::getPlatformKey() const {
+	return mEngine.getAppSettings().getString("platform:key", 0, "");
+}
+
+std::string BaseContentHelper::getPlatformType(const std::string& platformKey) const {
+	return getPlatformModel(platformKey).getPropertyString("type");
+}
+
+const std::vector<ContentModelRef>& BaseContentHelper::getPlatformEvents(const std::string& platformKey) const {
+	return getPlatformModel(platformKey).getChildByName("current_events").getChildren();
+}
+
 std::string BaseContentHelper::getCompositeKeyForPlatform() {
 	// TODO: get key value pairs from waffles_app.xml
 	auto key = mEngine.getWafflesSettings().getString("composite:key", 0, "");
@@ -80,14 +91,11 @@ ContentModelRef BaseContentHelper::getRecordByUid(const std::string& uid) const 
 }
 
 Resource BaseContentHelper::getBackgroundForPlatform() {
-	Platform platformObj(mEngine);
-	auto	 platform = platformObj.getPlatformModel();
+	auto platform = getPlatformModel();
 	if (platform.empty()) return {};
 
-	// get all the events scheduled for this platform, already sorted in order of importance
-	const auto& allPlatformEvents = platform.getChildByName("current_events").getChildren();
-
 	// check if events have playlists
+	const auto& allPlatformEvents = getPlatformEvents();
 	if (!allPlatformEvents.empty()) {
 		for (const auto& event : allPlatformEvents) {
 			if (event.getPropertyString("type_key") == "some_event" && !event.getPropertyResource("content-browsing-background").empty()) {
@@ -147,16 +155,15 @@ std::string BaseContentHelper::getInitialPresentationUid() {
 }
 
 std::vector<ContentModelRef> BaseContentHelper::getContentForPlatform() {
-	Platform platformObj(mEngine);
-	auto	 allValid	= mEngine.mContent.getChildByName(CONTENT).getChildren();
-	auto	 allContent = std::vector<ContentModelRef>();
+	auto allValid	= mEngine.mContent.getChildByName(CONTENT).getChildren();
+	auto allContent = std::vector<ContentModelRef>();
 
 	for (const auto& value : allValid) {
 		allContent.push_back(value);
 	}
 
 
-	auto platformChildren = platformObj.getPlatformModel().getChildren();
+	auto platformChildren = getPlatformModel().getChildren();
 	for (const auto& value : platformChildren) {
 		allContent.push_back(value);
 	}
@@ -171,17 +178,14 @@ std::vector<ContentModelRef> BaseContentHelper::getFilteredPlaylists(const Playl
 	auto eventPropName	  = filter.eventPropertyName.empty() ? "playlist" : filter.eventPropertyName;
 	auto platformPropName = filter.platformPropertyName.empty() ? "default_playlist" : filter.platformPropertyName;
 
-	Platform platformObj(mEngine);
-	auto	 platform = platformObj.getPlatformModel();
+	auto platform = getPlatformModel();
 	if (platform.empty()) return {};
 
-	ContentModelRef thePlaylist;
-
-	// get all the events scheduled for this platform, already sorted in order of importance
-	const auto&					 allPlatformEvents = platform.getChildByName("current_events").getChildren();
+	ContentModelRef				 thePlaylist;
 	std::vector<ContentModelRef> thePlaylists;
 
 	// check if events have playlists
+	const auto& allPlatformEvents = getPlatformEvents();
 	if (!allPlatformEvents.empty()) {
 		for (const auto& event : allPlatformEvents) {
 			auto eventTypeKey = event.getPropertyString("type_key");
@@ -304,9 +308,7 @@ std::string BaseContentHelper::getMediaPropertyKey(ContentModelRef model, const 
 }
 
 std::vector<ContentModelRef> BaseContentHelper::getStreamSources(const std::string& category) {
-	Platform platform(mEngine);
-
-	auto						 platformModel = platform.getPlatformModel();
+	auto						 platformModel = getPlatformModel();
 	auto						 kids		   = platformModel.getChildren();
 	std::vector<ContentModelRef> sources;
 	for (const auto& submodel : kids) {

--- a/src/ds/content/base_content_helper.h
+++ b/src/ds/content/base_content_helper.h
@@ -8,7 +8,7 @@ class BaseContentHelper : public ContentHelper {
   public:
 	BaseContentHelper(ui::SpriteEngine& eng);
 
-	//! Returns the platform key for the current platform.
+	//! Returns the platform key defined in the application settings.
 	std::string getPlatformKey() const override;
 	//! Returns the platform type for the current platform, which is a human-readable string defined in the CMS schema.
 	std::string getPlatformType() const override { return getPlatformType(getPlatformKey()); }
@@ -21,13 +21,21 @@ class BaseContentHelper : public ContentHelper {
 	}
 	//! Returns all the events scheduled for this platform, already sorted in order of importance.
 	const std::vector<ContentModelRef>& getPlatformEvents(const std::string& platformKey) const override;
+	//! Returns the composite key defined in the waffles settings.
+	std::string getCompositeKeyForPlatform() override;
+	//! Returns the content model for the specified \a uid, or an empty model if not found.
+	ContentModelRef getRecordByUid(const std::string& uid) const override;
+	//! Returns the content model for the "current_content" stored in the engine, if applicable.
+	ContentModelRef getCurrentContent() const override;
+	//! Returns the default background resource, or an empty resource if not defined.
+	Resource getBackgroundForPlatform() override;
+	//! Returns the default presentation playlist found in the content, or an empty model if not found.
+	ContentModelRef getPresentation() override;
+	//! Returns the first ambient playlist found in the content, or an empty model if not found.
+	ContentModelRef getAmbientPlaylist() override;
+	//! Returns the uid of the default presentation playlist found in the content, or an empty string if not found.
+	std::string getInitialPresentationUid() override;
 
-	std::string					 getCompositeKeyForPlatform() override;
-	ContentModelRef				 getRecordByUid(const std::string& uid) const override;
-	Resource					 getBackgroundForPlatform() override;
-	ContentModelRef				 getPresentation() override;
-	ContentModelRef				 getAmbientPlaylist() override;
-	std::string					 getInitialPresentationUid() override;
 	std::vector<ContentModelRef> getContentForPlatform() override;
 	std::vector<Resource>		 findMediaResources() override;
 	std::vector<ContentModelRef> getFilteredPlaylists(const PlaylistFilter& filter) override;
@@ -49,16 +57,31 @@ class BaseContentHelper : public ContentHelper {
 	std::string getStreamSourceTypeKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY) override;
 
   protected:
-	std::unordered_map<std::string, std::vector<std::string>> mAcceptableFolders;
-	std::unordered_map<std::string, std::vector<std::string>> mAcceptableMedia;
-	// std::unordered_map<std::string, std::vector<std::string>> mAcceptablePresentations;
-	std::unordered_map<std::string, std::vector<std::string>>					  mAcceptablePlaylists;
-	std::unordered_map<std::string, std::vector<std::string>>					  mAcceptableStreamSources;
-	std::unordered_map<std::string, std::vector<std::string>>					  mAcceptableStreams;
-	std::unordered_map<std::string, std::unordered_map<std::string, std::string>> mStreamSourceAddressProps;
-	std::unordered_map<std::string, std::unordered_map<std::string, std::string>> mStreamSourceTypeProps;
-	std::unordered_map<std::string, std::unordered_map<std::string, std::string>> mStreamMatchProp;
-	std::unordered_map<std::string, std::unordered_map<std::string, std::string>> mMediaProps;
+	const std::vector<std::string>&						getAcceptableFolders(const std::string& category) const;
+	const std::vector<std::string>&						getAcceptableMedia(const std::string& category) const;
+	const std::vector<std::string>&						getAcceptablePlaylists(const std::string& category) const;
+	const std::vector<std::string>&						getAcceptableStreamSources(const std::string& category) const;
+	const std::vector<std::string>&						getAcceptableStreams(const std::string& category) const;
+	const std::unordered_map<std::string, std::string>& getStreamSourceAddressProps(const std::string& category) const;
+	const std::unordered_map<std::string, std::string>& getStreamSourceTypeProps(const std::string& category) const;
+	const std::unordered_map<std::string, std::string>& getStreamMatchProp(const std::string& category) const;
+	const std::unordered_map<std::string, std::string>& getMediaProps(const std::string& category) const;
+
+	//! Use lazy initialization to load the acceptable folders, media, playlists, and stream sources.
+	void initializeAcceptableMedia() const;
+	//! Use lazy initialization to load the acceptable folders, media, playlists, and stream sources.
+	void initializeStreamSources() const;
+
+  private:
+	mutable std::unordered_map<std::string, std::vector<std::string>>					  mAcceptableFolders;
+	mutable std::unordered_map<std::string, std::vector<std::string>>					  mAcceptableMedia;
+	mutable std::unordered_map<std::string, std::vector<std::string>>					  mAcceptablePlaylists;
+	mutable std::unordered_map<std::string, std::vector<std::string>>					  mAcceptableStreamSources;
+	mutable std::unordered_map<std::string, std::vector<std::string>>					  mAcceptableStreams;
+	mutable std::unordered_map<std::string, std::unordered_map<std::string, std::string>> mStreamSourceAddressProps;
+	mutable std::unordered_map<std::string, std::unordered_map<std::string, std::string>> mStreamSourceTypeProps;
+	mutable std::unordered_map<std::string, std::unordered_map<std::string, std::string>> mStreamMatchProp;
+	mutable std::unordered_map<std::string, std::unordered_map<std::string, std::string>> mMediaProps;
 };
 
 } // namespace ds::model

--- a/src/ds/content/base_content_helper.h
+++ b/src/ds/content/base_content_helper.h
@@ -8,7 +8,20 @@ class BaseContentHelper : public ContentHelper {
   public:
 	BaseContentHelper(ui::SpriteEngine& eng);
 
-	// Inherited via ContentHelper
+	//! Returns the platform key for the current platform.
+	std::string getPlatformKey() const override;
+	//! Returns the platform type for the current platform, which is a human-readable string defined in the CMS schema.
+	std::string getPlatformType() const override { return getPlatformType(getPlatformKey()); }
+	//! Returns the platform type for the specified \a platformKey, which is a human-readable string defined in the CMS
+	//! schema.
+	std::string getPlatformType(const std::string& platformKey) const override;
+	//! Returns all the events scheduled for the current platform, already sorted in order of importance.
+	const std::vector<ContentModelRef>& getPlatformEvents() const override {
+		return getPlatformEvents(getPlatformKey());
+	}
+	//! Returns all the events scheduled for this platform, already sorted in order of importance.
+	const std::vector<ContentModelRef>& getPlatformEvents(const std::string& platformKey) const override;
+
 	std::string					 getCompositeKeyForPlatform() override;
 	ContentModelRef				 getRecordByUid(const std::string& uid) const override;
 	Resource					 getBackgroundForPlatform() override;

--- a/src/ds/content/content_helper.h
+++ b/src/ds/content/content_helper.h
@@ -4,6 +4,7 @@
 
 namespace ds::model {
 
+//! Abstract base class for content helpers. Provides implementation for some common methods.
 class ContentHelper {
   public:
 	virtual ~ContentHelper() = default;
@@ -32,11 +33,13 @@ class ContentHelper {
 	  : mEngine(eng) {}
 
 	//! Returns the platform model for the current platform.
-	ContentModelRef getPlatformModel() const { return getRecordByUid(getPlatformKey()); }
+	virtual ContentModelRef getPlatformModel() const { return getRecordByUid(getPlatformKey()); }
 	//! Returns the platform model for the specified \a platformKey.
-	ContentModelRef getPlatformModel(const std::string& platformKey) const { return getRecordByUid(platformKey); }
+	virtual ContentModelRef getPlatformModel(const std::string& platformKey) const {
+		return getRecordByUid(platformKey);
+	}
 
-	//! Returns the platform key for the current platform.
+	//! Returns the platform key defined in the application settings.
 	virtual std::string getPlatformKey() const = 0;
 	//! Returns the platform type for the current platform, which is a human-readable string defined in the CMS schema.
 	virtual std::string getPlatformType() const = 0;
@@ -47,18 +50,24 @@ class ContentHelper {
 	virtual const std::vector<ContentModelRef>& getPlatformEvents() const = 0;
 	//! Returns all the events scheduled for the specified \a platformKey, already sorted in order of importance.
 	virtual const std::vector<ContentModelRef>& getPlatformEvents(const std::string& platformKey) const = 0;
-
-	virtual std::string		getCompositeKeyForPlatform()		   = 0;
+	//! Returns the composite key defined in the waffles settings.
+	virtual std::string getCompositeKeyForPlatform() = 0;
+	//! Returns the content model for the specified \a uid, or an empty model if not found.
 	virtual ContentModelRef getRecordByUid(const std::string& uid) const = 0;
-	virtual Resource		getBackgroundForPlatform()			   = 0;
-
-	virtual ContentModelRef getPresentation()			= 0; // getInteractivePlaylist
+	//! Returns the content model for the "current_content" stored in the engine, if applicable.
+	virtual ContentModelRef getCurrentContent() const = 0;
+	//! Returns the default background resource, or an empty resource if not defined.
+	virtual Resource getBackgroundForPlatform() = 0;
+	//! Returns the default presentation playlist found in the content, or an empty model if not found.
+	virtual ContentModelRef getPresentation()			= 0;
+	//! Returns the first ambient playlist found in the content, or an empty model if not found.
 	virtual ContentModelRef getAmbientPlaylist()		= 0;
+	//! Returns the uid of the default presentation playlist found in the content, or an empty string if not found.
 	virtual std::string		getInitialPresentationUid() = 0;
 
-	virtual std::vector<ContentModelRef> getFilteredPlaylists(const PlaylistFilter& filter)				 = 0;
-	virtual std::vector<ContentModelRef> getContentForPlatform()										 = 0; // getAssets
-	virtual std::vector<ContentModelRef> getStreamSources(const std::string& category = DEFAULTCATEGORY) = 0;
+	virtual std::vector<ContentModelRef> getFilteredPlaylists(const PlaylistFilter& filter) = 0;
+	virtual std::vector<ContentModelRef> getContentForPlatform()							= 0; // getAssets
+	virtual std::vector<ContentModelRef> getStreamSources(const std::string& category = DEFAULTCATEGORY)		 = 0;
 	virtual ContentModelRef				 getStreamSourceForStream(ContentModelRef	 stream,
 																  const std::string& category = DEFAULTCATEGORY) = 0;
 
@@ -70,18 +79,18 @@ class ContentHelper {
 	virtual bool isValidStream(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)	   = 0;
 	virtual bool isValidPlaylist(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)	   = 0;
 
-	virtual std::string getMediaPropertyKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)		= 0;
-	virtual std::string getStreamMatchKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)			= 0;
+	virtual std::string getMediaPropertyKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY) = 0;
+	virtual std::string getStreamMatchKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)	  = 0;
 	virtual std::string getStreamSourceAddressKey(ContentModelRef	 model,
 												  const std::string& category = DEFAULTCATEGORY)				  = 0;
 	virtual std::string getStreamSourceTypeKey(ContentModelRef	  model,
 											   const std::string& category = DEFAULTCATEGORY)					  = 0;
-	
+
 	virtual std::vector<ContentModelRef> getRecordsOfType(const std::vector<ContentModelRef>& records,
 														  const std::string&				  type);
 
 	virtual std::vector<ContentProperty> findAllProperties(const std::vector<ContentModelRef>& records,
-	                                                      const std::string&				   propertyName);
+														   const std::string&				   propertyName);
 
   protected:
 	static void getRecordsByUid(const std::vector<ContentModelRef>& records, const std::string& uid,
@@ -89,7 +98,7 @@ class ContentHelper {
 	static void getRecordsByType(const std::vector<ContentModelRef>& records, const std::string& type,
 								 std::vector<ContentModelRef>& result);
 	static void getPropertyByName(const std::vector<ContentModelRef>& records, const std::string& propertyName,
-								 std::vector<ContentProperty>& result);
+								  std::vector<ContentProperty>& result);
 
 	ui::SpriteEngine& mEngine;
 };

--- a/src/ds/content/content_helper.h
+++ b/src/ds/content/content_helper.h
@@ -31,6 +31,23 @@ class ContentHelper {
 	ContentHelper(ui::SpriteEngine& eng)
 	  : mEngine(eng) {}
 
+	//! Returns the platform model for the current platform.
+	ContentModelRef getPlatformModel() const { return getRecordByUid(getPlatformKey()); }
+	//! Returns the platform model for the specified \a platformKey.
+	ContentModelRef getPlatformModel(const std::string& platformKey) const { return getRecordByUid(platformKey); }
+
+	//! Returns the platform key for the current platform.
+	virtual std::string getPlatformKey() const = 0;
+	//! Returns the platform type for the current platform, which is a human-readable string defined in the CMS schema.
+	virtual std::string getPlatformType() const = 0;
+	//! Returns the platform type for the specified \a platformKey, which is a human-readable string defined in the CMS
+	//! schema.
+	virtual std::string getPlatformType(const std::string& platformKey) const = 0;
+	//! Returns all the events scheduled for the current platform, already sorted in order of importance.
+	virtual const std::vector<ContentModelRef>& getPlatformEvents() const = 0;
+	//! Returns all the events scheduled for the specified \a platformKey, already sorted in order of importance.
+	virtual const std::vector<ContentModelRef>& getPlatformEvents(const std::string& platformKey) const = 0;
+
 	virtual std::string		getCompositeKeyForPlatform()		   = 0;
 	virtual ContentModelRef getRecordByUid(const std::string& uid) const = 0;
 	virtual Resource		getBackgroundForPlatform()			   = 0;
@@ -42,7 +59,8 @@ class ContentHelper {
 	virtual std::vector<ContentModelRef> getFilteredPlaylists(const PlaylistFilter& filter)				 = 0;
 	virtual std::vector<ContentModelRef> getContentForPlatform()										 = 0; // getAssets
 	virtual std::vector<ContentModelRef> getStreamSources(const std::string& category = DEFAULTCATEGORY) = 0;
-	virtual ContentModelRef				 getStreamSourceForStream(ContentModelRef stream, const std::string& category = DEFAULTCATEGORY) = 0;
+	virtual ContentModelRef				 getStreamSourceForStream(ContentModelRef	 stream,
+																  const std::string& category = DEFAULTCATEGORY) = 0;
 
 	virtual std::vector<Resource> findMediaResources() = 0;
 
@@ -54,8 +72,10 @@ class ContentHelper {
 
 	virtual std::string getMediaPropertyKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)		= 0;
 	virtual std::string getStreamMatchKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)			= 0;
-	virtual std::string getStreamSourceAddressKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY) = 0;
-	virtual std::string getStreamSourceTypeKey(ContentModelRef model, const std::string& category = DEFAULTCATEGORY)	= 0;
+	virtual std::string getStreamSourceAddressKey(ContentModelRef	 model,
+												  const std::string& category = DEFAULTCATEGORY)				  = 0;
+	virtual std::string getStreamSourceTypeKey(ContentModelRef	  model,
+											   const std::string& category = DEFAULTCATEGORY)					  = 0;
 	
 	virtual std::vector<ContentModelRef> getRecordsOfType(const std::vector<ContentModelRef>& records,
 														  const std::string&				  type);

--- a/src/ds/content/content_model.h
+++ b/src/ds/content/content_model.h
@@ -18,13 +18,14 @@ class SpriteEngine;
 
 namespace ds::model {
 
-const std::string VALID_MAP	  = "valid_map";
-const std::string RECORD_MAP  = "record_map";
-const std::string CONTENT	  = "content";
-const std::string PLATFORM	  = "platform";
-const std::string ALL_EVENTS  = "all_events";
-const std::string ALL_RECORDS = "all_records";
-const std::string ALL_TAGS	  = "all_tags";
+const std::string VALID_MAP		  = "valid_map";
+const std::string RECORD_MAP	  = "record_map";
+const std::string CONTENT		  = "content";
+const std::string PLATFORM		  = "platform";
+const std::string ALL_EVENTS	  = "all_events";
+const std::string ALL_RECORDS	  = "all_records";
+const std::string ALL_TAGS		  = "all_tags";
+const std::string CURRENT_CONTENT = "current_content";
 
 /**
  * \class ContentProperty

--- a/src/ds/content/platform.cpp
+++ b/src/ds/content/platform.cpp
@@ -18,17 +18,22 @@ ContentModelRef Platform::getRecordByUid(const ContentModelRef& model, const std
 	return {};
 }
 
+#pragma warning(push)
+#pragma warning(disable : 4996) // Disable deprecation warning for this specific usage
+
 ContentModelRef Platform::getRecordByUid(const ui::SpriteEngine& engine, const std::string& uid) {
 	return getRecordByUid(engine.mContent.getChildByName("all_records"), uid);
 }
+
+#pragma warning(pop)
 
 Platform::Platform(ui::SpriteEngine& engine, const std::string& platformKey)
   : mEngine(engine)
   , mEventClient(engine) {
 
-	mCurrentContent = mEngine.mContent.getChildByName("current_content");
+	mCurrentContent = mEngine.mContent.getChildByName(CURRENT_CONTENT);
 	if (mCurrentContent.empty()) {
-		mCurrentContent.setName("current_content");
+		mCurrentContent.setName(CURRENT_CONTENT);
 		mEngine.mContent.replaceChild(mCurrentContent);
 	}
 

--- a/src/ds/content/platform.h
+++ b/src/ds/content/platform.h
@@ -11,9 +11,11 @@ using PlatformType = std::string;
 
 class Platform {
   public:
+	[[deprecated("Use of the Platform class is discouraged. Please use ContentHelper class or the ContentHelperFactory instead.")]]
 	Platform(ui::SpriteEngine& engine, const std::string& platformKey = "");
 	virtual ~Platform() = default;
 
+	Platform() = delete;
 	Platform(const Platform&)			 = delete;
 	Platform& operator=(const Platform&) = delete;
 	Platform(Platform&&)				 = delete;
@@ -22,19 +24,23 @@ class Platform {
 	// types
 	static const PlatformType UNDEFINED;
 
-
 	// Static methods for retrieving records.
-	// These should be deprecated. *DO NOT USE*
-	[[deprecated]] static ContentModelRef getRecordByUid(const ContentModelRef& model, const std::string& uid);
-	[[deprecated]] static ContentModelRef getRecordByUid(const ui::SpriteEngine& engine, const std::string& uid);
-	/**--**/
+	[[deprecated("Use of the Platform class is discouraged. Please use ContentHelper::getRecordByUid() instead.")]]
+	static ContentModelRef getRecordByUid(const ContentModelRef& model, const std::string& uid);
+	[[deprecated("Use of the Platform class is discouraged. Please use ContentHelper::getRecordByUid() instead.")]]
+	static ContentModelRef getRecordByUid(const ui::SpriteEngine& engine, const std::string& uid);
+
+	bool					   isInitialized() const { return mInitialized; }
+	[[deprecated("Use of the Platform class is discouraged. Please use ContentHelper::getPlatformKey() instead.")]]
+	virtual const std::string& getPlatformKey() const;
+	[[deprecated("Use of the Platform class is discouraged. Please use ContentHelper::getPlatformModel() instead.")]]
+	virtual ContentModelRef	   getPlatformModel();
+	[[deprecated("Use of the Platform class is discouraged. Please use ContentHelper::getPlatformType() instead.")]]
+	virtual PlatformType	   getPlatformType() const;
+	[[deprecated("Use of the Platform class is discouraged. Please use ContentHelper::getCurrentContent() instead.")]]
+	virtual ContentModelRef	   getCurrentContent() const;
 
 	virtual void			   refreshContent();
-	bool					   isInitialized() const { return mInitialized; }
-	virtual const std::string& getPlatformKey() const;
-	virtual ContentModelRef	   getPlatformModel();
-	virtual PlatformType	   getPlatformType() const;
-	virtual ContentModelRef	   getCurrentContent() const;
 	virtual void			   setupContentListener();
 
 

--- a/src/ds/content/service/bridge_service.cpp
+++ b/src/ds/content/service/bridge_service.cpp
@@ -96,6 +96,7 @@ void BridgeService::refreshEvents(bool force) {
 BridgeService::Loop::Loop(ds::ui::SpriteEngine& engine)
   : mApp(ci::app::App::get())
   , mEngine(engine)
+  , mContentHelper(engine)
   , mAbort(false)
   , mForce(false)
   , mRefreshDatabase(true) // Force refresh on start.
@@ -891,11 +892,9 @@ bool BridgeService::Loop::updatePlatformEvents() const {
 	Poco::DateTime		thisDayTime;
 	thisDayTime.makeLocal(ldt.tzd());
 
-	bool updated  = false;
-	
-	auto contentHelper = model::ContentHelperFactory::getDefault<ds::model::BaseContentHelper>();
-	auto platform	   = contentHelper->getPlatformModel();
+	bool updated = false;
 
+	auto platform		 = mContentHelper.getPlatformModel();
 	auto scheduledEvents = platform.getChildByName("scheduled_events");
 	auto platformEvents	 = scheduledEvents.getChildren();
 
@@ -1017,8 +1016,8 @@ bool BridgeService::Loop::updatePlatformEvents() const {
 		});
 
 		// For interoperability, store current events.
-		auto platformCurrentContent = contentHelper->getCurrentContent();
-		auto platformCurrentEvents = platformCurrentContent.getChildByName("current_events");
+		auto platformCurrentContent = mContentHelper.getCurrentContent();
+		auto platformCurrentEvents	= platformCurrentContent.getChildByName("current_events");
 
 		if (platformCurrentEvents.empty() || platformCurrentEvents.getChildren() != currentEvents) {
 			platformCurrentEvents.setName("current_events");
@@ -1027,7 +1026,7 @@ bool BridgeService::Loop::updatePlatformEvents() const {
 			updated = true;
 		}
 	} else {
-		auto currentContent = contentHelper->getCurrentContent();
+		auto currentContent = mContentHelper.getCurrentContent();
 
 		// Probably don't want to get rid of ALL the children...
 		if (!currentContent.getChildren().empty()) {

--- a/src/ds/content/service/bridge_service.cpp
+++ b/src/ds/content/service/bridge_service.cpp
@@ -6,6 +6,7 @@
 #include <Poco/DateTimeFormatter.h>
 #include <Poco/DateTimeParser.h>
 
+#include <ds/content/base_content_helper.h>
 #include <ds/content/content_events.h>
 #include <ds/debug/logger.h>
 #include <ds/query/query_client.h>
@@ -794,8 +795,8 @@ bool BridgeService::Loop::loadContent() {
 					record.setProperty(field_uid, it.getString(7));
 				} else if (type == "TAGS") {
 					auto tags = record.getPropertyString(field_uid);
-					
-					//add as a comma seperated value.
+
+					// add as a comma seperated value.
 					if (tags.empty()) {
 						tags = it.getString(52);
 					} else {
@@ -890,9 +891,10 @@ bool BridgeService::Loop::updatePlatformEvents() const {
 	Poco::DateTime		thisDayTime;
 	thisDayTime.makeLocal(ldt.tzd());
 
-	bool				updated = false;
-	ds::model::Platform platformObj(mEngine);
-	auto				platform = platformObj.getPlatformModel();
+	bool updated  = false;
+	
+	auto contentHelper = model::ContentHelperFactory::getDefault<ds::model::BaseContentHelper>();
+	auto platform	   = contentHelper->getPlatformModel();
 
 	auto scheduledEvents = platform.getChildByName("scheduled_events");
 	auto platformEvents	 = scheduledEvents.getChildren();
@@ -1015,16 +1017,17 @@ bool BridgeService::Loop::updatePlatformEvents() const {
 		});
 
 		// For interoperability, store current events.
-		auto platformCurrentEvents = platformObj.getCurrentContent().getChildByName("current_events");
+		auto platformCurrentContent = contentHelper->getCurrentContent();
+		auto platformCurrentEvents = platformCurrentContent.getChildByName("current_events");
 
 		if (platformCurrentEvents.empty() || platformCurrentEvents.getChildren() != currentEvents) {
 			platformCurrentEvents.setName("current_events");
 			platformCurrentEvents.setChildren(currentEvents);
-			platformObj.getCurrentContent().replaceChild(platformCurrentEvents);
+			platformCurrentContent.replaceChild(platformCurrentEvents);
 			updated = true;
 		}
 	} else {
-		ds::model::ContentModelRef currentContent = platformObj.getCurrentContent();
+		auto currentContent = contentHelper->getCurrentContent();
 
 		// Probably don't want to get rid of ALL the children...
 		if (!currentContent.getChildren().empty()) {

--- a/src/ds/content/service/bridge_service.h
+++ b/src/ds/content/service/bridge_service.h
@@ -5,6 +5,7 @@
 #include <Poco/DateTime.h>
 
 #include <ds/app/event_client.h>
+#include <ds/content/base_content_helper.h>
 #include <ds/content/platform.h>
 #include <ds/network/helper/delayed_node_watcher.h>
 #include <ds/network/https_client.h>
@@ -83,14 +84,15 @@ class BridgeService {
 		ci::app::AppBase* mApp =
 			nullptr; // Pointer to main application, allowing us to execute code on the main thread.
 
-		ds::ui::SpriteEngine&										mEngine;	   // Reference to the sprite engine.
-		Poco::Mutex													mContentMutex; // Controls access to content.
-		ds::model::ContentModelRef									mContent;	   //
-		ds::model::ContentModelRef									mPlatforms;	   //
-		ds::model::ContentModelRef									mEvents;	   //
-		ds::model::ContentModelRef									mRecords;	   //
-		ds::model::ContentModelRef									mTags;		   // all the tags
-		std::unordered_map<std::string, ds::model::ContentModelRef> mRecordMap;	   // all the records
+		ds::ui::SpriteEngine&		 mEngine;		 // Reference to the sprite engine.
+		ds::model::BaseContentHelper mContentHelper; // Pointer to the content helper, used for accessing content.
+		Poco::Mutex					 mContentMutex;	 // Controls access to content.
+		ds::model::ContentModelRef	 mContent;		 //
+		ds::model::ContentModelRef	 mPlatforms;	 //
+		ds::model::ContentModelRef	 mEvents;		 //
+		ds::model::ContentModelRef	 mRecords;		 //
+		ds::model::ContentModelRef	 mTags;			 // all the tags
+		std::unordered_map<std::string, ds::model::ContentModelRef> mRecordMap; // all the records
 		std::unordered_map<std::string, ds::model::ContentModelRef>
 					mValidMap;			   // all the valid records (as determined by the validator)
 		Poco::Mutex mMutex;				   // Controls access to abort, force and refresh flags.

--- a/src/ds/content/service/bridge_service.h
+++ b/src/ds/content/service/bridge_service.h
@@ -85,7 +85,7 @@ class BridgeService {
 			nullptr; // Pointer to main application, allowing us to execute code on the main thread.
 
 		ds::ui::SpriteEngine&		 mEngine;		 // Reference to the sprite engine.
-		ds::model::BaseContentHelper mContentHelper; // Pointer to the content helper, used for accessing content.
+		ds::model::BaseContentHelper mContentHelper; // Content helper, used for accessing content.
 		Poco::Mutex					 mContentMutex;	 // Controls access to content.
 		ds::model::ContentModelRef	 mContent;		 //
 		ds::model::ContentModelRef	 mPlatforms;	 //


### PR DESCRIPTION
By deprecating the Platform class and moving that functionality into BaseContentHelper, like we did in a recent commit, construction of BaseContentHelper should be as lean as possible. Therefor, I have moved the initialization done in its constructor to a few helper methods and then do lazy initialization. While testing that, I noticed that BaseWafflesHelper was deriving from BaseContentHelper, but also had an unnecessary BaseContentHelper member variable. I have refactored the code to fix that and also replaced all uses of the obsolete Platform class in the respective projects, using the ContentHelperFactory to obtain the default helper where applicable.

This is a rather big change that could potentially cause compile errors on old projects. Do let me know if you need help refactoring / fixing.