### PR TITLE
Merge changes from develop-ImageService-dynamic and develop-auto_update_list_trycatch into develop

### DIFF
--- a/projects/viewers/src/ds/ui/media/media_player.h
+++ b/projects/viewers/src/ds/ui/media/media_player.h
@@ -44,7 +44,7 @@ class MediaPlayer : public ds::ui::Sprite {
 	void setResourcePreview(const ds::Resource& reccy) override { mResourcePreview = reccy; }
 
 	/// Returns the data model for the currently set media (may be blank or errored)
-	const ds::Resource& getResource() { return mResource; }
+	const ds::Resource& getResource() const override { return mResource; }
 
 	/// Returns the data model for the currently set media (may be blank or errored)
 	const ds::Resource& getResourcePreview() { return mResourcePreview; }

--- a/projects/viewers/src/ds/ui/media/media_viewer.cpp
+++ b/projects/viewers/src/ds/ui/media/media_viewer.cpp
@@ -82,12 +82,13 @@ void MediaViewer::loadMedia(const ds::Resource& reccy, const bool initializeImme
 }
 
 
-ds::Resource MediaViewer::getResource() {
+const ds::Resource& MediaViewer::getResource() const {
 	if (mMediaPlayer) {
 		return mMediaPlayer->getResource();
 	}
 
-	return ds::Resource("", ds::Resource::ERROR_TYPE);
+	static const ds::Resource ERROR_RESOURCE("", ds::Resource::ERROR_TYPE);
+	return ERROR_RESOURCE;
 }
 
 void MediaViewer::setDefaultBounds(const float defaultWidth, const float defaultHeight) {

--- a/projects/viewers/src/ds/ui/media/media_viewer.h
+++ b/projects/viewers/src/ds/ui/media/media_viewer.h
@@ -28,10 +28,10 @@ class MediaViewer : public BasePanel {
 	void loadMedia(const ds::Resource& reccy, const bool initializeImmediately = true);
 
 	/// Support the base sprite setting function, which is the same as loadMedia and initialize immediately
-	virtual void setResource(const ds::Resource& reccy) { loadMedia(reccy); }
+	void setResource(const ds::Resource& reccy) override { loadMedia(reccy); }
 
 	/// Returns the data model for the currently set media (may be blank or errored)
-	ds::Resource getResource();
+	const ds::Resource &getResource() const override;
 
 	// Sets the area for the initial default size calculation. must be called before initialize or load media to
 	// have an effect

--- a/projects/viewers/src/ds/ui/media/player/pdf_player.h
+++ b/projects/viewers/src/ds/ui/media/player/pdf_player.h
@@ -27,10 +27,10 @@ class PDFPlayer : public ds::ui::IPdf {
 	void setNormalTouch();
 	void setPosScaleTouch();
 
-	void		 setMedia(const std::string mediaPath);
-	virtual void setResource(const ds::Resource& mediaResource) override;
+	void setMedia(const std::string mediaPath);
+	void setResource(const ds::Resource& mediaResource) override;
 
-	ds::Resource& getResource() { return mSourceResource; }
+	const ds::Resource& getResource() const override { return mSourceResource; }
 
 	void layout();
 

--- a/src/ds/app/auto_update.h
+++ b/src/ds/app/auto_update.h
@@ -29,6 +29,8 @@ class AutoUpdate {
 
 	ds::ui::SpriteEngine& mEngine;
 
+	std::mutex mMutex;
+
   private:
 	AutoUpdate();
 

--- a/src/ds/app/auto_update.h
+++ b/src/ds/app/auto_update.h
@@ -29,7 +29,7 @@ class AutoUpdate {
 
 	ds::ui::SpriteEngine& mEngine;
 
-	std::mutex mBenMutex;
+	std::mutex mItemMutex;
 
   private:
 	AutoUpdate();

--- a/src/ds/app/auto_update.h
+++ b/src/ds/app/auto_update.h
@@ -29,7 +29,7 @@ class AutoUpdate {
 
 	ds::ui::SpriteEngine& mEngine;
 
-	std::mutex mMutex;
+	std::mutex mBenMutex;
 
   private:
 	AutoUpdate();

--- a/src/ds/app/auto_update_list.cpp
+++ b/src/ds/app/auto_update_list.cpp
@@ -28,7 +28,7 @@ void AutoUpdateList::update(const ds::UpdateParams& p) {
 		std::scoped_lock lock(mRunning.mMutex);
 		for (int i = 0; i < mRunning.mQueue.size(); i++) {
 			{
-				std::scoped_lock lock2(mRunning.mQueue[i]->mMutex);
+				std::scoped_lock lock2(mRunning.mQueue[i]->mBenMutex);
 				auto item = mRunning.mQueue[i];
 				if (!item) continue;
 				try {
@@ -41,13 +41,13 @@ void AutoUpdateList::update(const ds::UpdateParams& p) {
 		}
 	}
 	{
-		std::scoped_lock lock(mWaiting.mMutex);
+		std::scoped_lock lockx(mWaiting.mMutex);
 		if (!mWaiting.mQueue.empty()) {
 			//for (auto it = mWaiting.mQueue.begin(), end = mWaiting.mQueue.end(); it != end; ++it) {
 			for (int i = 0; i < mWaiting.mQueue.size(); i++) {
 				{
-					std::scoped_lock lock2(mRunning.mMutex);
-					std::scoped_lock lock3(mWaiting.mQueue[i]->mMutex);
+					std::scoped_lock lockx2(mRunning.mMutex);
+					std::scoped_lock lockx3(mWaiting.mQueue[i]->mBenMutex);
 					mRunning.mQueue.push_back(mWaiting.mQueue[i]);
 				}
 			}
@@ -60,7 +60,7 @@ void AutoUpdateList::addWaiting(AutoUpdate* v) {
 	if (!v) return;
 	{
 		std::scoped_lock lock(mWaiting.mMutex);
-		std::scoped_lock lock2(v->mMutex);
+		//std::scoped_lock lock2(v->mBenMutex);
 		mWaiting.mQueue.push_back(v);
 	}
 }
@@ -68,13 +68,13 @@ void AutoUpdateList::addWaiting(AutoUpdate* v) {
 void AutoUpdateList::remove(AutoUpdate* v) {
 	if (!v) return;
 	{
-		std::scoped_lock lock(v->mMutex);
+		std::scoped_lock lock(v->mBenMutex);
 		{
-			std::scoped_lock lock(mRunning.mMutex);
+			//std::scoped_lock lockee(mRunning.mMutex);
 			mRunning.mQueue.erase(std::remove(mRunning.mQueue.begin(), mRunning.mQueue.end(), v), mRunning.mQueue.end());
 		}
 		{
-			std::scoped_lock lock(mWaiting.mMutex);
+			//std::scoped_lock locky(mWaiting.mMutex);
 			mWaiting.mQueue.erase(std::remove(mWaiting.mQueue.begin(), mWaiting.mQueue.end(), v), mWaiting.mQueue.end());
 		}
 	}

--- a/src/ds/app/auto_update_list.cpp
+++ b/src/ds/app/auto_update_list.cpp
@@ -13,39 +13,71 @@ namespace ds {
  * \class AutoUpdateList
  */
 AutoUpdateList::AutoUpdateList() {
-	mRunning.reserve(32);
-	mWaiting.reserve(8);
+	{
+		std::scoped_lock lock(mRunning.mMutex);
+		mRunning.mQueue.reserve(128);
+	}
+	{
+		std::scoped_lock lock(mWaiting.mMutex);
+		mWaiting.mQueue.reserve(32);
+	}
 }
 
 void AutoUpdateList::update(const ds::UpdateParams& p) {
-	if (!mWaiting.empty()) {
-		for (auto it = mWaiting.begin(), end = mWaiting.end(); it != end; ++it) {
-			mRunning.push_back(*it);
+	{
+		std::scoped_lock lock(mRunning.mMutex);
+		for (int i = 0; i < mRunning.mQueue.size(); i++) {
+			{
+				std::scoped_lock lock2(mRunning.mQueue[i]->mMutex);
+				auto item = mRunning.mQueue[i];
+				if (!item) continue;
+				try {
+					item->update(p);
+				}
+				catch (std::exception e) {
+					DS_LOG_ERROR("Error in ds_cinder/src/ds/app/auto_update_list.cpp AutoUpdateList::update(..): " << e.what());
+				}
+			}
 		}
-		mWaiting.clear();
 	}
-	if (mRunning.empty()) return;
-
-	for (auto it : mRunning) {
-		if (!it) continue;
-		try {
-			it->update(p);
+	{
+		std::scoped_lock lock(mWaiting.mMutex);
+		if (!mWaiting.mQueue.empty()) {
+			//for (auto it = mWaiting.mQueue.begin(), end = mWaiting.mQueue.end(); it != end; ++it) {
+			for (int i = 0; i < mWaiting.mQueue.size(); i++) {
+				{
+					std::scoped_lock lock2(mRunning.mMutex);
+					std::scoped_lock lock3(mWaiting.mQueue[i]->mMutex);
+					mRunning.mQueue.push_back(mWaiting.mQueue[i]);
+				}
+			}
 		}
-		catch (std::exception e) {
-			DS_LOG_ERROR("Error in ds_cinder/src/ds/app/auto_update_list.cpp AutoUpdateList::update(..): " << e.what());
-		}
+		mWaiting.mQueue.clear();
 	}
 }
 
 void AutoUpdateList::addWaiting(AutoUpdate* v) {
 	if (!v) return;
-	mWaiting.push_back(v);
+	{
+		std::scoped_lock lock(mWaiting.mMutex);
+		std::scoped_lock lock2(v->mMutex);
+		mWaiting.mQueue.push_back(v);
+	}
 }
 
 void AutoUpdateList::remove(AutoUpdate* v) {
 	if (!v) return;
-	mRunning.erase(std::remove(mRunning.begin(), mRunning.end(), v), mRunning.end());
-	mWaiting.erase(std::remove(mWaiting.begin(), mWaiting.end(), v), mWaiting.end());
+	{
+		std::scoped_lock lock(v->mMutex);
+		{
+			std::scoped_lock lock(mRunning.mMutex);
+			mRunning.mQueue.erase(std::remove(mRunning.mQueue.begin(), mRunning.mQueue.end(), v), mRunning.mQueue.end());
+		}
+		{
+			std::scoped_lock lock(mWaiting.mMutex);
+			mWaiting.mQueue.erase(std::remove(mWaiting.mQueue.begin(), mWaiting.mQueue.end(), v), mWaiting.mQueue.end());
+		}
+	}
 }
 
 } // namespace ds

--- a/src/ds/app/auto_update_list.cpp
+++ b/src/ds/app/auto_update_list.cpp
@@ -27,7 +27,12 @@ void AutoUpdateList::update(const ds::UpdateParams& p) {
 	if (mRunning.empty()) return;
 
 	for (auto it : mRunning) {
-		it->update(p);
+		try {
+			it->update(p);
+		}
+		catch (std::exception e) {
+			DS_LOG_ERROR("Error in ds_cinder/src/ds/app/auto_update_list.cpp AutoUpdateList::update(..): " << e.what());
+		}
 	}
 }
 

--- a/src/ds/app/auto_update_list.cpp
+++ b/src/ds/app/auto_update_list.cpp
@@ -27,6 +27,7 @@ void AutoUpdateList::update(const ds::UpdateParams& p) {
 	if (mRunning.empty()) return;
 
 	for (auto it : mRunning) {
+		if (!it) continue;
 		try {
 			it->update(p);
 		}

--- a/src/ds/app/auto_update_list.cpp
+++ b/src/ds/app/auto_update_list.cpp
@@ -28,7 +28,7 @@ void AutoUpdateList::update(const ds::UpdateParams& p) {
 		std::scoped_lock lock(mRunning.mMutex);
 		for (int i = 0; i < mRunning.mQueue.size(); i++) {
 			{
-				std::scoped_lock lock2(mRunning.mQueue[i]->mBenMutex);
+				std::scoped_lock lock2(mRunning.mQueue[i]->mItemMutex);
 				auto item = mRunning.mQueue[i];
 				if (!item) continue;
 				try {
@@ -47,7 +47,7 @@ void AutoUpdateList::update(const ds::UpdateParams& p) {
 			for (int i = 0; i < mWaiting.mQueue.size(); i++) {
 				{
 					std::scoped_lock lockx2(mRunning.mMutex);
-					std::scoped_lock lockx3(mWaiting.mQueue[i]->mBenMutex);
+					std::scoped_lock lockx3(mWaiting.mQueue[i]->mItemMutex);
 					mRunning.mQueue.push_back(mWaiting.mQueue[i]);
 				}
 			}
@@ -68,7 +68,7 @@ void AutoUpdateList::addWaiting(AutoUpdate* v) {
 void AutoUpdateList::remove(AutoUpdate* v) {
 	if (!v) return;
 	{
-		std::scoped_lock lock(v->mBenMutex);
+		std::scoped_lock lock(v->mItemMutex);
 		{
 			//std::scoped_lock lockee(mRunning.mMutex);
 			mRunning.mQueue.erase(std::remove(mRunning.mQueue.begin(), mRunning.mQueue.end(), v), mRunning.mQueue.end());

--- a/src/ds/app/auto_update_list.h
+++ b/src/ds/app/auto_update_list.h
@@ -23,12 +23,18 @@ class AutoUpdateList {
 	void remove(AutoUpdate*);
 
 	friend class AutoUpdate;
-	std::vector<AutoUpdate*> mRunning;
+	
+	struct AutoUpdateQueue {
+		std::mutex mMutex;
+		std::vector<AutoUpdate*> mQueue;
+	};
+
+	AutoUpdateQueue mRunning;
 	/// A list of pending update objects -- when an update is added,
 	/// it starts here, then gets placed in the real update list
 	/// at the start of the next update cycle. This prevents a
 	/// a bug where the vector gets modified during an update.
-	std::vector<AutoUpdate*> mWaiting;
+	AutoUpdateQueue mWaiting;
 };
 
 } // namespace ds

--- a/src/ds/ui/service/load_image_service.cpp
+++ b/src/ds/ui/service/load_image_service.cpp
@@ -29,12 +29,9 @@ class GenericStopWatch {
 		return static_cast<Rep>(counted_time);
 	}
 
-	unsigned elapsedAttos() { return elapsedTime<unsigned, std::chrono::attoseconds>(); }
-	unsigned elapsedFemtos() { return elapsedTime<unsigned, std::chrono::femtoseconds>(); }
-	unsigned elapsedPicos() { return elapsedTime<unsigned, std::chrono::picoseconds>(); }
-	unsigned elapsedNanos() { return elapsedTime<unsigned, std::chrono::nanoseconds>(); }
-	unsigned elapsedMicros() { return elapsedTime<unsigned, std::chrono::microseconds>(); }
-	unsigned elapsedMillis() { return elapsedTime<unsigned, std::chrono::milliseconds>(); }
+	unsigned elapsedNanos() const { return elapsedTime<unsigned, std::chrono::nanoseconds>(); }
+	unsigned elapsedMicros() const { return elapsedTime<unsigned, std::chrono::microseconds>(); }
+	unsigned elapsedMillis() const { return elapsedTime<unsigned, std::chrono::milliseconds>(); }
 
   protected:
 	TimePoint mStartPoint;
@@ -94,7 +91,7 @@ void LoadImageService::clearCache() {
 	ImageMetaData::clearMetadataCache();
 }
 
-void LoadImageService::logCache() {
+void LoadImageService::logCache() const {
 	DS_LOG_INFO("Load Image Service, number of in use images:" << mInUseImages.size());
 	for (auto it : mInUseImages) {
 		DS_LOG_INFO("Image, refs=" << it.second.mRefs << " err=" << it.second.mError << " flags=" << it.second.mFlags
@@ -105,7 +102,7 @@ void LoadImageService::logCache() {
 void LoadImageService::stopThreads() {
 	mShouldQuit = true;
 
-	for (auto it : mThreads) {
+	for (const auto& it: mThreads) {
 		it->join();
 	}
 
@@ -119,7 +116,7 @@ LoadImageService::~LoadImageService() {
 }
 
 
-void LoadImageService::handleImageLoadRequest(ImageLoadRequest& request) {
+void LoadImageService::handleImageLoadRequest(ImageLoadRequest& request) const {
 	const bool doMipMapping = ((request.mFlags & ds::ui::Image::IMG_ENABLE_MIPMAP_F) != 0);
 
 	ci::gl::Texture::Format fmt;
@@ -184,7 +181,7 @@ void LoadImageService::update(const ds::UpdateParams&) {
 	newCompletedRequests.clear();
 }
 
-void LoadImageService::acquire(const std::string&    filePath, const int flags, Image* requester,
+void LoadImageService::acquire(const std::string&    filePath, const int flags, Sprite* requester,
                                const LoadedCallback& loadedCallback) {
 	if (filePath.empty()) {
 		DS_LOG_VERBOSE(6, "LoadImageService got a blank file path.");
@@ -213,7 +210,7 @@ void LoadImageService::acquire(const std::string&    filePath, const int flags, 
 		}
 	} else {
 		// Obtain cropping information, used for trimming white space.
-		const auto resource = requester->getImageResource();
+		const auto resource = requester->getResource();
 
 		mInUseImages[filePath]			= ImageLoadRequest(filePath, flags, resource.getCrop());
 		mInUseImages[filePath].mLoading = true; // Indicates that this request has been added to the loading queue
@@ -235,7 +232,7 @@ void LoadImageService::acquire(const std::string&    filePath, const int flags, 
 }
 
 
-void LoadImageService::release(const std::string& filePath, Image* referrer) {
+void LoadImageService::release(const std::string& filePath, Sprite* referrer) {
 	if (filePath.empty()) return;
 
 	/// Remove the callback for this path and referrer

--- a/src/ds/ui/service/load_image_service.h
+++ b/src/ds/ui/service/load_image_service.h
@@ -32,10 +32,10 @@ class LoadImageService : public ds::AutoUpdate {
 	/// Important! Be sure to call release before the requester goes away
 	/// The callback will be called one time only, and calls back if there is an error or it succeeds.
 	/// All callbacks happen in the update cycle
-	void acquire(const std::string& filePath, const int flags, Image* requester, const LoadedCallback& loadedCallback);
+	void acquire(const std::string& filePath, const int flags, Sprite* requester, const LoadedCallback& loadedCallback);
 
 	/// You must call release if you no longer want the image or the reffer is about to be released
-	void release(const std::string& filePath, Image* requester);
+	void release(const std::string& filePath, Sprite* requester);
 
 	/// \brief Starts the threads to load stuff and creates OpenGL contexts
 	/// Can be called multiple times, will reinit the loading threads if the load_image:threads
@@ -49,7 +49,7 @@ class LoadImageService : public ds::AutoUpdate {
 	void clearCache();
 
 	/// Logs all in-use and cached images to info
-	void logCache();
+	void logCache() const;
 
   private:
 	/// Keeps track of requests for images, in-use images, and cached images
@@ -100,7 +100,7 @@ class LoadImageService : public ds::AutoUpdate {
 	bool mCacheEverything;
 
   protected:
-	void handleImageLoadRequest(ImageLoadRequest&);
+	void handleImageLoadRequest(ImageLoadRequest&) const;
 };
 
 } // namespace ds::ui

--- a/src/ds/ui/sprite/image.h
+++ b/src/ds/ui/sprite/image.h
@@ -65,6 +65,9 @@ class Image : public Sprite {
 	 */
 	virtual void setResource(const ds::Resource& resource) override { setImageResource(resource); }
 
+	/// Returns the ds::Resource if it was set as a full resource or as an id.
+	const ds::Resource& getResource() const override { return mResource; }
+
 	/// Returns the absolute image path, even if the image was set by resource
 	const std::string& getImageFilename() { return mFilename; }
 

--- a/src/ds/ui/sprite/sprite.cpp
+++ b/src/ds/ui/sprite/sprite.cpp
@@ -1780,6 +1780,11 @@ void Sprite::setBaseShader(const std::string& vertShader, const std::string& fra
 	}
 }
 
+const ds::Resource& Sprite::getResource() const {
+	static const ds::Resource EMPTY_RESOURCE;
+	return EMPTY_RESOURCE;
+}
+
 void Sprite::setResource(const ds::Resource&) {
 	DS_LOG_WARNING("Set resource hasn't been implemented for this sprite type. Sprite name="
 				   << ds::utf8_from_wstr(getSpriteName(true)));

--- a/src/ds/ui/sprite/sprite.h
+++ b/src/ds/ui/sprite/sprite.h
@@ -749,6 +749,10 @@ namespace ui {
 		void setBaseShader(const std::string& vertShaderString, const std::string& fragShaderString,
 						   const std::string& shaderName, bool applyToChildren = false);
 
+		/// Get the resource content for a sprite. This is a base function that should be overridden by anything thatAdd commentMore actions
+		/// can take a Resource (Image, Video, PDF, etc)
+		virtual const ds::Resource& getResource() const;
+
 		/// Set the resource content for a sprite. This is a base function that should be overridden by anything that
 		/// can take a Resource (Image, Video, PDF, etc)
 		virtual void setResource(const ds::Resource&);


### PR DESCRIPTION
While working on both `hrpt_cee_directories` and `linkedin_messaging`, I ended up doing a merge for each off of develop to cover functionality related to known bugs. This branch contains both of these, for a PR back into develop.

`develop-auto_update_list_trycatch` is the main one, from hrpt_cee_directories work, which sought to solve crashing issues when encountering CMS updates (with the older "NuWaffles" style of CMS). It adds mutexes for scoped_lock safety in `AutoUpdateList`, which was done alongside @afrancois, and has so far seemed to cease crashes on directories without perceivable downside.

`develop-ImageService-dynamic` is more minor, where when working on `linkedin-messaging`, there were some build errors related to casting types, with `ImageService`, `media_player`, etc being the culprits. These are things that had seemed to have been tackled in `af/waffles`, and so I used them as a guideline as to how to get `develop` back up to buildable. Please note that while this half is "simpler" in certain ways, I also am not as personally aware as to any problematic steps I may have taken, so review is extra appreciated.

This branch was tested against `hrpt_cee_directories`, `align_technology_center`, and `linkedin-messaging`, since they are the most recently touched projects that I am knowledgeable on that are traditionally built against `develop` rather than `af/waffles`.